### PR TITLE
negotiate adapter limits at OpenGPU and pre-check buffer sizes

### DIFF
--- a/wgpu.go
+++ b/wgpu.go
@@ -32,15 +32,16 @@ import (
 // OpenGPU, use it from any goroutine (calls are serialized internally), and
 // Close it when done.
 type GPU struct {
-	mu       sync.Mutex
-	instance uintptr
-	adapter  uintptr
-	device   uintptr
-	queue    uintptr
-	module   uintptr
-	pipes    gpuPipelines
-	name     string
-	closed   bool
+	mu         sync.Mutex
+	instance   uintptr
+	adapter    uintptr
+	device     uintptr
+	queue      uintptr
+	module     uintptr
+	pipes      gpuPipelines
+	name       string
+	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
+	closed     bool
 }
 
 // GPUPower tells OpenGPU which adapter to prefer on machines with more than
@@ -155,6 +156,29 @@ type wgpuAdapterInfo struct {
 	deviceID     uint32
 }
 
+// wgpuLimits mirrors WGPULimits: 14 leading u32s, three u64 sizes split by
+// u32 runs. Only the named sizes are read; the rest ride along so the
+// adapter's limits can be requested back verbatim.
+type wgpuLimits struct {
+	u32a                        [14]uint32
+	maxUniformBufferBindingSize uint64
+	maxStorageBufferBindingSize uint64
+	u32b                        [3]uint32
+	_                           uint32
+	maxBufferSize               uint64
+	u32c                        [12]uint32
+}
+
+type wgpuSupportedLimits struct {
+	nextInChain uintptr
+	limits      wgpuLimits
+}
+
+type wgpuRequiredLimits struct {
+	nextInChain uintptr
+	limits      wgpuLimits
+}
+
 type wgpuDeviceDescriptor struct {
 	nextInChain          uintptr
 	label                uintptr
@@ -175,6 +199,7 @@ var (
 	fnCreateInstance          func(unsafe.Pointer) uintptr
 	fnInstanceRequestAdapter  func(uintptr, unsafe.Pointer, uintptr, unsafe.Pointer)
 	fnAdapterGetInfo          func(uintptr, unsafe.Pointer)
+	fnAdapterGetLimits        func(uintptr, unsafe.Pointer) uint32
 	fnAdapterRequestDevice    func(uintptr, unsafe.Pointer, uintptr, unsafe.Pointer)
 	fnDeviceGetQueue          func(uintptr) uintptr
 	fnDeviceCreateShaderMod   func(uintptr, unsafe.Pointer) uintptr
@@ -292,6 +317,7 @@ func loadWGPU() error {
 			{&fnCreateInstance, "wgpuCreateInstance"},
 			{&fnInstanceRequestAdapter, "wgpuInstanceRequestAdapter"},
 			{&fnAdapterGetInfo, "wgpuAdapterGetInfo"},
+			{&fnAdapterGetLimits, "wgpuAdapterGetLimits"},
 			{&fnAdapterRequestDevice, "wgpuAdapterRequestDevice"},
 			{&fnDeviceGetQueue, "wgpuDeviceGetQueue"},
 			{&fnDeviceCreateShaderMod, "wgpuDeviceCreateShaderModule"},
@@ -409,9 +435,19 @@ func OpenGPU(power ...GPUPower) (*GPU, error) {
 		g.name += " (cpu)"
 	}
 
+	// Request the adapter's own limits back so big storage buffers are not
+	// capped at the conservative defaults (128MiB bindings).
+	var sup wgpuSupportedLimits
 	desc := wgpuDeviceDescriptor{errCallback: errorCB}
+	var req wgpuRequiredLimits
+	if fnAdapterGetLimits(g.adapter, unsafe.Pointer(&sup)) == 1 {
+		req.limits = sup.limits
+		desc.requiredLimits = uintptr(unsafe.Pointer(&req))
+		g.maxStorage = min(sup.limits.maxStorageBufferBindingSize, sup.limits.maxBufferSize)
+	}
 	fnAdapterRequestDevice(g.adapter, unsafe.Pointer(&desc), deviceCB, nil)
 	runtime.KeepAlive(&desc)
+	runtime.KeepAlive(&req)
 	if cbDevice == 0 {
 		g.Close()
 		return nil, fmt.Errorf("tensai: wgpu device request failed: %s", cbFailMsg)

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -35,15 +35,16 @@ import (
 // OpenGPU, use it from any goroutine (calls are serialized internally), and
 // Close it when done.
 type GPU struct {
-	mu       sync.Mutex
-	instance uintptr
-	adapter  uintptr
-	device   uintptr
-	queue    uintptr
-	module   uintptr
-	pipes    gpuPipelines
-	name     string
-	closed   bool
+	mu         sync.Mutex
+	instance   uintptr
+	adapter    uintptr
+	device     uintptr
+	queue      uintptr
+	module     uintptr
+	pipes      gpuPipelines
+	name       string
+	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
+	closed     bool
 }
 
 // GPUPower tells OpenGPU which adapter to prefer on machines with more than
@@ -157,6 +158,22 @@ type wgpuUncapturedErrorCallbackInfo struct {
 	userdata2   uintptr
 }
 
+// wgpuLimits mirrors the v29 WGPULimits: a chain pointer, 14 leading u32s,
+// and three u64 sizes split by u32 runs (the tail gained maxImmediateSize
+// and lost maxInterStageShaderComponents relative to v22, keeping 12
+// u32s). Only the named sizes are read; the rest ride along so the
+// adapter's limits can be requested back verbatim.
+type wgpuLimits struct {
+	nextInChain                 uintptr
+	u32a                        [14]uint32
+	maxUniformBufferBindingSize uint64
+	maxStorageBufferBindingSize uint64
+	u32b                        [3]uint32
+	_                           uint32
+	maxBufferSize               uint64
+	u32c                        [12]uint32
+}
+
 type wgpuDeviceDescriptor struct {
 	nextInChain          uintptr
 	label                wgpuStringView
@@ -242,6 +259,7 @@ var (
 	fnCreateInstance          func(*wgpuInstanceDescriptor) uintptr
 	fnInstanceRequestAdapter  func(uintptr, *wgpuRequestAdapterOptions, wgpuCallbackInfo) uint64
 	fnAdapterGetInfo          func(uintptr, *wgpuAdapterInfo) uint32
+	fnAdapterGetLimits        func(uintptr, *wgpuLimits) uint32
 	fnAdapterRequestDevice    func(uintptr, *wgpuDeviceDescriptor, wgpuCallbackInfo) uint64
 	fnDeviceGetQueue          func(uintptr) uintptr
 	fnDeviceCreateShaderMod   func(uintptr, *wgpuShaderModuleDescriptor) uintptr
@@ -356,6 +374,7 @@ func loadWGPU() error {
 			{&fnCreateInstance, "wgpuCreateInstance"},
 			{&fnInstanceRequestAdapter, "wgpuInstanceRequestAdapter"},
 			{&fnAdapterGetInfo, "wgpuAdapterGetInfo"},
+			{&fnAdapterGetLimits, "wgpuAdapterGetLimits"},
 			{&fnAdapterRequestDevice, "wgpuAdapterRequestDevice"},
 			{&fnDeviceGetQueue, "wgpuDeviceGetQueue"},
 			{&fnDeviceCreateShaderMod, "wgpuDeviceCreateShaderModule"},
@@ -488,13 +507,22 @@ func OpenGPU(power ...GPUPower) (*GPU, error) {
 		g.name += " (cpu)"
 	}
 
+	// Request the adapter's own limits back so big storage buffers are not
+	// capped at the conservative defaults (128MiB bindings).
+	var lim wgpuLimits
 	dDesc := wgpuDeviceDescriptor{
 		uncaptured: wgpuUncapturedErrorCallbackInfo{callback: errorCB},
+	}
+	if fnAdapterGetLimits(g.adapter, &lim) == 1 {
+		lim.nextInChain = 0
+		dDesc.requiredLimits = uintptr(unsafe.Pointer(&lim))
+		g.maxStorage = min(lim.maxStorageBufferBindingSize, lim.maxBufferSize)
 	}
 	fnAdapterRequestDevice(g.adapter, &dDesc, wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowSpontaneous, callback: deviceCB,
 	})
 	runtime.KeepAlive(&dDesc)
+	runtime.KeepAlive(&lim)
 	if cbDevice == 0 {
 		g.Close()
 		return nil, fmt.Errorf("tensai: wgpu device request failed: %s", cbFailMsg)

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -33,6 +33,9 @@ func (g *GPU) MatMul(a, b *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 // Close is a no-op in builds without the wgpu tag.
 func (g *GPU) Close() {}
 
+// StorageLimit returns 0 in builds without the wgpu tag.
+func (g *GPU) StorageLimit() uint64 { return 0 }
+
 // GPUTensor is a GPU-resident tensor. This build has it disabled; build
 // with -tags wgpu or -tags wgpu24 to enable it.
 type GPUTensor struct{}

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -278,6 +278,19 @@ type GPUTensor struct {
 // copyable in (Upload) and out (Download).
 const gpuTensorUsage = wgpuBufferUsageStorage | wgpuBufferUsageCopySrc | wgpuBufferUsageCopyDst
 
+// StorageLimit reports how many bytes a single GPU buffer may hold under
+// the device limits negotiated at OpenGPU time (0 when unknown). Tensor
+// operations return an error instead of touching the driver when a buffer
+// would exceed it.
+func (g *GPU) StorageLimit() uint64 { return g.maxStorage }
+
+func (g *GPU) checkSize(bytes uint64) error {
+	if g.maxStorage != 0 && bytes > g.maxStorage {
+		return fmt.Errorf("tensai: gpu buffer of %d bytes exceeds the device storage limit of %d", bytes, g.maxStorage)
+	}
+	return nil
+}
+
 // Shape returns a copy of the tensor's shape.
 func (t *GPUTensor) Shape() []int { return append([]int(nil), t.shape...) }
 
@@ -296,6 +309,9 @@ func (g *GPU) Upload(t *Tensor) (*GPUTensor, error) {
 	defer wgpuMu.Unlock()
 	if g.closed {
 		return nil, errors.New("tensai: gpu is closed")
+	}
+	if err := g.checkSize(uint64(len(t.Data)) * 4); err != nil {
+		return nil, err
 	}
 	buf := g.newBuffer(gpuTensorUsage, uint64(len(t.Data))*4)
 	if buf == 0 {
@@ -447,6 +463,9 @@ func (g *GPU) stridedMatMul(a, b *GPUTensor, outShape []int, transB bool, m, k, 
 	uncapturedCB = ""
 
 	outBytes := uint64(prodDims(outShape)) * 4
+	if err := g.checkSize(outBytes); err != nil {
+		return nil, err
+	}
 	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
 	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
 	bufOut := g.newBuffer(gpuTensorUsage, outBytes)


### PR DESCRIPTION
Devices were created with wgpu's conservative default limits, capping storage bindings at 128MiB regardless of hardware — a multi-head attention scores buffer past that killed the process inside the driver. OpenGPU now reads the adapter's limits and requests them back verbatim (WGPULimits mirrored for each API generation), exposes the negotiated ceiling as `GPU.StorageLimit`, and Upload/matmul pre-check sizes against it, returning a clean error instead of crashing. Mesa's lavapipe and dozen genuinely cap at 128MiB so oversized shapes now fail politely there; native drivers typically report multi-GiB limits and gain real headroom. Verified on lavapipe under both bindings and the real GPU through dozen.