### PR TITLE
optimize dot worker scheduling

### DIFF
--- a/dot_generic.go
+++ b/dot_generic.go
@@ -2,9 +2,25 @@
 
 package tensai
 
+import "runtime"
+
 // dotRows computes rows lo..hi of out = a * b. This is the portable
 // fallback; build with GOEXPERIMENT=simd on amd64 to get the AVX2 kernel in
 // dot_simd.go.
 func dotRows(out, a, b *Matrix, lo, hi int) {
 	dotRowsGeneric(out, a, b, lo, hi)
+}
+
+func dotWorkerCount(rows, inner, cols int) int {
+	workers := 1
+	if rows*inner*cols >= 1<<20 {
+		workers = runtime.NumCPU()
+		if workers > 8 {
+			workers = 8
+		}
+		if workers > rows {
+			workers = rows
+		}
+	}
+	return workers
 }

--- a/dot_simd.go
+++ b/dot_simd.go
@@ -3,6 +3,7 @@
 package tensai
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"unsafe"
 )
@@ -61,4 +62,15 @@ func dotRows(out, a, b *Matrix, lo, hi int) {
 			}
 		}
 	}
+}
+
+func dotWorkerCount(rows, inner, cols int) int {
+	workers := 1
+	if rows*inner*cols >= 1<<23 {
+		workers = runtime.NumCPU()
+		if workers > rows {
+			workers = rows
+		}
+	}
+	return workers
 }

--- a/kernels.go
+++ b/kernels.go
@@ -94,12 +94,14 @@ func scaleSliceGeneric(dst []Float, s Float) {
 // adamStepGeneric applies one Adam/AdamW update over a parameter slice.
 // rc1/rc2 are the reciprocal bias corrections 1/(1-beta^t).
 func adamStepGeneric(w, g, m, v []Float, beta1, beta2, rc1, rc2, lr, eps, wd Float) {
-	for i := range w {
+	ib1 := 1 - beta1
+	ib2 := 1 - beta2
+	for i, wi := range w {
 		gi := g[i]
-		m[i] = beta1*m[i] + (1-beta1)*gi
-		v[i] = beta2*v[i] + (1-beta2)*gi*gi
-		mHat := m[i] * rc1
-		vHat := v[i] * rc2
-		w[i] -= lr * (mHat/(sqrtF(vHat)+eps) + wd*w[i])
+		mi := beta1*m[i] + ib1*gi
+		vi := beta2*v[i] + ib2*gi*gi
+		m[i] = mi
+		v[i] = vi
+		w[i] = wi - lr*(mi*rc1/(sqrtF(vi*rc2)+eps)+wd*wi)
 	}
 }

--- a/tensor.go
+++ b/tensor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"runtime"
 	"sync"
 )
 
@@ -115,13 +114,7 @@ func DotInto(out, a, b *Matrix) error {
 	clear(out.Data) // dotRows accumulates
 	// Rows are independent, so large products are split across CPUs. Small
 	// ones stay single-threaded to avoid goroutine overhead.
-	workers := 1
-	if a.Rows*a.Cols*b.Cols >= 1<<23 {
-		workers = runtime.NumCPU()
-		if workers > a.Rows {
-			workers = a.Rows
-		}
-	}
+	workers := dotWorkerCount(a.Rows, a.Cols, b.Cols)
 	chunk := (a.Rows + workers - 1) / workers
 	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {


### PR DESCRIPTION
Optimizes matrix multiplication worker scheduling for generic builds while keeping SIMD scheduling conservative, and trims redundant work in the generic Adam update loop.