### PR TITLE
spread scale and softmax over a 2-D dispatch grid

### DIFF
--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -463,6 +463,56 @@ func TestGPUMultiHeadAttention(t *testing.T) {
 	}
 }
 
+func TestGPUDispatch2D(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(18))
+
+	// 70000 rows exceed the 65535 single-axis dispatch limit, exercising
+	// the 2-D workgroup grid in softmax.
+	x := randTensor(rng, 70000, 8)
+	gx, err := g.Upload(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gx.Free()
+	sm, err := gx.Softmax()
+	if err != nil {
+		t.Fatalf("softmax: %v", err)
+	}
+	defer sm.Free()
+	got, err := sm.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cpuSoftmaxLast(x)
+	for i := range x.Data {
+		if diff := math.Abs(float64(got.Data[i] - x.Data[i])); diff > 1e-5 {
+			t.Fatalf("softmax element %d: gpu=%v cpu=%v", i, got.Data[i], x.Data[i])
+		}
+	}
+
+	// 17.4M elements exceed 65535 workgroups of 256 lanes for scale.
+	y := randTensor(rng, 68000, 256)
+	gy, err := g.Upload(y)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gy.Free()
+	if err := gy.Scale(2); err != nil {
+		t.Fatalf("scale: %v", err)
+	}
+	sGot, err := gy.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, i := range []int{0, 12345, len(y.Data) / 2, len(y.Data) - 1} {
+		if diff := math.Abs(float64(sGot.Data[i] - y.Data[i]*2)); diff > 1e-5 {
+			t.Fatalf("scale element %d: gpu=%v want=%v", i, sGot.Data[i], y.Data[i]*2)
+		}
+	}
+}
+
 func TestGPUMatMulLarge(t *testing.T) {
 	g := openTestGPU(t)
 	defer g.Close()

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -137,9 +137,14 @@ struct ScaleParams { count: u32, s: f32 }
 @group(0) @binding(6) var<storage, read_write> sbuf: array<f32>;
 
 @compute @workgroup_size(256, 1, 1)
-fn scale_ip(@builtin(global_invocation_id) gid: vec3<u32>) {
-    if (gid.x < scp.count) {
-        sbuf[gid.x] = sbuf[gid.x] * scp.s;
+fn scale_ip(@builtin(workgroup_id) wg: vec3<u32>,
+            @builtin(num_workgroups) nwg: vec3<u32>,
+            @builtin(local_invocation_id) lid: vec3<u32>) {
+    // Workgroups are laid out on a 2-D grid to escape the 65535 per-axis
+    // dispatch limit.
+    let idx = (wg.y * nwg.x + wg.x) * 256u + lid.x;
+    if (idx < scp.count) {
+        sbuf[idx] = sbuf[idx] * scp.s;
     }
 }
 
@@ -152,8 +157,16 @@ var<workgroup> red: array<f32, 256>;
 
 @compute @workgroup_size(256, 1, 1)
 fn softmax_last(@builtin(workgroup_id) wid: vec3<u32>,
+                @builtin(num_workgroups) nwg: vec3<u32>,
                 @builtin(local_invocation_id) lid: vec3<u32>) {
-    let base = wid.x * sp.cols;
+    // One workgroup per row, on a 2-D grid to escape the 65535 per-axis
+    // dispatch limit. row is workgroup-uniform, so returning here keeps
+    // the barriers below in uniform control flow.
+    let row = wid.y * nwg.x + wid.x;
+    if (row >= sp.rows) {
+        return;
+    }
+    let base = row * sp.cols;
     var m = -3.40282e38;
     for (var i = lid.x; i < sp.cols; i = i + 256u) {
         m = max(m, sx[base + i]);
@@ -467,6 +480,15 @@ func (g *GPU) stridedMatMul(a, b *GPUTensor, outShape []int, transB bool, m, k, 
 	return &GPUTensor{g: g, buf: bufOut, shape: outShape}, nil
 }
 
+// split2D spreads n workgroups over a 2-D dispatch grid, since a single
+// axis is capped at 65535.
+func split2D(n int) (x, y uint32) {
+	if n <= 65535 {
+		return uint32(n), 1
+	}
+	return 65535, uint32((n + 65534) / 65535)
+}
+
 // Scale multiplies every element by s, in place — the GPU counterpart of
 // Tensor.Scale.
 func (t *GPUTensor) Scale(s Float) error {
@@ -474,9 +496,6 @@ func (t *GPUTensor) Scale(s Float) error {
 		return errors.New("tensai: gpu tensor already freed")
 	}
 	count := t.Size()
-	if count > 65535*gpuKernelWG {
-		return fmt.Errorf("tensai: gpu scale size %d exceeds dispatch limit", count)
-	}
 	g := t.g
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -500,7 +519,8 @@ func (t *GPUTensor) Scale(s Float) error {
 	runtime.KeepAlive(&entries)
 	defer fnBindGroupRelease(bindGroup)
 
-	return g.dispatch(g.pipes.scale, bindGroup, uint32((count+gpuKernelWG-1)/gpuKernelWG), 1, 1)
+	x, y := split2D((count + gpuKernelWG - 1) / gpuKernelWG)
+	return g.dispatch(g.pipes.scale, bindGroup, x, y, 1)
 }
 
 // Softmax applies a numerically stable softmax over the last axis,
@@ -514,9 +534,6 @@ func (t *GPUTensor) Softmax() (*GPUTensor, error) {
 	}
 	cols := t.shape[len(t.shape)-1]
 	rows := t.Size() / cols
-	if rows > 65535 {
-		return nil, fmt.Errorf("tensai: gpu softmax row count %d exceeds 65535", rows)
-	}
 	g := t.g
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -543,7 +560,8 @@ func (t *GPUTensor) Softmax() (*GPUTensor, error) {
 	runtime.KeepAlive(&entries)
 	defer fnBindGroupRelease(bindGroup)
 
-	if err := g.dispatch(g.pipes.softmax, bindGroup, uint32(rows), 1, 1); err != nil {
+	x, y := split2D(rows)
+	if err := g.dispatch(g.pipes.softmax, bindGroup, x, y, 1); err != nil {
 		fnBufferRelease(bufOut)
 		return nil, err
 	}


### PR DESCRIPTION
A single dispatch axis is capped at 65535 workgroups, which limited scale to 16.7M elements and softmax to 65535 rows — multi-head attention at batch 8, heads 8, seq 512 already tripped it. Both kernels now derive their linear index from a 2-D workgroup grid via num_workgroups; the softmax row check is workgroup-uniform, so the early return keeps its barriers in uniform control flow. New tests push both kernels past the old caps, passing on lavapipe under both bindings and on the real GPU through dozen. Very large attention shapes now stop at the next boundary — a 256MiB scores buffer versus the default 128MiB maxStorageBufferBindingSize — which raising device limits at OpenGPU time will address separately.