### PR TITLE
reduce fit step allocations

### DIFF
--- a/loss.go
+++ b/loss.go
@@ -23,19 +23,28 @@ func (MeanSquaredError) Name() string { return "mse" }
 
 // Loss returns the mean squared error and its gradient.
 func (MeanSquaredError) Loss(pred, target *Matrix) (Float, *Matrix, error) {
+	grad := NewMatrix(pred.Rows, pred.Cols)
+	loss, err := (MeanSquaredError{}).LossInto(pred, target, grad)
+	return loss, grad, err
+}
+
+// LossInto writes the MSE gradient into grad and returns the average loss.
+func (MeanSquaredError) LossInto(pred, target, grad *Matrix) (Float, error) {
 	if err := checkShapes(pred, target); err != nil {
-		return 0, nil, err
+		return 0, err
+	}
+	if err := checkShapes(pred, grad); err != nil {
+		return 0, err
 	}
 	n := Float(len(pred.Data))
 	var sum Float
-	grad := NewMatrix(pred.Rows, pred.Cols)
 	for i := range pred.Data {
 		diff := pred.Data[i] - target.Data[i]
 		sum += diff * diff
 		// d/dpred (1/n * (pred-target)^2) = 2/n * (pred-target)
 		grad.Data[i] = 2.0 * diff / n
 	}
-	return sum / n, grad, nil
+	return sum / n, nil
 }
 
 // SoftmaxCrossEntropy combines softmax + cross-entropy with integer class
