### PR TITLE
add Embedding, LayerNorm, and GELU layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - **Matrix operations** - `Matrix` plus basic operations such as `Dot`, `Add`, `T`, and `AddBias`. Tensors are float32 (`tensai.Float`)
 - **SIMD acceleration** - AVX2 kernels written with Go's experimental `simd/archsimd` package: still pure Go, no cgo, no assembly files. Matmul, ReLU/LeakyReLU, Sigmoid/Tanh/Softmax (via a vectorized polynomial `exp`), and the Adam update are all 8-lane vectorized. Build with `GOEXPERIMENT=simd` on amd64 (Go 1.26 and 1.27 APIs both supported via build tags); every other build uses the portable fallbacks automatically
 - **Low-allocation training** - layers reuse their forward/backward scratch buffers across training steps (a full MLP step runs in ~29 allocations), so GC stays out of the training loop; `Predict` always returns freshly allocated results
-- **Layers** - `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `Dropout`, plus `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, and `Softmax` activations
+- **Layers** - `Embedding`, `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `LayerNorm`, `Dropout`, plus `ReLU`, `LeakyReLU`, `GELU`, `Sigmoid`, `Tanh`, and `Softmax` activations
 - **Loss functions** - `MeanSquaredError` for regression, `SoftmaxCrossEntropy` for multi-class classification, and `BinaryCrossEntropy` for binary targets
 - **Optimizers** - momentum `SGD`, `Adam`, and `AdamW` (decoupled weight decay)
 - **k-NN baseline** - a `KNN` classifier whose distance matrix runs on the same SIMD matmul kernel; useful as a no-training baseline next to the networks
@@ -104,6 +104,8 @@ model.LoadFile("model.json")
 
 `Conv2D` and `MaxPool2D` treat each row as a channel-major image: `index = (channel*height + y)*width + x`. `Dropout` and `BatchNorm` switch automatically between training behavior (inside `Fit`/`FitStep`) and inference behavior (inside `Predict`).
 
+`Embedding` keeps the current matrix-only API: each input row is a token-id sequence, and the layer concatenates the looked-up embedding vectors across columns. For example, `Compile(4, ...)` plus `NewEmbedding(vocab, 8)` turns an `Mx4` token-id matrix into an `Mx32` dense feature matrix that can feed `LayerNorm`, `GELU`, and `Dense`.
+
 ### Automatic differentiation
 
 When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients:
@@ -185,6 +187,7 @@ Both raw IDX files and `.gz` variants are accepted.
 ## Design Notes
 
 - All operations are batched. Inputs are `MxN` matrices, where `M` is the batch size and `N` is the feature dimension.
+- `Embedding` inputs are also matrices: values must be exact integer token ids stored in `Float`, and the embedding vectors are flattened across the row.
 - The `Layer` interface standardizes `Forward`, `Backward`, `Params`, and `Grads`, which keeps new layers such as convolution or dropout straightforward to add.
 - `Dense` weights use Glorot/He-style initialization to keep early training stable.
 - `SoftmaxCrossEntropy` subtracts the row maximum before softmax for numerical stability.

--- a/features_test.go
+++ b/features_test.go
@@ -75,6 +75,14 @@ func TestLeakyReLUGradient(t *testing.T) {
 	checkLayerGrad(t, l, randomInput(4, 6, 1), 5e-3)
 }
 
+func TestGELUGradient(t *testing.T) {
+	l := &GELU{}
+	if _, err := l.Init(6, nil); err != nil {
+		t.Fatal(err)
+	}
+	checkLayerGrad(t, l, randomInput(4, 6, 31), 5e-3)
+}
+
 func TestSoftmaxGradient(t *testing.T) {
 	l := &Softmax{}
 	if _, err := l.Init(5, nil); err != nil {
@@ -109,6 +117,18 @@ func TestBatchNormGradient(t *testing.T) {
 		bn.beta[i] = -0.25
 	}
 	checkLayerGrad(t, bn, randomInput(6, 4, 4), 1e-2)
+}
+
+func TestLayerNormGradient(t *testing.T) {
+	ln := NewLayerNorm()
+	if _, err := ln.Init(4, nil); err != nil {
+		t.Fatal(err)
+	}
+	for i := range ln.gamma.Data {
+		ln.gamma.Data[i] = Float(0.8 + 0.2*float64(i))
+		ln.beta[i] = Float(-0.3 + 0.1*float64(i))
+	}
+	checkLayerGrad(t, ln, randomInput(6, 4, 41), 1e-2)
 }
 
 func TestBatchNormEvalUsesRunningStats(t *testing.T) {
@@ -263,6 +283,78 @@ func TestDropout(t *testing.T) {
 	}
 }
 
+func TestEmbeddingForwardBackward(t *testing.T) {
+	emb := NewEmbedding(4, 2)
+	if outCols, err := emb.Init(3, rand.New(rand.NewSource(17))); err != nil {
+		t.Fatal(err)
+	} else if outCols != 6 {
+		t.Fatalf("expected out cols 6, got %d", outCols)
+	}
+	weights, err := NewMatrixFromSlice(4, 2, []Float{
+		1, 2,
+		3, 4,
+		5, 6,
+		7, 8,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := emb.SetParams(weights, nil); err != nil {
+		t.Fatal(err)
+	}
+	in, err := NewMatrixFromSlice(2, 3, []Float{
+		0, 1, 0,
+		2, 1, 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := emb.Forward(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOut := []Float{
+		1, 2, 3, 4, 1, 2,
+		5, 6, 3, 4, 7, 8,
+	}
+	for i, want := range wantOut {
+		if out.Data[i] != want {
+			t.Fatalf("forward %d: got %g want %g", i, out.Data[i], want)
+		}
+	}
+	gradOut, err := NewMatrixFromSlice(2, 6, []Float{
+		1, 10, 2, 20, 3, 30,
+		4, 40, 5, 50, 6, 60,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gradIn, err := emb.Backward(gradOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, got := range gradIn.Data {
+		if got != 0 {
+			t.Fatalf("input grad %d: got %g want 0", i, got)
+		}
+	}
+	gradW, gradB := emb.Grads()
+	if gradB != nil {
+		t.Fatal("embedding should not expose bias gradients")
+	}
+	wantGradW := []Float{
+		4, 40,
+		7, 70,
+		4, 40,
+		6, 60,
+	}
+	for i, want := range wantGradW {
+		if gradW.Data[i] != want {
+			t.Fatalf("gradW %d: got %g want %g", i, gradW.Data[i], want)
+		}
+	}
+}
+
 func TestBinaryCrossEntropyGradient(t *testing.T) {
 	rng := rand.New(rand.NewSource(13))
 	pred := NewMatrix(4, 3)
@@ -371,6 +463,70 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	}
 	if err := m3.Load(&buf); err == nil {
 		t.Error("loading into a different architecture should fail")
+	}
+}
+
+func TestEmbeddingLayerNormGELUSaveLoadRoundtrip(t *testing.T) {
+	build := func() *Sequential {
+		m := NewSequential()
+		m.Add(NewEmbedding(4, 3))
+		m.Add(NewLayerNorm())
+		m.Add(&GELU{})
+		m.Add(NewDense(2))
+		if err := m.Compile(2, SoftmaxCrossEntropy{}, NewAdam(0.03)); err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+
+	var inputData []Float
+	var targetData []Float
+	for a := 0; a < 4; a++ {
+		for b := 0; b < 4; b++ {
+			inputData = append(inputData, Float(a), Float(b))
+			if a == b {
+				targetData = append(targetData, 1)
+			} else {
+				targetData = append(targetData, 0)
+			}
+		}
+	}
+	in, err := NewMatrixFromSlice(16, 2, inputData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tgt, err := NewMatrixFromSlice(16, 1, targetData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m1 := build()
+	for i := 0; i < 30; i++ {
+		if _, err := m1.FitStep(in, tgt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := m1.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	m2 := build()
+	if err := m2.Load(&buf); err != nil {
+		t.Fatal(err)
+	}
+	p1, err := m1.Predict(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := m2.Predict(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range p1.Data {
+		if math.Abs(float64(p1.Data[i]-p2.Data[i])) > 1e-12 {
+			t.Fatalf("prediction %d differs after load: %g vs %g", i, p1.Data[i], p2.Data[i])
+		}
 	}
 }
 

--- a/layer.go
+++ b/layer.go
@@ -2,6 +2,7 @@ package tensai
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 )
 
@@ -332,6 +333,250 @@ func (t *Tanh) Backward(gradOutput *Matrix) (*Matrix, error) {
 	return out, nil
 }
 
+// GELU activation: f(x) = 0.5*x*(1+erf(x/sqrt(2))).
+type GELU struct{ activationBase }
+
+func (g *GELU) Init(inputCols int, _ *rand.Rand) (int, error) { return inputCols, nil }
+
+func (g *GELU) Forward(input *Matrix) (*Matrix, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+	g.input = input
+	out := g.fwdBuf(input.Rows, input.Cols)
+	for i, x := range input.Data {
+		out.Data[i] = geluF(x)
+	}
+	g.output = out
+	return out, nil
+}
+
+func (g *GELU) Backward(gradOutput *Matrix) (*Matrix, error) {
+	if g.input == nil {
+		return nil, fmt.Errorf("tensai: gelu backward called before forward")
+	}
+	out := g.bwdBuf(gradOutput.Rows, gradOutput.Cols)
+	for i, grad := range gradOutput.Data {
+		out.Data[i] = grad * geluGrad(g.input.Data[i])
+	}
+	return out, nil
+}
+
+// LayerNorm normalizes each row over its feature dimension and applies a
+// learnable affine transform.
+type LayerNorm struct {
+	bufferPair
+
+	gamma *Matrix
+	beta  []Float
+
+	gradGamma *Matrix
+	gradBeta  []Float
+
+	normalized *Matrix
+	invStd     []Float
+	eps        Float
+}
+
+// NewLayerNorm returns a LayerNorm with the default epsilon.
+func NewLayerNorm() *LayerNorm {
+	return &LayerNorm{eps: 1e-5}
+}
+
+func (l *LayerNorm) Init(inputCols int, _ *rand.Rand) (int, error) {
+	if inputCols <= 0 {
+		return 0, fmt.Errorf("tensai: layernorm init with non-positive input cols: %d", inputCols)
+	}
+	l.gamma = NewMatrix(1, inputCols)
+	for i := range l.gamma.Data {
+		l.gamma.Data[i] = 1
+	}
+	l.beta = make([]Float, inputCols)
+	l.gradGamma = NewMatrix(1, inputCols)
+	l.gradBeta = make([]Float, inputCols)
+	return inputCols, nil
+}
+
+func (l *LayerNorm) Forward(input *Matrix) (*Matrix, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+	if l.gamma == nil || input.Cols != l.gamma.Cols {
+		return nil, fmt.Errorf("tensai: layernorm forward shape mismatch: input %dx%d gamma %v",
+			input.Rows, input.Cols, shapeString(l.gamma))
+	}
+	out := l.fwdBuf(input.Rows, input.Cols)
+	l.normalized = ensureMatrix(l.normalized, input.Rows, input.Cols)
+	if cap(l.invStd) < input.Rows {
+		l.invStd = make([]Float, input.Rows)
+	} else {
+		l.invStd = l.invStd[:input.Rows]
+	}
+	colsF := Float(input.Cols)
+	for r := 0; r < input.Rows; r++ {
+		inRow := input.Data[r*input.Cols : (r+1)*input.Cols]
+		normRow := l.normalized.Data[r*input.Cols : (r+1)*input.Cols]
+		outRow := out.Data[r*input.Cols : (r+1)*input.Cols]
+		var mean Float
+		for _, v := range inRow {
+			mean += v
+		}
+		mean /= colsF
+		var variance Float
+		for _, v := range inRow {
+			d := v - mean
+			variance += d * d
+		}
+		variance /= colsF
+		invStd := 1 / sqrtF(variance+l.eps)
+		l.invStd[r] = invStd
+		for c, v := range inRow {
+			xhat := (v - mean) * invStd
+			normRow[c] = xhat
+			outRow[c] = xhat*l.gamma.Data[c] + l.beta[c]
+		}
+	}
+	return out, nil
+}
+
+func (l *LayerNorm) Backward(gradOutput *Matrix) (*Matrix, error) {
+	if l.normalized == nil {
+		return nil, fmt.Errorf("tensai: layernorm backward called before forward")
+	}
+	l.gradGamma = ensureMatrix(l.gradGamma, 1, gradOutput.Cols)
+	clear(l.gradGamma.Data)
+	clear(l.gradBeta)
+	out := l.bwdBuf(gradOutput.Rows, gradOutput.Cols)
+	colsF := Float(gradOutput.Cols)
+	for r := 0; r < gradOutput.Rows; r++ {
+		gRow := gradOutput.Data[r*gradOutput.Cols : (r+1)*gradOutput.Cols]
+		xhatRow := l.normalized.Data[r*gradOutput.Cols : (r+1)*gradOutput.Cols]
+		outRow := out.Data[r*gradOutput.Cols : (r+1)*gradOutput.Cols]
+		var sumDXhat, sumDXhatXhat Float
+		for c, g := range gRow {
+			l.gradGamma.Data[c] += g * xhatRow[c]
+			l.gradBeta[c] += g
+			dxhat := g * l.gamma.Data[c]
+			sumDXhat += dxhat
+			sumDXhatXhat += dxhat * xhatRow[c]
+		}
+		invStd := l.invStd[r]
+		for c, g := range gRow {
+			dxhat := g * l.gamma.Data[c]
+			outRow[c] = invStd / colsF * (colsF*dxhat - sumDXhat - xhatRow[c]*sumDXhatXhat)
+		}
+	}
+	return out, nil
+}
+
+func (l *LayerNorm) Grads() (*Matrix, []Float) {
+	return l.gradGamma, l.gradBeta
+}
+
+func (l *LayerNorm) Params() (*Matrix, []Float) {
+	return l.gamma, l.beta
+}
+
+func (l *LayerNorm) SetParams(weights *Matrix, bias []Float) error {
+	if weights == nil || weights.Rows != 1 || len(bias) != weights.Cols {
+		return fmt.Errorf("tensai: layernorm SetParams mismatch: weights=%v bias len=%d",
+			shapeString(weights), len(bias))
+	}
+	l.gamma = weights
+	l.beta = bias
+	return nil
+}
+
+// Embedding looks up a learned vector for each token id in the input row and
+// concatenates the vectors across columns.
+type Embedding struct {
+	bufferPair
+
+	weights *Matrix
+	gradW   *Matrix
+	input   *Matrix
+}
+
+// NewEmbedding returns a trainable embedding table of shape vocabSize x dim.
+func NewEmbedding(vocabSize, dim int) *Embedding {
+	return &Embedding{weights: NewMatrix(vocabSize, dim)}
+}
+
+func (e *Embedding) Init(inputCols int, rng *rand.Rand) (int, error) {
+	if inputCols <= 0 {
+		return 0, fmt.Errorf("tensai: embedding init with non-positive input cols: %d", inputCols)
+	}
+	if e.weights == nil || e.weights.Rows <= 0 || e.weights.Cols <= 0 {
+		return 0, fmt.Errorf("tensai: embedding init with invalid table shape")
+	}
+	e.weights = RandomMatrix(e.weights.Rows, e.weights.Cols, rng)
+	e.gradW = NewMatrix(e.weights.Rows, e.weights.Cols)
+	return inputCols * e.weights.Cols, nil
+}
+
+func (e *Embedding) Forward(input *Matrix) (*Matrix, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+	e.input = input
+	outCols := input.Cols * e.weights.Cols
+	out := e.fwdBuf(input.Rows, outCols)
+	for r := 0; r < input.Rows; r++ {
+		outRow := out.Data[r*out.Cols : (r+1)*out.Cols]
+		for c := 0; c < input.Cols; c++ {
+			idx, err := embeddingIndex(input.At(r, c), e.weights.Rows)
+			if err != nil {
+				return nil, err
+			}
+			copy(outRow[c*e.weights.Cols:(c+1)*e.weights.Cols], e.weights.Data[idx*e.weights.Cols:(idx+1)*e.weights.Cols])
+		}
+	}
+	return out, nil
+}
+
+func (e *Embedding) Backward(gradOutput *Matrix) (*Matrix, error) {
+	if e.input == nil {
+		return nil, fmt.Errorf("tensai: embedding backward called before forward")
+	}
+	wantCols := e.input.Cols * e.weights.Cols
+	if gradOutput.Rows != e.input.Rows || gradOutput.Cols != wantCols {
+		return nil, fmt.Errorf("tensai: embedding backward shape mismatch: grad %dx%d, want %dx%d",
+			gradOutput.Rows, gradOutput.Cols, e.input.Rows, wantCols)
+	}
+	e.gradW = ensureMatrix(e.gradW, e.weights.Rows, e.weights.Cols)
+	clear(e.gradW.Data)
+	for r := 0; r < e.input.Rows; r++ {
+		gRow := gradOutput.Data[r*gradOutput.Cols : (r+1)*gradOutput.Cols]
+		for c := 0; c < e.input.Cols; c++ {
+			idx, err := embeddingIndex(e.input.At(r, c), e.weights.Rows)
+			if err != nil {
+				return nil, err
+			}
+			addSlice(e.gradW.Data[idx*e.weights.Cols:(idx+1)*e.weights.Cols], gRow[c*e.weights.Cols:(c+1)*e.weights.Cols])
+		}
+	}
+	gradInput := e.bwdBuf(e.input.Rows, e.input.Cols)
+	clear(gradInput.Data)
+	return gradInput, nil
+}
+
+func (e *Embedding) Grads() (*Matrix, []Float) {
+	return e.gradW, nil
+}
+
+func (e *Embedding) Params() (*Matrix, []Float) {
+	return e.weights, nil
+}
+
+func (e *Embedding) SetParams(weights *Matrix, bias []Float) error {
+	if weights == nil || len(bias) != 0 {
+		return fmt.Errorf("tensai: embedding SetParams mismatch: weights=%v bias len=%d",
+			shapeString(weights), len(bias))
+	}
+	e.weights = weights
+	return nil
+}
+
 // Softmax normalizes each row into a probability distribution. Unlike the
 // element-wise activations its backward pass couples all columns of a row.
 // Note that SoftmaxCrossEntropy already applies softmax internally; use this
@@ -386,4 +631,31 @@ func (s *Softmax) Backward(gradOutput *Matrix) (*Matrix, error) {
 		}
 	}
 	return out, nil
+}
+
+func geluF(x Float) Float {
+	return 0.5 * x * (1 + Float(math.Erf(float64(x/math.Sqrt2))))
+}
+
+func geluGrad(x Float) Float {
+	const invSqrt2Pi = 0.3989422804014327
+	return 0.5*(1+Float(math.Erf(float64(x/math.Sqrt2)))) + x*Float(invSqrt2Pi)*expF(-0.5*x*x)
+}
+
+func shapeString(m *Matrix) string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%dx%d", m.Rows, m.Cols)
+}
+
+func embeddingIndex(v Float, vocabSize int) (int, error) {
+	idx := int(v)
+	if Float(idx) != v {
+		return 0, fmt.Errorf("tensai: embedding token id must be an integer, got %g", v)
+	}
+	if idx < 0 || idx >= vocabSize {
+		return 0, fmt.Errorf("tensai: embedding token id %d out of range [0,%d)", idx, vocabSize)
+	}
+	return idx, nil
 }


### PR DESCRIPTION
## Summary

Three new layers for the Sequential API, extending it toward transformer-style building blocks:

- **Embedding** — maps rows of integer token ids to concatenated learned vectors (`Mx(seq*dim)`). Gradients for duplicate tokens accumulate by scatter-add. Exposes weights only (no bias), so optimizer registration and `Save`/`Load` work unchanged.
- **LayerNorm** — per-row normalization with learnable gamma/beta, using the BatchNorm backward formula along the row axis. No running statistics, so serialization is just the parameters.
- **GELU** — exact erf form with the analytic derivative (Φ(x) + x·φ(x)).

## Verification

- Finite-difference gradient checks for GELU and LayerNorm; Embedding verified against exact hand-computed forward/gradient values including duplicate-token accumulation
- Embedding + LayerNorm + GELU + Dense save/load round trip (bitwise-identical predictions after reload)
- Tested on go1.27 and go1.26.1, both with and without `GOEXPERIMENT=simd`