### PR TITLE
avoid clearing dot output eagerly

### DIFF
--- a/dot_simd.go
+++ b/dot_simd.go
@@ -35,6 +35,7 @@ func dotRows(out, a, b *Matrix, lo, hi int) {
 		aRow := a.Data[r*a.Cols : (r+1)*a.Cols]
 		aBits := unsafe.Slice((*uint32)(unsafe.Pointer(&aRow[0])), len(aRow))
 		outRow := out.Data[r*cols : (r+1)*cols]
+		initialized := false
 		for k := range aBits {
 			if aBits[k]<<1 == 0 { // +0.0 or -0.0
 				continue
@@ -42,6 +43,28 @@ func dotRows(out, a, b *Matrix, lo, hi int) {
 			bRow := b.Data[k*cols : (k+1)*cols]
 			vv := archsimd.BroadcastUint32x8(aBits[k]).AsFloat32x8()
 			var c int
+			if !initialized {
+				for ; c < wide; c += 32 {
+					archsimd.LoadFloat32x8Slice(bRow[c:]).
+						Mul(vv).StoreSlice(outRow[c:])
+					archsimd.LoadFloat32x8Slice(bRow[c+8:]).
+						Mul(vv).StoreSlice(outRow[c+8:])
+					archsimd.LoadFloat32x8Slice(bRow[c+16:]).
+						Mul(vv).StoreSlice(outRow[c+16:])
+					archsimd.LoadFloat32x8Slice(bRow[c+24:]).
+						Mul(vv).StoreSlice(outRow[c+24:])
+				}
+				for ; c < vecs; c += 8 {
+					archsimd.LoadFloat32x8Slice(bRow[c:]).
+						Mul(vv).StoreSlice(outRow[c:])
+				}
+				if c < cols {
+					archsimd.LoadFloat32x8SlicePart(bRow[c:]).
+						Mul(vv).StoreSlicePart(outRow[c:])
+				}
+				initialized = true
+				continue
+			}
 			for ; c < wide; c += 32 {
 				archsimd.LoadFloat32x8Slice(bRow[c:]).
 					MulAdd(vv, archsimd.LoadFloat32x8Slice(outRow[c:])).StoreSlice(outRow[c:])
@@ -60,6 +83,9 @@ func dotRows(out, a, b *Matrix, lo, hi int) {
 				archsimd.LoadFloat32x8SlicePart(bRow[c:]).
 					MulAdd(vv, archsimd.LoadFloat32x8SlicePart(outRow[c:])).StoreSlicePart(outRow[c:])
 			}
+		}
+		if !initialized {
+			clear(outRow)
 		}
 	}
 }

--- a/tensor.go
+++ b/tensor.go
@@ -111,7 +111,6 @@ func DotInto(out, a, b *Matrix) error {
 		return fmt.Errorf("tensai: dot output shape mismatch: got %dx%d, want %dx%d",
 			out.Rows, out.Cols, a.Rows, b.Cols)
 	}
-	clear(out.Data) // dotRows accumulates
 	// Rows are independent, so large products are split across CPUs. Small
 	// ones stay single-threaded to avoid goroutine overhead.
 	workers := dotWorkerCount(a.Rows, a.Cols, b.Cols)
@@ -158,14 +157,25 @@ func dotRowsGeneric(out, a, b *Matrix, lo, hi int) {
 	for r := lo; r < hi; r++ {
 		aRow := a.Data[r*a.Cols : (r+1)*a.Cols]
 		outRow := out.Data[r*b.Cols : (r+1)*b.Cols]
+		initialized := false
 		for k, av := range aRow {
 			if av == 0 {
 				continue
 			}
 			bRow := b.Data[k*b.Cols : (k+1)*b.Cols]
+			if !initialized {
+				for c, bv := range bRow {
+					outRow[c] = av * bv
+				}
+				initialized = true
+				continue
+			}
 			for c, bv := range bRow {
 				outRow[c] += av * bv
 			}
+		}
+		if !initialized {
+			clear(outRow)
 		}
 	}
 }


### PR DESCRIPTION
Avoids eagerly clearing the full dot output buffer by writing the first non-zero product directly into each output row, then accumulating the remaining products. The SIMD path uses the same first-write strategy with multiply-and-store before switching back to FMA accumulation.

Benchmarks are median values from repeated runs on AMD Ryzen 7 7735HS.

| Build | Benchmark | Before | After | Change | Allocs |
| --- | --- | ---: | ---: | ---: | ---: |
| generic | BenchmarkDot512 | 14044642 ns/op | 13744567 ns/op | 2.1% faster | 19 -> 19 |
| generic | BenchmarkFitStepMLP | 2067283 ns/op | 1915601 ns/op | 7.3% faster | 51 -> 51 |
| simd | BenchmarkDot128 | 412306 ns/op | 385214 ns/op | 6.6% faster | 2 -> 2 |
| simd | BenchmarkDot512 | 10145136 ns/op | 7913749 ns/op | 22.0% faster | 35 -> 35 |
| simd | BenchmarkFitStepMLP | 1310026 ns/op | 1226517 ns/op | 6.4% faster | 0 -> 0 |

Validation: `go test ./...` and `GOEXPERIMENT=simd go test ./...`.