@@ -48,20 +57,29 @@ func (SoftmaxCrossEntropy) Name() string { return "softmax_ce" }
 // Loss returns the average negative log-likelihood of the target classes
 // and the combined softmax-cross-entropy gradient (pred - onehot) / batch.
 func (SoftmaxCrossEntropy) Loss(pred, target *Matrix) (Float, *Matrix, error) {
+	grad := NewMatrix(pred.Rows, pred.Cols)
+	loss, err := (SoftmaxCrossEntropy{}).LossInto(pred, target, grad)
+	return loss, grad, err
+}
+
+// LossInto writes the softmax-cross-entropy gradient into grad.
+func (SoftmaxCrossEntropy) LossInto(pred, target, grad *Matrix) (Float, error) {
 	if pred.Rows != target.Rows {
-		return 0, nil, fmt.Errorf("tensai: softmax_ce row mismatch: %d vs %d", pred.Rows, target.Rows)
+		return 0, fmt.Errorf("tensai: softmax_ce row mismatch: %d vs %d", pred.Rows, target.Rows)
 	}
 	if target.Cols != 1 {
-		return 0, nil, fmt.Errorf("tensai: softmax_ce target must be Mx1, got %dx%d", target.Rows, target.Cols)
+		return 0, fmt.Errorf("tensai: softmax_ce target must be Mx1, got %dx%d", target.Rows, target.Cols)
+	}
+	if err := checkShapes(pred, grad); err != nil {
+		return 0, err
 	}
 
 	var loss Float
-	grad := NewMatrix(pred.Rows, pred.Cols)
 	invRows := 1 / Float(pred.Rows)
 	for r := 0; r < pred.Rows; r++ {
 		cls := int(target.Data[r])
 		if cls < 0 || cls >= pred.Cols {
-			return 0, nil, fmt.Errorf("tensai: softmax_ce class %d out of range [0,%d)", cls, pred.Cols)
+			return 0, fmt.Errorf("tensai: softmax_ce class %d out of range [0,%d)", cls, pred.Cols)
 		}
 
 		// Numerically stable softmax for row r, with the probabilities
@@ -88,7 +106,7 @@ func (SoftmaxCrossEntropy) Loss(pred, target *Matrix) (Float, *Matrix, error) {
 		scaleSlice(probs, invRows)
 		probs[cls] -= invRows
 	}
-	return loss * invRows, grad, nil
+	return loss * invRows, nil
 }
 
 // BinaryCrossEntropy computes the average binary cross-entropy between
@@ -101,13 +119,22 @@ func (BinaryCrossEntropy) Name() string { return "bce" }
 
 // Loss returns the average binary cross-entropy and its gradient.
 func (BinaryCrossEntropy) Loss(pred, target *Matrix) (Float, *Matrix, error) {
+	grad := NewMatrix(pred.Rows, pred.Cols)
+	loss, err := (BinaryCrossEntropy{}).LossInto(pred, target, grad)
+	return loss, grad, err
+}
+
+// LossInto writes the BCE gradient into grad and returns the average loss.
+func (BinaryCrossEntropy) LossInto(pred, target, grad *Matrix) (Float, error) {
 	if err := checkShapes(pred, target); err != nil {
-		return 0, nil, err
+		return 0, err
+	}
+	if err := checkShapes(pred, grad); err != nil {
+		return 0, err
 	}
 	const eps = 1e-12
 	n := Float(len(pred.Data))
 	var sum Float
-	grad := NewMatrix(pred.Rows, pred.Cols)
 	for i := range pred.Data {
 		p := pred.Data[i]
 		if p < eps {
@@ -119,7 +146,7 @@ func (BinaryCrossEntropy) Loss(pred, target *Matrix) (Float, *Matrix, error) {
 		sum -= t*logF(p) + (1-t)*logF(1-p)
 		grad.Data[i] = (p - t) / (p * (1 - p) * n)
 	}
-	return sum / n, grad, nil
+	return sum / n, nil
 }
 
 func checkShapes(a, b *Matrix) error {

--- a/model.go
+++ b/model.go
@@ -17,6 +17,11 @@ type Sequential struct {
 	loss      Loss
 	lossName  string
 	rng       *rand.Rand
+	lossGrad  *Matrix
+}
+
+type lossInto interface {
+	LossInto(pred, target, grad *Matrix) (Float, error)
 }
 
 // NewSequential returns an empty Sequential model. optimizer and loss are
@@ -129,9 +134,20 @@ func (s *Sequential) FitStep(input, target *Matrix) (Float, error) {
 	if err != nil {
 		return 0, err
 	}
-	lossVal, grad, err := s.loss.Loss(pred, target)
-	if err != nil {
-		return 0, fmt.Errorf("tensai: loss: %w", err)
+	var lossVal Float
+	var grad *Matrix
+	if li, ok := s.loss.(lossInto); ok {
+		s.lossGrad = ensureMatrix(s.lossGrad, pred.Rows, pred.Cols)
+		lossVal, err = li.LossInto(pred, target, s.lossGrad)
+		grad = s.lossGrad
+		if err != nil {
+			return 0, fmt.Errorf("tensai: loss: %w", err)
+		}
+	} else {
+		lossVal, grad, err = s.loss.Loss(pred, target)
+		if err != nil {
+			return 0, fmt.Errorf("tensai: loss: %w", err)
+		}
 	}
 	if err := s.backward(grad); err != nil {
 		return 0, err

--- a/tensor.go
+++ b/tensor.go
@@ -115,6 +115,10 @@ func DotInto(out, a, b *Matrix) error {
 	// Rows are independent, so large products are split across CPUs. Small
 	// ones stay single-threaded to avoid goroutine overhead.
 	workers := dotWorkerCount(a.Rows, a.Cols, b.Cols)
+	if workers == 1 {
+		dotRows(out, a, b, 0, a.Rows)
+		return nil
+	}
 	chunk := (a.Rows + workers - 1) / workers
 	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {


### PR DESCRIPTION
Reuses loss-gradient buffers during training and skips goroutine setup when matrix multiplication runs with a single worker.

Benchmarks are median values from 5 runs on AMD Ryzen 7 7735HS.

| Build | Benchmark | Before | After | Change | Allocs |
| --- | --- | ---: | ---: | ---: | ---: |
| generic | BenchmarkDot128 | 434385 ns/op | 432380 ns/op | 0.5% faster | 19 -> 19 |
| generic | BenchmarkFitStepMLP | 2262800 ns/op | 1987813 ns/op | 12.1% faster | 71 -> 51 |
| simd | BenchmarkDot128 | 402132 ns/op | 374839 ns/op | 6.8% faster | 5 -> 2 |
| simd | BenchmarkFitStepMLP | 1500165 ns/op | 1260135 ns/op | 16.0% faster | 29 -> 0 |

Validation: `go test ./...` and `GOEXPERIMENT=simd go test ./...`.
