### PR TITLE
add GPUTensor: GPU-resident buffers for chained MatMul

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ out, err := gpu.MatMul(a, b)
 
 On machines with both an integrated and a discrete GPU, pass a preference: `tensai.OpenGPU(tensai.GPULowPower)` steers to the iGPU, `tensai.GPUHighPerformance` to the dGPU (it is a hint — with a single adapter you always get that one).
 
+Buffers can also stay resident on the GPU, so a weight rides the bus once instead of on every call and intermediates never leave the device:
+
+```go
+gw, _ := gpu.Upload(w)              // weight uploaded once
+defer gw.Free()                     // GPU memory is not garbage collected
+gx, _ := gpu.Upload(x)
+h, _ := gx.MatMul(gw)               // chain freely; nothing touches the host
+out, _ := h.MatMul(gw2)
+result, _ := out.Download()         // one readback at the end
+```
+
+`gpu.MatMul(a, b)` is shorthand for Upload → MatMul → Download → Free. Residency matters most on discrete GPUs, where every transfer crosses PCIe; on shared-memory iGPUs the win is smaller and comes mainly from skipping intermediate readbacks.
+
 There is no cgo involved: the bindings load the [wgpu-native](https://github.com/gfx-rs/wgpu-native) shared library at runtime via `ebitengine/purego` (`dlopen` on linux/macOS, `LoadLibrary` on Windows). Download a **v22.1.0.5** release binary (the C API these bindings target), then either install it where the loader finds it or point `TENSAI_WGPU_LIB` at it:
 
 ```bash

--- a/wgpu.go
+++ b/wgpu.go
@@ -504,127 +504,38 @@ func (g *GPU) Close() {
 	}
 }
 
-func (g *GPU) newBuffer(usage uint32, size uint64) uintptr {
-	desc := wgpuBufferDescriptor{usage: usage, size: size}
+// The primitives below back the shared GPUTensor layer in wgputensor.go;
+// their signatures match the wgpu24 bindings so that layer compiles
+// against either API generation.
+
+func (g *GPU) newBuffer(usage, size uint64) uintptr {
+	desc := wgpuBufferDescriptor{usage: uint32(usage), size: size}
 	buf := fnDeviceCreateBuffer(g.device, unsafe.Pointer(&desc))
 	runtime.KeepAlive(&desc)
 	return buf
 }
 
-// MatMul is the GPU version of the package-level MatMul: identical shape
-// and broadcasting semantics, executed as one compute dispatch. Inputs and
-// the result live in host memory; each call uploads the operands and reads
-// the product back, so it only pays off for large products.
-func (g *GPU) MatMul(a, b *Tensor) (*Tensor, error) {
-	na, nb := len(a.Shape), len(b.Shape)
-	if na < 2 || nb < 2 {
-		return nil, fmt.Errorf("tensai: matmul needs at least 2 axes: %v * %v", a.Shape, b.Shape)
-	}
-	m, k := a.Shape[na-2], a.Shape[na-1]
-	if b.Shape[nb-2] != k {
-		return nil, fmt.Errorf("tensai: matmul shape mismatch: %v * %v", a.Shape, b.Shape)
-	}
-	n := b.Shape[nb-1]
-	batch, err := broadcastShapes(a.Shape[:na-2], b.Shape[:nb-2])
-	if err != nil {
-		return nil, err
-	}
-	out := NewTensor(append(append([]int(nil), batch...), m, n)...)
-	batches := prodDims(batch)
-	if batches > 65535 {
-		return nil, fmt.Errorf("tensai: gpu matmul batch count %d exceeds 65535", batches)
-	}
+func (g *GPU) makeBindGroup(entries []wgpuBindGroupEntry) uintptr {
+	desc := wgpuBindGroupDescriptor{layout: g.layout, entryCount: uintptr(len(entries)), entries: &entries[0]}
+	bg := fnDeviceCreateBindGroup(g.device, unsafe.Pointer(&desc))
+	runtime.KeepAlive(&desc)
+	return bg
+}
 
-	// Element offsets of each batch's matrix in a and b.
-	as := broadcastStrides(a.Shape[:na-2], batch)
-	bs := broadcastStrides(b.Shape[:nb-2], batch)
-	offs := make([]uint32, 2*batches)
-	for bi := 0; bi < batches; bi++ {
-		offA, offB := 0, 0
-		for d, rem := len(batch)-1, bi; d >= 0; d-- {
-			i := rem % batch[d]
-			rem /= batch[d]
-			offA += i * as[d]
-			offB += i * bs[d]
-		}
-		offs[2*bi] = uint32(offA * m * k)
-		offs[2*bi+1] = uint32(offB * k * n)
-	}
-	params := [4]uint32{uint32(m), uint32(k), uint32(n), uint32(batches)}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	wgpuMu.Lock()
-	defer wgpuMu.Unlock()
-	if g.closed {
-		return nil, errors.New("tensai: gpu is closed")
-	}
-	uncapturedCB = ""
-
-	outBytes := uint64(len(out.Data)) * 4
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
-	bufA := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(a.Data))*4)
-	bufB := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(b.Data))*4)
-	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
-	bufOut := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopySrc, outBytes)
-	bufRead := g.newBuffer(wgpuBufferUsageMapRead|wgpuBufferUsageCopyDst, outBytes)
-	defer func() {
-		for _, buf := range []uintptr{bufParams, bufA, bufB, bufOffs, bufOut, bufRead} {
-			if buf != 0 {
-				fnBufferRelease(buf)
-			}
-		}
-	}()
-
-	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
-	fnQueueWriteBuffer(g.queue, bufA, 0, unsafe.Pointer(&a.Data[0]), uintptr(len(a.Data))*4)
-	fnQueueWriteBuffer(g.queue, bufB, 0, unsafe.Pointer(&b.Data[0]), uintptr(len(b.Data))*4)
-	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
-
-	entries := [5]wgpuBindGroupEntry{
-		{binding: 0, buffer: bufParams, size: 16},
-		{binding: 1, buffer: bufA, size: uint64(len(a.Data)) * 4},
-		{binding: 2, buffer: bufB, size: uint64(len(b.Data)) * 4},
-		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
-		{binding: 4, buffer: bufOut, size: outBytes},
-	}
-	bgDesc := wgpuBindGroupDescriptor{layout: g.layout, entryCount: 5, entries: &entries[0]}
-	bindGroup := fnDeviceCreateBindGroup(g.device, unsafe.Pointer(&bgDesc))
-	runtime.KeepAlive(&entries)
-	runtime.KeepAlive(&bgDesc)
-	defer fnBindGroupRelease(bindGroup)
-
-	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
-	pass := fnEncoderBeginComputePass(encoder, nil)
-	fnPassSetPipeline(pass, g.pipeline)
-	fnPassSetBindGroup(pass, 0, bindGroup, 0, nil)
-	fnPassDispatch(pass, uint32((n+7)/8), uint32((m+7)/8), uint32(batches))
-	fnPassEnd(pass)
-	fnPassRelease(pass)
-	fnEncoderCopyBuffer(encoder, bufOut, 0, bufRead, 0, outBytes)
-	cmd := fnEncoderFinish(encoder, nil)
-	fnCmdEncoderRelease(encoder)
-	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
-	fnCmdBufferRelease(cmd)
-
+// mapRead blocks until buf (usage MapRead) is mapped and returns the mapped
+// range; the caller must fnBufferUnmap when done.
+func (g *GPU) mapRead(buf uintptr, bytes uint64) (unsafe.Pointer, error) {
 	cbMapDone, cbMapOK = false, false
-	fnBufferMapAsync(bufRead, wgpuMapModeRead, 0, uintptr(outBytes), mapCB, nil)
+	fnBufferMapAsync(buf, wgpuMapModeRead, 0, uintptr(bytes), mapCB, nil)
 	for !cbMapDone {
 		fnDevicePoll(g.device, 1, nil)
 	}
 	if !cbMapOK {
-		return nil, fmt.Errorf("tensai: gpu matmul readback failed: %s", uncapturedCB)
+		return nil, fmt.Errorf("tensai: gpu readback failed: %s", uncapturedCB)
 	}
-	src := fnBufferGetConstMapped(bufRead, 0, uintptr(outBytes))
+	src := fnBufferGetConstMapped(buf, 0, uintptr(bytes))
 	if src == nil {
-		return nil, errors.New("tensai: gpu matmul: mapped range unavailable")
+		return nil, errors.New("tensai: gpu readback: mapped range unavailable")
 	}
-	copy(out.Data, unsafe.Slice((*Float)(src), len(out.Data)))
-	fnBufferUnmap(bufRead)
-	if uncapturedCB != "" {
-		return nil, fmt.Errorf("tensai: gpu matmul failed: %s", uncapturedCB)
-	}
-	runtime.KeepAlive(a)
-	runtime.KeepAlive(b)
-	return out, nil
+	return src, nil
 }

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -587,6 +587,10 @@ func (g *GPU) Close() {
 	}
 }
 
+// The primitives below back the shared GPUTensor layer in wgputensor.go;
+// their signatures match the v22 bindings so that layer compiles against
+// either API generation.
+
 func (g *GPU) newBuffer(usage, size uint64) uintptr {
 	desc := wgpuBufferDescriptor{usage: usage, size: size}
 	buf := fnDeviceCreateBuffer(g.device, &desc)
@@ -594,122 +598,29 @@ func (g *GPU) newBuffer(usage, size uint64) uintptr {
 	return buf
 }
 
-// MatMul is the GPU version of the package-level MatMul: identical shape
-// and broadcasting semantics, executed as one compute dispatch. Inputs and
-// the result live in host memory; each call uploads the operands and reads
-// the product back, so it only pays off for large products.
-func (g *GPU) MatMul(a, b *Tensor) (*Tensor, error) {
-	na, nb := len(a.Shape), len(b.Shape)
-	if na < 2 || nb < 2 {
-		return nil, fmt.Errorf("tensai: matmul needs at least 2 axes: %v * %v", a.Shape, b.Shape)
-	}
-	m, k := a.Shape[na-2], a.Shape[na-1]
-	if b.Shape[nb-2] != k {
-		return nil, fmt.Errorf("tensai: matmul shape mismatch: %v * %v", a.Shape, b.Shape)
-	}
-	n := b.Shape[nb-1]
-	batch, err := broadcastShapes(a.Shape[:na-2], b.Shape[:nb-2])
-	if err != nil {
-		return nil, err
-	}
-	out := NewTensor(append(append([]int(nil), batch...), m, n)...)
-	batches := prodDims(batch)
-	if batches > 65535 {
-		return nil, fmt.Errorf("tensai: gpu matmul batch count %d exceeds 65535", batches)
-	}
+func (g *GPU) makeBindGroup(entries []wgpuBindGroupEntry) uintptr {
+	desc := wgpuBindGroupDescriptor{layout: g.layout, entryCount: uintptr(len(entries)), entries: &entries[0]}
+	bg := fnDeviceCreateBindGroup(g.device, &desc)
+	runtime.KeepAlive(&desc)
+	return bg
+}
 
-	// Element offsets of each batch's matrix in a and b.
-	as := broadcastStrides(a.Shape[:na-2], batch)
-	bs := broadcastStrides(b.Shape[:nb-2], batch)
-	offs := make([]uint32, 2*batches)
-	for bi := 0; bi < batches; bi++ {
-		offA, offB := 0, 0
-		for d, rem := len(batch)-1, bi; d >= 0; d-- {
-			i := rem % batch[d]
-			rem /= batch[d]
-			offA += i * as[d]
-			offB += i * bs[d]
-		}
-		offs[2*bi] = uint32(offA * m * k)
-		offs[2*bi+1] = uint32(offB * k * n)
-	}
-	params := [4]uint32{uint32(m), uint32(k), uint32(n), uint32(batches)}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	wgpuMu.Lock()
-	defer wgpuMu.Unlock()
-	if g.closed {
-		return nil, errors.New("tensai: gpu is closed")
-	}
-	uncapturedCB = ""
-
-	outBytes := uint64(len(out.Data)) * 4
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
-	bufA := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(a.Data))*4)
-	bufB := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(b.Data))*4)
-	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
-	bufOut := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopySrc, outBytes)
-	bufRead := g.newBuffer(wgpuBufferUsageMapRead|wgpuBufferUsageCopyDst, outBytes)
-	defer func() {
-		for _, buf := range []uintptr{bufParams, bufA, bufB, bufOffs, bufOut, bufRead} {
-			if buf != 0 {
-				fnBufferRelease(buf)
-			}
-		}
-	}()
-
-	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
-	fnQueueWriteBuffer(g.queue, bufA, 0, unsafe.Pointer(&a.Data[0]), uintptr(len(a.Data))*4)
-	fnQueueWriteBuffer(g.queue, bufB, 0, unsafe.Pointer(&b.Data[0]), uintptr(len(b.Data))*4)
-	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
-
-	entries := [5]wgpuBindGroupEntry{
-		{binding: 0, buffer: bufParams, size: 16},
-		{binding: 1, buffer: bufA, size: uint64(len(a.Data)) * 4},
-		{binding: 2, buffer: bufB, size: uint64(len(b.Data)) * 4},
-		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
-		{binding: 4, buffer: bufOut, size: outBytes},
-	}
-	bgDesc := wgpuBindGroupDescriptor{layout: g.layout, entryCount: 5, entries: &entries[0]}
-	bindGroup := fnDeviceCreateBindGroup(g.device, &bgDesc)
-	runtime.KeepAlive(&entries)
-	runtime.KeepAlive(&bgDesc)
-	defer fnBindGroupRelease(bindGroup)
-
-	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
-	pass := fnEncoderBeginComputePass(encoder, nil)
-	fnPassSetPipeline(pass, g.pipeline)
-	fnPassSetBindGroup(pass, 0, bindGroup, 0, nil)
-	fnPassDispatch(pass, uint32((n+7)/8), uint32((m+7)/8), uint32(batches))
-	fnPassEnd(pass)
-	fnPassRelease(pass)
-	fnEncoderCopyBuffer(encoder, bufOut, 0, bufRead, 0, outBytes)
-	cmd := fnEncoderFinish(encoder, nil)
-	fnCmdEncoderRelease(encoder)
-	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
-	fnCmdBufferRelease(cmd)
-
+// mapRead blocks until buf (usage MapRead) is mapped and returns the mapped
+// range; the caller must fnBufferUnmap when done.
+func (g *GPU) mapRead(buf uintptr, bytes uint64) (unsafe.Pointer, error) {
 	cbMapDone, cbMapOK, cbFailMsg = false, false, ""
-	fnBufferMapAsync(bufRead, wgpuMapModeRead, 0, uintptr(outBytes), wgpuCallbackInfo{
+	fnBufferMapAsync(buf, wgpuMapModeRead, 0, uintptr(bytes), wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowProcessEvents, callback: mapCB,
 	})
 	for !cbMapDone {
 		fnDevicePoll(g.device, 1, nil)
 	}
 	if !cbMapOK {
-		return nil, fmt.Errorf("tensai: gpu matmul readback failed: %s %s", cbFailMsg, uncapturedCB)
+		return nil, fmt.Errorf("tensai: gpu readback failed: %s %s", cbFailMsg, uncapturedCB)
 	}
-	src := fnBufferGetConstMapped(bufRead, 0, uintptr(outBytes))
+	src := fnBufferGetConstMapped(buf, 0, uintptr(bytes))
 	if src == nil {
-		return nil, errors.New("tensai: gpu matmul: mapped range unavailable")
+		return nil, errors.New("tensai: gpu readback: mapped range unavailable")
 	}
-	copy(out.Data, unsafe.Slice((*Float)(src), len(out.Data)))
-	fnBufferUnmap(bufRead)
-	if uncapturedCB != "" {
-		return nil, fmt.Errorf("tensai: gpu matmul failed: %s", uncapturedCB)
-	}
-	runtime.KeepAlive(a)
-	runtime.KeepAlive(b)
-	return out, nil
+	return src, nil
 }

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -32,3 +32,25 @@ func (g *GPU) MatMul(a, b *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 
 // Close is a no-op in builds without the wgpu tag.
 func (g *GPU) Close() {}
+
+// GPUTensor is a GPU-resident tensor. This build has it disabled; build
+// with -tags wgpu or -tags wgpu24 to enable it.
+type GPUTensor struct{}
+
+// Upload always fails in builds without the wgpu tag.
+func (g *GPU) Upload(t *Tensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// MatMul always fails in builds without the wgpu tag.
+func (t *GPUTensor) MatMul(o *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// Download always fails in builds without the wgpu tag.
+func (t *GPUTensor) Download() (*Tensor, error) { return nil, errNoWGPU }
+
+// Free is a no-op in builds without the wgpu tag.
+func (t *GPUTensor) Free() {}
+
+// Shape returns nil in builds without the wgpu tag.
+func (t *GPUTensor) Shape() []int { return nil }
+
+// Size returns 0 in builds without the wgpu tag.
+func (t *GPUTensor) Size() int { return 0 }

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -87,6 +87,116 @@ func TestGPUAdapterSelection(t *testing.T) {
 	}
 }
 
+func TestGPUTensorResident(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(11))
+
+	// A weight uploaded once serves several MatMuls without re-upload.
+	w := randTensor(rng, 64, 32)
+	gw, err := g.Upload(w)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	defer gw.Free()
+	if !sameDims(gw.Shape(), []int{64, 32}) || gw.Size() != 64*32 {
+		t.Fatalf("shape/size: %v %d", gw.Shape(), gw.Size())
+	}
+	for i := 0; i < 3; i++ {
+		x := randTensor(rng, 4, 5, 64)
+		gx, err := g.Upload(x)
+		if err != nil {
+			t.Fatalf("upload x: %v", err)
+		}
+		gy, err := gx.MatMul(gw)
+		if err != nil {
+			t.Fatalf("resident matmul: %v", err)
+		}
+		got, err := gy.Download()
+		if err != nil {
+			t.Fatalf("download: %v", err)
+		}
+		want, err := MatMul(x, w)
+		if err != nil {
+			t.Fatalf("cpu matmul: %v", err)
+		}
+		if !sameDims(got.Shape, want.Shape) {
+			t.Fatalf("shape: got %v want %v", got.Shape, want.Shape)
+		}
+		for j := range want.Data {
+			if diff := math.Abs(float64(got.Data[j] - want.Data[j])); diff > 1e-4 {
+				t.Fatalf("round %d element %d: gpu=%v cpu=%v", i, j, got.Data[j], want.Data[j])
+			}
+		}
+		gy.Free()
+		gx.Free()
+	}
+}
+
+func TestGPUTensorChain(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(12))
+
+	// (a @ b) @ c entirely on the GPU: the intermediate never touches the
+	// host.
+	a, b, c := randTensor(rng, 2, 4, 8), randTensor(rng, 2, 8, 3), randTensor(rng, 2, 3, 6)
+	ga, err := g.Upload(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ga.Free()
+	gb, err := g.Upload(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gb.Free()
+	gc, err := g.Upload(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gc.Free()
+
+	ab, err := ga.MatMul(gb)
+	if err != nil {
+		t.Fatalf("a@b: %v", err)
+	}
+	defer ab.Free()
+	abc, err := ab.MatMul(gc)
+	if err != nil {
+		t.Fatalf("(a@b)@c: %v", err)
+	}
+	got, err := abc.Download()
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	wantAB, err := MatMul(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := MatMul(wantAB, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range want.Data {
+		if diff := math.Abs(float64(got.Data[i] - want.Data[i])); diff > 1e-4 {
+			t.Fatalf("element %d: gpu=%v cpu=%v", i, got.Data[i], want.Data[i])
+		}
+	}
+
+	if _, err := ab.MatMul(ab); err == nil {
+		t.Fatal("expected shape mismatch error for (2,4,3)@(2,4,3)")
+	}
+	abc.Free()
+	if _, err := abc.Download(); err == nil {
+		t.Fatal("expected error downloading a freed tensor")
+	}
+	if _, err := abc.MatMul(ga); err == nil {
+		t.Fatal("expected error using a freed tensor")
+	}
+	abc.Free() // second Free is a no-op
+}
+
 func TestGPUMatMulLarge(t *testing.T) {
 	g := openTestGPU(t)
 	defer g.Close()

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -1,0 +1,231 @@
+//go:build (wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin))
+
+package tensai
+
+// GPUTensor: tensors resident in GPU memory, so a weight is uploaded once
+// and reused across calls instead of riding the bus on every MatMul. This
+// file is shared between the v22 (wgpu.go) and v24+ (wgpu24.go) bindings —
+// it only touches primitives whose shapes agree across the two generations
+// (newBuffer, makeBindGroup, mapRead, and the fn* pointers with identical
+// signatures).
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// GPUTensor is a tensor whose data lives in GPU memory. Create one with
+// GPU.Upload or as the result of GPUTensor.MatMul, read it back with
+// Download, and release it with Free — GPU memory is not garbage
+// collected.
+type GPUTensor struct {
+	g     *GPU
+	buf   uintptr
+	shape []int
+	freed bool
+}
+
+// Every GPUTensor buffer is storage-usable (matmul input and output),
+// copyable in (Upload) and out (Download).
+const gpuTensorUsage = wgpuBufferUsageStorage | wgpuBufferUsageCopySrc | wgpuBufferUsageCopyDst
+
+// Shape returns a copy of the tensor's shape.
+func (t *GPUTensor) Shape() []int { return append([]int(nil), t.shape...) }
+
+// Size returns the total number of elements.
+func (t *GPUTensor) Size() int { return prodDims(t.shape) }
+
+// Upload copies a tensor into GPU memory. The returned GPUTensor is
+// independent of t.
+func (g *GPU) Upload(t *Tensor) (*GPUTensor, error) {
+	if len(t.Data) == 0 {
+		return nil, errors.New("tensai: cannot upload an empty tensor")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	buf := g.newBuffer(gpuTensorUsage, uint64(len(t.Data))*4)
+	if buf == 0 {
+		return nil, errors.New("tensai: gpu buffer allocation failed")
+	}
+	fnQueueWriteBuffer(g.queue, buf, 0, unsafe.Pointer(&t.Data[0]), uintptr(len(t.Data))*4)
+	runtime.KeepAlive(t)
+	return &GPUTensor{g: g, buf: buf, shape: append([]int(nil), t.Shape...)}, nil
+}
+
+// Download copies the tensor back into host memory.
+func (t *GPUTensor) Download() (*Tensor, error) {
+	if t.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	out := NewTensor(t.shape...)
+	bytes := uint64(len(out.Data)) * 4
+	staging := g.newBuffer(wgpuBufferUsageMapRead|wgpuBufferUsageCopyDst, bytes)
+	defer fnBufferRelease(staging)
+
+	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
+	fnEncoderCopyBuffer(encoder, t.buf, 0, staging, 0, bytes)
+	cmd := fnEncoderFinish(encoder, nil)
+	fnCmdEncoderRelease(encoder)
+	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
+	fnCmdBufferRelease(cmd)
+
+	src, err := g.mapRead(staging, bytes)
+	if err != nil {
+		return nil, err
+	}
+	copy(out.Data, unsafe.Slice((*Float)(src), len(out.Data)))
+	fnBufferUnmap(staging)
+	return out, nil
+}
+
+// Free releases the GPU buffer. The tensor must not be used afterwards;
+// calling Free again is a no-op.
+func (t *GPUTensor) Free() {
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if t.freed {
+		return
+	}
+	t.freed = true
+	fnBufferRelease(t.buf)
+}
+
+// MatMul multiplies two GPU-resident tensors with the same shape and
+// broadcasting semantics as the package-level MatMul, returning a new
+// GPU-resident tensor without any host transfer. Chain calls freely; only
+// Download moves data back.
+func (t *GPUTensor) MatMul(o *GPUTensor) (*GPUTensor, error) {
+	if t.freed || o.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if t.g != o.g {
+		return nil, errors.New("tensai: gpu tensors belong to different GPUs")
+	}
+	na, nb := len(t.shape), len(o.shape)
+	if na < 2 || nb < 2 {
+		return nil, fmt.Errorf("tensai: matmul needs at least 2 axes: %v * %v", t.shape, o.shape)
+	}
+	m, k := t.shape[na-2], t.shape[na-1]
+	if o.shape[nb-2] != k {
+		return nil, fmt.Errorf("tensai: matmul shape mismatch: %v * %v", t.shape, o.shape)
+	}
+	n := o.shape[nb-1]
+	batch, err := broadcastShapes(t.shape[:na-2], o.shape[:nb-2])
+	if err != nil {
+		return nil, err
+	}
+	batches := prodDims(batch)
+	if batches > 65535 {
+		return nil, fmt.Errorf("tensai: gpu matmul batch count %d exceeds 65535", batches)
+	}
+	outShape := append(append([]int(nil), batch...), m, n)
+
+	// Element offsets of each batch's matrix in t and o.
+	as := broadcastStrides(t.shape[:na-2], batch)
+	bs := broadcastStrides(o.shape[:nb-2], batch)
+	offs := make([]uint32, 2*batches)
+	for bi := 0; bi < batches; bi++ {
+		offA, offB := 0, 0
+		for d, rem := len(batch)-1, bi; d >= 0; d-- {
+			i := rem % batch[d]
+			rem /= batch[d]
+			offA += i * as[d]
+			offB += i * bs[d]
+		}
+		offs[2*bi] = uint32(offA * m * k)
+		offs[2*bi+1] = uint32(offB * k * n)
+	}
+	params := [4]uint32{uint32(m), uint32(k), uint32(n), uint32(batches)}
+
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	outBytes := uint64(prodDims(outShape)) * 4
+	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
+	bufOut := g.newBuffer(gpuTensorUsage, outBytes)
+	defer fnBufferRelease(bufParams)
+	defer fnBufferRelease(bufOffs)
+
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
+
+	entries := [5]wgpuBindGroupEntry{
+		{binding: 0, buffer: bufParams, size: 16},
+		{binding: 1, buffer: t.buf, size: uint64(t.Size()) * 4},
+		{binding: 2, buffer: o.buf, size: uint64(o.Size()) * 4},
+		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
+		{binding: 4, buffer: bufOut, size: outBytes},
+	}
+	bindGroup := g.makeBindGroup(entries[:])
+	runtime.KeepAlive(&entries)
+	defer fnBindGroupRelease(bindGroup)
+
+	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
+	pass := fnEncoderBeginComputePass(encoder, nil)
+	fnPassSetPipeline(pass, g.pipeline)
+	fnPassSetBindGroup(pass, 0, bindGroup, 0, nil)
+	fnPassDispatch(pass, uint32((n+7)/8), uint32((m+7)/8), uint32(batches))
+	fnPassEnd(pass)
+	fnPassRelease(pass)
+	cmd := fnEncoderFinish(encoder, nil)
+	fnCmdEncoderRelease(encoder)
+	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
+	fnCmdBufferRelease(cmd)
+
+	// Validation errors surface through the uncaptured-error callback,
+	// which wgpu-native fires during submission; pump once without
+	// blocking on the actual compute work.
+	fnDevicePoll(g.device, 0, nil)
+	if uncapturedCB != "" {
+		fnBufferRelease(bufOut)
+		return nil, fmt.Errorf("tensai: gpu matmul failed: %s", uncapturedCB)
+	}
+	return &GPUTensor{g: g, buf: bufOut, shape: outShape}, nil
+}
+
+// MatMul is the GPU version of the package-level MatMul: identical shape
+// and broadcasting semantics, executed as one compute dispatch. Inputs and
+// the result live in host memory; each call uploads the operands and reads
+// the product back, so it only pays off for large products — keep operands
+// resident with Upload / GPUTensor.MatMul to amortize the transfers.
+func (g *GPU) MatMul(a, b *Tensor) (*Tensor, error) {
+	ga, err := g.Upload(a)
+	if err != nil {
+		return nil, err
+	}
+	defer ga.Free()
+	gb, err := g.Upload(b)
+	if err != nil {
+		return nil, err
+	}
+	defer gb.Free()
+	gc, err := ga.MatMul(gb)
+	if err != nil {
+		return nil, err
+	}
+	defer gc.Free()
+	return gc.Download()
+}


### PR DESCRIPTION
Adds GPU-resident buffers, step 1 of the resident-buffers / tiled-kernel / element-wise-kernels plan. `gpu.Upload` copies a tensor to the GPU once and returns a `GPUTensor`; `GPUTensor.MatMul` multiplies resident tensors with the same shape and broadcasting semantics as the package-level MatMul, so chains like `(x@w1)@w2` never touch host memory; `Download` reads the result back and `Free` releases the buffer. The existing `gpu.MatMul` becomes shorthand for Upload → MatMul → Download → Free, with API and behavior unchanged. The layer lives in wgputensor.go, shared by the v22 and v24+ bindings through per-file primitives with matching signatures; tested on lavapipe under both bindings and on the real host GPU through dozen inside WSL2.