### PR TITLE
wgpu24: run on Windows by isolating the by-value calling convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ wgpu-native picks Vulkan on Linux, Vulkan or D3D12 on Windows, and Metal on macO
 
 #### `-tags wgpu24`: the new wgpu-native API, and the real GPU inside WSL2
 
-`-tags wgpu24` (linux/darwin) builds the same `OpenGPU` API against the reworked wgpu-native C API instead — pair it with a **v29-series** release binary. The new API's payoff is `WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter`, which un-hides non-conformant Vulkan drivers. Concretely: Mesa's dozen (Vulkan-on-D3D12, shipped in the kisak-mesa PPA) exposes the real host GPU inside WSL2, but the v22 API hides it as non-conformant and falls back to lavapipe; the wgpu24 build reaches it:
+`-tags wgpu24` (linux/darwin/windows) builds the same `OpenGPU` API against the reworked wgpu-native C API instead — pair it with a **v29-series** release binary. The new API's payoff is `WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter`, which un-hides non-conformant Vulkan drivers. Concretely: Mesa's dozen (Vulkan-on-D3D12, shipped in the kisak-mesa PPA) exposes the real host GPU inside WSL2, but the v22 API hides it as non-conformant and falls back to lavapipe; the wgpu24 build reaches it:
 
 ```bash
 VK_DRIVER_FILES=/path/to/dzn_icd.json \
@@ -291,7 +291,16 @@ TENSAI_WGPU_LIB=$PWD/wgpu29/lib/libwgpu_native.so \
     go run -tags wgpu24 ./_example/wgpu   # adapter: Microsoft Direct3D12 (AMD Radeon(TM) Graphics)
 ```
 
-The new API passes structs by value, which the purego bindings can express through the SysV/AAPCS register conventions on linux/darwin but not portably on Windows — Windows stays on `-tags wgpu`, where D3D12 needs no translation layer anyway. When both tags are set, `wgpu24` wins.
+The new API passes structs by value. Every one of them is reached through a pointer field except the three callback-info arguments, and those are the only per-OS code in the binding: `wgpu24_callinfo.go` hands the 40-byte struct to SysV/AAPCS in registers, while `wgpu24_callinfo_windows.go` passes its address, because the Windows x64 convention already defines any aggregate that is not 1, 2, 4, or 8 bytes wide as passed by reference. `WGPUFuture` results come back in RAX either way. When both tags are set, `wgpu24` wins.
+
+On Windows, pair it with `wgpu-windows-x86_64-msvc-release.zip` from the same v29 release:
+
+```powershell
+$env:TENSAI_WGPU_LIB="$PWD\wgpu29\lib\wgpu_native.dll"
+go run -tags wgpu24 ./_example/wgpu
+```
+
+Note that new does not mean faster: on a Radeon 780M at `32x512x512@512x512` the v22 library runs the same shader in 85ms and the v29 one in 165ms (D3D12 190ms, Vulkan 438ms when forced with `WGPU_BACKEND`). Use `wgpu24` for the adapters it reaches, not for speed.
 
 ## Run
 

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -1,4 +1,4 @@
-//go:build wgpu24 && (linux || darwin)
+//go:build wgpu24 && (linux || darwin || windows)
 
 package tensai
 
@@ -8,14 +8,16 @@ package tensai
 // GPUPower) is identical, so everything else — including _example/wgpu —
 // works unchanged.
 //
-// Two things justify the second binding generation. The new API passes
-// WGPUStringView and callback-info structs by value, which purego can
-// express on linux/darwin amd64/arm64 (SysV/AAPCS pass small aggregates in
-// registers) but not portably on Windows — so this file is linux/darwin
-// only, and Windows stays on -tags wgpu with the v22 library. In exchange
-// the new API exposes WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter,
-// which un-hides non-conformant Vulkan drivers — concretely Mesa's dozen
+// What justifies the second binding generation is
+// WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter, which un-hides
+// non-conformant Vulkan drivers — concretely Mesa's dozen
 // (Vulkan-on-D3D12), the only route to the real GPU inside WSL2.
+//
+// The new API passes WGPUStringView and callback-info structs by value.
+// Every such struct here is reached through a pointer field except the
+// three callback-info arguments, whose calling convention differs between
+// SysV/AAPCS and Windows x64; wgpu24_callinfo.go and its _windows sibling
+// hold that difference, and nothing else in this file has to care.
 //
 // Use a wgpu-native v29-series shared library with this build; the v22
 // library will fail symbol registration cleanly.
@@ -253,14 +255,13 @@ type wgpuAdapterInfo struct {
 }
 
 // Function pointers resolved from the shared library. RequestAdapter,
-// RequestDevice, and MapAsync take their callback-info struct by value and
-// return a WGPUFuture (a single uint64, ABI-identical to returning uint64).
+// RequestDevice, and MapAsync are not here: they take a callback-info
+// struct by value, so they live in the per-OS wgpu24_callinfo files behind
+// the requestAdapter/requestDevice/bufferMapAsync wrappers.
 var (
 	fnCreateInstance          func(*wgpuInstanceDescriptor) uintptr
-	fnInstanceRequestAdapter  func(uintptr, *wgpuRequestAdapterOptions, wgpuCallbackInfo) uint64
 	fnAdapterGetInfo          func(uintptr, *wgpuAdapterInfo) uint32
 	fnAdapterGetLimits        func(uintptr, *wgpuLimits) uint32
-	fnAdapterRequestDevice    func(uintptr, *wgpuDeviceDescriptor, wgpuCallbackInfo) uint64
 	fnDeviceGetQueue          func(uintptr) uintptr
 	fnDeviceCreateShaderMod   func(uintptr, *wgpuShaderModuleDescriptor) uintptr
 	fnDeviceCreatePipeline    func(uintptr, *wgpuComputePipelineDescriptor) uintptr
@@ -277,7 +278,6 @@ var (
 	fnEncoderFinish           func(uintptr, unsafe.Pointer) uintptr
 	fnQueueSubmit             func(uintptr, uintptr, unsafe.Pointer)
 	fnQueueWriteBuffer        func(uintptr, uintptr, uint64, unsafe.Pointer, uintptr)
-	fnBufferMapAsync          func(uintptr, uint64, uintptr, uintptr, wgpuCallbackInfo) uint64
 	fnBufferGetConstMapped    func(uintptr, uintptr, uintptr) unsafe.Pointer
 	fnBufferUnmap             func(uintptr)
 	fnDevicePoll              func(uintptr, uint32, unsafe.Pointer) uint32
@@ -372,10 +372,8 @@ func loadWGPU() error {
 			name string
 		}{
 			{&fnCreateInstance, "wgpuCreateInstance"},
-			{&fnInstanceRequestAdapter, "wgpuInstanceRequestAdapter"},
 			{&fnAdapterGetInfo, "wgpuAdapterGetInfo"},
 			{&fnAdapterGetLimits, "wgpuAdapterGetLimits"},
-			{&fnAdapterRequestDevice, "wgpuAdapterRequestDevice"},
 			{&fnDeviceGetQueue, "wgpuDeviceGetQueue"},
 			{&fnDeviceCreateShaderMod, "wgpuDeviceCreateShaderModule"},
 			{&fnDeviceCreatePipeline, "wgpuDeviceCreateComputePipeline"},
@@ -392,7 +390,6 @@ func loadWGPU() error {
 			{&fnEncoderFinish, "wgpuCommandEncoderFinish"},
 			{&fnQueueSubmit, "wgpuQueueSubmit"},
 			{&fnQueueWriteBuffer, "wgpuQueueWriteBuffer"},
-			{&fnBufferMapAsync, "wgpuBufferMapAsync"},
 			{&fnBufferGetConstMapped, "wgpuBufferGetConstMappedRange"},
 			{&fnBufferUnmap, "wgpuBufferUnmap"},
 			{&fnDevicePoll, "wgpuDevicePoll"},
@@ -411,6 +408,7 @@ func loadWGPU() error {
 		} {
 			purego.RegisterLibFunc(f.ptr, lib, f.name)
 		}
+		registerCallInfoFns(lib)
 
 		// New-API callbacks receive WGPUStringView messages by value; on
 		// SysV/AAPCS a 16-byte aggregate arrives as two register words, so
@@ -479,7 +477,7 @@ func OpenGPU(power ...GPUPower) (*GPU, error) {
 	}
 	// wgpu-native still fires these callbacks synchronously.
 	cbAdapter, cbDevice, cbFailMsg = 0, 0, ""
-	fnInstanceRequestAdapter(g.instance, &opts, wgpuCallbackInfo{
+	requestAdapter(g.instance, &opts, wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowSpontaneous, callback: adapterCB,
 	})
 	runtime.KeepAlive(&opts)
@@ -518,7 +516,7 @@ func OpenGPU(power ...GPUPower) (*GPU, error) {
 		dDesc.requiredLimits = uintptr(unsafe.Pointer(&lim))
 		g.maxStorage = min(lim.maxStorageBufferBindingSize, lim.maxBufferSize)
 	}
-	fnAdapterRequestDevice(g.adapter, &dDesc, wgpuCallbackInfo{
+	requestDevice(g.adapter, &dDesc, wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowSpontaneous, callback: deviceCB,
 	})
 	runtime.KeepAlive(&dDesc)
@@ -617,7 +615,7 @@ func (g *GPU) makeBindGroup(layout uintptr, entries []wgpuBindGroupEntry) uintpt
 // range; the caller must fnBufferUnmap when done.
 func (g *GPU) mapRead(buf uintptr, bytes uint64) (unsafe.Pointer, error) {
 	cbMapDone, cbMapOK, cbFailMsg = false, false, ""
-	fnBufferMapAsync(buf, wgpuMapModeRead, 0, uintptr(bytes), wgpuCallbackInfo{
+	bufferMapAsync(buf, wgpuMapModeRead, 0, uintptr(bytes), wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowProcessEvents, callback: mapCB,
 	})
 	for !cbMapDone {

--- a/wgpu24_callinfo.go
+++ b/wgpu24_callinfo.go
@@ -1,0 +1,34 @@
+//go:build wgpu24 && (linux || darwin)
+
+package tensai
+
+import "github.com/ebitengine/purego"
+
+// The three entry points that take their callback-info struct by value.
+// SysV and AAPCS hand a 40-byte aggregate to the callee in registers and
+// on the stack, which purego reproduces from the Go struct type, so these
+// signatures mirror webgpu.h directly. Windows needs the same calls spelled
+// differently; see wgpu24_callinfo_windows.go.
+var (
+	fnInstanceRequestAdapter func(uintptr, *wgpuRequestAdapterOptions, wgpuCallbackInfo) uint64
+	fnAdapterRequestDevice   func(uintptr, *wgpuDeviceDescriptor, wgpuCallbackInfo) uint64
+	fnBufferMapAsync         func(uintptr, uint64, uintptr, uintptr, wgpuCallbackInfo) uint64
+)
+
+func registerCallInfoFns(lib uintptr) {
+	purego.RegisterLibFunc(&fnInstanceRequestAdapter, lib, "wgpuInstanceRequestAdapter")
+	purego.RegisterLibFunc(&fnAdapterRequestDevice, lib, "wgpuAdapterRequestDevice")
+	purego.RegisterLibFunc(&fnBufferMapAsync, lib, "wgpuBufferMapAsync")
+}
+
+func requestAdapter(instance uintptr, opts *wgpuRequestAdapterOptions, info wgpuCallbackInfo) uint64 {
+	return fnInstanceRequestAdapter(instance, opts, info)
+}
+
+func requestDevice(adapter uintptr, desc *wgpuDeviceDescriptor, info wgpuCallbackInfo) uint64 {
+	return fnAdapterRequestDevice(adapter, desc, info)
+}
+
+func bufferMapAsync(buf uintptr, mode uint64, offset, size uintptr, info wgpuCallbackInfo) uint64 {
+	return fnBufferMapAsync(buf, mode, offset, size, info)
+}

--- a/wgpu24_callinfo_windows.go
+++ b/wgpu24_callinfo_windows.go
@@ -1,0 +1,48 @@
+//go:build wgpu24 && windows
+
+package tensai
+
+import (
+	"runtime"
+
+	"github.com/ebitengine/purego"
+)
+
+// The same three entry points as wgpu24_callinfo.go, spelled for the
+// Windows x64 convention. There an aggregate that is not 1, 2, 4, or 8
+// bytes wide is passed by reference: the caller keeps a copy alive for the
+// duration of the call and hands over its address. wgpuCallbackInfo is 40
+// bytes, so a pointer parameter *is* the by-value ABI here, and purego's
+// register-level struct support is not needed at all.
+//
+// The WGPUFuture results stay uint64: an 8-byte aggregate comes back in
+// RAX on Windows exactly as it does under SysV.
+var (
+	fnInstanceRequestAdapter func(uintptr, *wgpuRequestAdapterOptions, *wgpuCallbackInfo) uint64
+	fnAdapterRequestDevice   func(uintptr, *wgpuDeviceDescriptor, *wgpuCallbackInfo) uint64
+	fnBufferMapAsync         func(uintptr, uint64, uintptr, uintptr, *wgpuCallbackInfo) uint64
+)
+
+func registerCallInfoFns(lib uintptr) {
+	purego.RegisterLibFunc(&fnInstanceRequestAdapter, lib, "wgpuInstanceRequestAdapter")
+	purego.RegisterLibFunc(&fnAdapterRequestDevice, lib, "wgpuAdapterRequestDevice")
+	purego.RegisterLibFunc(&fnBufferMapAsync, lib, "wgpuBufferMapAsync")
+}
+
+func requestAdapter(instance uintptr, opts *wgpuRequestAdapterOptions, info wgpuCallbackInfo) uint64 {
+	f := fnInstanceRequestAdapter(instance, opts, &info)
+	runtime.KeepAlive(&info)
+	return f
+}
+
+func requestDevice(adapter uintptr, desc *wgpuDeviceDescriptor, info wgpuCallbackInfo) uint64 {
+	f := fnAdapterRequestDevice(adapter, desc, &info)
+	runtime.KeepAlive(&info)
+	return f
+}
+
+func bufferMapAsync(buf uintptr, mode uint64, offset, size uintptr, info wgpuCallbackInfo) uint64 {
+	f := fnBufferMapAsync(buf, mode, offset, size, &info)
+	runtime.KeepAlive(&info)
+	return f
+}

--- a/wgpu_dlopen_windows.go
+++ b/wgpu_dlopen_windows.go
@@ -1,4 +1,4 @@
-//go:build wgpu && windows
+//go:build (wgpu || wgpu24) && windows
 
 package tensai
 

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -1,4 +1,4 @@
-//go:build !((wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin)))
+//go:build !((wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin || windows)))
 
 package tensai
 

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -1,4 +1,4 @@
-//go:build (wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin))
+//go:build (wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin || windows))
 
 package tensai
 


### PR DESCRIPTION
The reworked wgpu-native C API was documented here as unreachable from Windows because it passes structs by value. That was too pessimistic. Only three entry points take one — `InstanceRequestAdapter`, `AdapterRequestDevice`, and `BufferMapAsync`, each with a 40-byte callback-info — and the Windows x64 convention already defines any aggregate that is not 1, 2, 4, or 8 bytes wide as passed by reference. The call that needs purego's register-level struct support under SysV/AAPCS needs none at all here: declare the parameter as a pointer and hand over the address of a copy kept alive across the call. `WGPUFuture` is 8 bytes and comes back in RAX under both conventions.

That difference is the only per-OS code. `wgpu24_callinfo.go` keeps the by-value signatures, `wgpu24_callinfo_windows.go` spells the same three with pointers, and both expose `requestAdapter`/`requestDevice`/`bufferMapAsync`, so `wgpu24.go` stays platform-blind; the remaining build tags widen to windows.

Verified on Windows 11 against wgpu-native v29.0.1.1 with an AMD Radeon iGPU — all eight GPU tests pass. New is not faster, though, so `wgpu24` stays a way to reach adapters the old API hides rather than a speedup:

| build at `32x512x512@512x512` | gpu | cpu |
| --- | --- | --- |
| `-tags wgpu`, v22 library | 85ms | 304ms |
| `-tags wgpu24`, v29 library | 165ms | 304ms |

https://claude.ai/code/session_01RNgLhsGwJpDqD2r9kc8VYh
