### PR TITLE
reuse one readback buffer per GPU instead of one per download

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ $env:TENSAI_WGPU_LIB="$PWD\wgpu\lib\wgpu_native.dll"
 go run -tags wgpu ./_example/wgpu
 ```
 
-`_example/wgpu -sweep` walks a ladder of sizes and marks where the GPU overtakes the CPU kernel. Because the CPU side is the same `dotRows` kernel the rest of the package uses, building the example twice compares all three implementations — portable Go, AVX2, and the GPU:
+`_example/wgpu -sweep` walks a ladder of sizes and marks where the GPU overtakes the CPU kernel. It reports `gpu+xfer` for the convenient Upload → MatMul → Download call and `resident` for inputs uploaded once and reused (the final result is still downloaded each iteration). Because the CPU side is the same `dotRows` kernel the rest of the package uses, building the example twice compares portable Go, AVX2, and both GPU usage patterns:
 
 ```bash
 GOEXPERIMENT=nosimd go build -tags wgpu -o wgpu-nosimd ./_example/wgpu
@@ -266,20 +266,9 @@ GOEXPERIMENT=simd   go build -tags wgpu -o wgpu-simd   ./_example/wgpu
 ./wgpu-nosimd -sweep && ./wgpu-simd -sweep
 ```
 
-On a Ryzen iGPU (AMD Radeon 780M, Vulkan) the crossover moves with the CPU kernel — the faster the CPU, the bigger the product has to be before the upload and readback pay for themselves:
+The crossover moves with the CPU kernel, GPU driver, and transfer pattern. The `res/cpu` column and crossover marker use the resident-input timing, since that is the normal pattern for repeated inference. Small MNIST layers generally remain CPU-faster because dispatch and the final readback dominate them.
 
-```
-             shape                   MFLOP        gpu        cpu   gpu/cpu
-mnist dense  1x100x784@784x128        20.1     2.52ms      491µs     0.19x
-tiny         1x128x128@128x128         4.2    3.356ms      353µs     0.11x
-small        1x512x512@512x512       268.4    4.523ms    4.499ms     0.99x
-medium       8x512x512@512x512      2147.5   15.894ms   49.388ms     3.11x   <- crossover (AVX2)
-huge         64x512x512@512x512    17179.9   121.01ms  392.146ms     3.24x
-```
-
-With the portable kernel instead of AVX2 the crossover arrives one rung earlier, at `small`. Either way a single MNIST layer is two orders of magnitude too small to bother.
-
-wgpu-native picks Vulkan on Linux, Vulkan or D3D12 on Windows, and Metal on macOS, so AMD, Intel, Apple, and NVIDIA GPUs all work — as do CPU Vulkan implementations like lavapipe, which is how the tests run on machines without a GPU. Every call uploads the operands and reads the product back over the bus, so the GPU only pays off for large products; without the build tag `OpenGPU` returns an error and nothing else changes.
+wgpu-native picks Vulkan on Linux, Vulkan or D3D12 on Windows, and Metal on macOS, so AMD, Intel, Apple, and NVIDIA GPUs all work — as do CPU Vulkan implementations like lavapipe, which is how the tests run on machines without a GPU. `gpu.MatMul` uploads the operands and reads the product back on every call; `Upload` plus `GPUTensor.MatMul` keeps inputs and intermediates resident, so only the final result needs to cross the bus. Without the build tag `OpenGPU` returns an error and nothing else changes.
 
 #### `-tags wgpu24`: the new wgpu-native API, and the real GPU inside WSL2
 

--- a/_example/wgpu/main.go
+++ b/_example/wgpu/main.go
@@ -9,8 +9,9 @@
 //	GOEXPERIMENT=nosimd go build -tags wgpu -o wgpu-nosimd ./_example/wgpu
 //	GOEXPERIMENT=simd   go build -tags wgpu -o wgpu-simd   ./_example/wgpu
 //
-// the first binary's cpu column is the portable Go kernel, the second's is
-// the AVX2 one, and the gpu column is the same either way.
+// the first binary's cpu column is the portable Go kernel and the second's
+// is the AVX2 one. gpu+xfer includes input uploads; resident reuses inputs
+// already on the device. Both GPU columns include the final download.
 //
 // The GPU path only exists in builds with -tags wgpu on linux, darwin, or
 // windows; anywhere else OpenGPU fails cleanly and this command explains
@@ -105,30 +106,64 @@ func timeOp(fn func() error) (time.Duration, error) {
 	}
 }
 
-// measure times one product on both backends, reporting the fastest of
-// reps windows each. The first GPU call also allocates buffers and warms
-// the driver's caches, so it is thrown away rather than timed.
-func measure(gpu *tensai.GPU, s shape, reps int) (gpuTime, cpuTime time.Duration, diff float64, err error) {
+// measure times the convenient upload/matmul/download path, the usual
+// resident-input GPU path, and the CPU. Resident timing still downloads the
+// result on every call, both to synchronize the GPU and to model inference
+// that consumes its final output on the host; only repeated input uploads are
+// removed. The first calls warm the driver's caches and are not timed.
+func measure(gpu *tensai.GPU, s shape, reps int) (transferTime, residentTime, cpuTime time.Duration, diff float64, err error) {
 	rng := rand.New(rand.NewSource(1))
 	a := randTensor(rng, s.batch, s.m, s.k)
 	w := randTensor(rng, s.k, s.n)
 
 	if _, err := gpu.MatMul(a, w); err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, 0, err
 	}
-	var got, want *tensai.Tensor
-	gpuTime, cpuTime = time.Hour, time.Hour
+	ga, err := gpu.Upload(a)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	defer ga.Free()
+	gw, err := gpu.Upload(w)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	defer gw.Free()
+
+	var transferGot, residentGot, want *tensai.Tensor
+	residentOp := func() error {
+		out, e := ga.MatMul(gw)
+		if e != nil {
+			return e
+		}
+		defer out.Free()
+		residentGot, e = out.Download()
+		return e
+	}
+	if err := residentOp(); err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	transferTime, residentTime, cpuTime = time.Hour, time.Hour, time.Hour
 	for i := 0; i < reps; i++ {
 		d, err := timeOp(func() error {
 			var e error
-			got, e = gpu.MatMul(a, w)
+			transferGot, e = gpu.MatMul(a, w)
 			return e
 		})
 		if err != nil {
-			return 0, 0, 0, err
+			return 0, 0, 0, 0, err
 		}
-		if d < gpuTime {
-			gpuTime = d
+		if d < transferTime {
+			transferTime = d
+		}
+
+		d, err = timeOp(residentOp)
+		if err != nil {
+			return 0, 0, 0, 0, err
+		}
+		if d < residentTime {
+			residentTime = d
 		}
 
 		d, err = timeOp(func() error {
@@ -137,13 +172,14 @@ func measure(gpu *tensai.GPU, s shape, reps int) (gpuTime, cpuTime time.Duration
 			return e
 		})
 		if err != nil {
-			return 0, 0, 0, err
+			return 0, 0, 0, 0, err
 		}
 		if d < cpuTime {
 			cpuTime = d
 		}
 	}
-	return gpuTime, cpuTime, maxDiff(got, want), nil
+	diff = math.Max(maxDiff(transferGot, want), maxDiff(residentGot, want))
+	return transferTime, residentTime, cpuTime, diff, nil
 }
 
 // mflop counts the multiply-add pairs in one product, in millions.
@@ -152,33 +188,34 @@ func mflop(s shape) float64 {
 }
 
 func sweep(gpu *tensai.GPU, reps int) {
-	fmt.Printf("%-12s %-18s %10s %10s %10s %9s   %s\n",
-		"", "shape", "MFLOP", "gpu", "cpu", "gpu/cpu", "max diff")
+	fmt.Printf("%-12s %-18s %10s %10s %10s %10s %9s   %s\n",
+		"", "shape", "MFLOP", "gpu+xfer", "resident", "cpu", "res/cpu", "max diff")
 	crossed := false
 	for _, s := range ladder {
-		gpuTime, cpuTime, diff, err := measure(gpu, s, reps)
+		transferTime, residentTime, cpuTime, diff, err := measure(gpu, s, reps)
 		if err != nil {
 			fmt.Printf("%-12s %-18s %10s\n", s.label,
 				fmt.Sprintf("%dx%dx%d@%dx%d", s.batch, s.m, s.k, s.k, s.n), "failed: "+err.Error())
 			continue
 		}
-		ratio := float64(cpuTime) / float64(gpuTime)
+		ratio := float64(cpuTime) / float64(residentTime)
 		mark := ""
 		if ratio >= 1 && !crossed {
 			crossed = true
 			mark = "  <- gpu takes the lead here"
 		}
-		fmt.Printf("%-12s %-18s %10.1f %10s %10s %8.2fx   %.1e%s\n",
+		fmt.Printf("%-12s %-18s %10.1f %10s %10s %10s %8.2fx   %.1e%s\n",
 			s.label,
 			fmt.Sprintf("%dx%dx%d@%dx%d", s.batch, s.m, s.k, s.k, s.n),
 			mflop(s),
-			gpuTime.Round(time.Microsecond),
+			transferTime.Round(time.Microsecond),
+			residentTime.Round(time.Microsecond),
 			cpuTime.Round(time.Microsecond),
 			ratio, diff, mark)
 	}
 	if !crossed {
 		fmt.Println("\nthe CPU kernel won every size: this machine's GPU never")
-		fmt.Println("earns back the upload and readback at these shapes")
+		fmt.Println("earns back the dispatch and final readback at these shapes")
 	}
 }
 
@@ -231,23 +268,24 @@ func main() {
 	// (batch, m, k) @ (k, n) -> (batch, m, n) is a single dispatch with one
 	// upload of the weight.
 	s := shape{"", *batch, *m, *k, *n}
-	gpuTime, cpuTime, diff, err := measure(gpu, s, *reps)
+	transferTime, residentTime, cpuTime, diff, err := measure(gpu, s, *reps)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("a[%d %d %d] @ w[%d %d] = out[%d %d %d] (%.1f MFLOP)\n",
 		s.batch, s.m, s.k, s.k, s.n, s.batch, s.m, s.n, mflop(s))
-	fmt.Printf("  gpu: %v\n", gpuTime)
+	fmt.Printf("  gpu + input upload: %v\n", transferTime)
+	fmt.Printf("  gpu, resident inputs: %v\n", residentTime)
 	fmt.Printf("  cpu: %v\n", cpuTime)
 	fmt.Printf("  max |gpu - cpu|: %.2e\n", diff)
 
-	// Every call uploads both operands and reads the product back, so the
-	// GPU only wins once the arithmetic outgrows the transfer. Run -sweep
-	// to see where the two lines cross on this machine.
-	if ratio := float64(cpuTime) / float64(gpuTime); ratio >= 1 {
+	// The resident path still reads the final product back, so the GPU only
+	// wins once the arithmetic outgrows dispatch and readback. Run -sweep to
+	// compare that path with the convenient per-call upload path.
+	if ratio := float64(cpuTime) / float64(residentTime); ratio >= 1 {
 		fmt.Printf("\ngpu is %.2fx faster than the CPU kernel\n", ratio)
 	} else {
-		fmt.Printf("\ngpu is %.2fx slower than the CPU kernel: this product\n"+
-			"is too small to pay for the upload and readback\n", 1/ratio)
+		fmt.Printf("\ngpu with resident inputs is %.2fx slower than the CPU kernel:\n"+
+			"this product is too small to pay for dispatch and final readback\n", 1/ratio)
 	}
 }

--- a/wgpu.go
+++ b/wgpu.go
@@ -39,6 +39,7 @@ type GPU struct {
 	queue      uintptr
 	module     uintptr
 	pipes      gpuPipelines
+	readback   gpuReadbackBuffer
 	name       string
 	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
 	closed     bool
@@ -503,6 +504,7 @@ func (g *GPU) Close() {
 		return
 	}
 	g.closed = true
+	g.releaseReadback()
 	g.releasePipelines()
 	for _, r := range []struct {
 		fn func(uintptr)

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -44,6 +44,7 @@ type GPU struct {
 	queue      uintptr
 	module     uintptr
 	pipes      gpuPipelines
+	readback   gpuReadbackBuffer
 	name       string
 	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
 	closed     bool
@@ -576,6 +577,7 @@ func (g *GPU) Close() {
 		return
 	}
 	g.closed = true
+	g.releaseReadback()
 	g.releasePipelines()
 	for _, r := range []struct {
 		fn func(uintptr)

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -278,6 +278,48 @@ type GPUTensor struct {
 // copyable in (Upload) and out (Download).
 const gpuTensorUsage = wgpuBufferUsageStorage | wgpuBufferUsageCopySrc | wgpuBufferUsageCopyDst
 
+// gpuReadbackBuffer is the reusable MapRead staging buffer. Downloads are
+// serialized by GPU.mu and wgpuMu, and mapRead waits for the copy to finish,
+// so the buffer is idle again before it is returned to this slot.
+type gpuReadbackBuffer struct {
+	buf  uintptr
+	size uint64
+}
+
+// takeReadback returns an unmapped staging buffer at least bytes large. The
+// single retained buffer grows to the largest download seen by this GPU.
+// The caller holds GPU.mu and wgpuMu.
+func (g *GPU) takeReadback(bytes uint64) (uintptr, uint64) {
+	if g.readback.buf != 0 && g.readback.size >= bytes {
+		buf, capacity := g.readback.buf, g.readback.size
+		g.readback = gpuReadbackBuffer{}
+		return buf, capacity
+	}
+	if g.readback.buf != 0 {
+		fnBufferRelease(g.readback.buf)
+		g.readback = gpuReadbackBuffer{}
+	}
+	return g.newBuffer(wgpuBufferUsageMapRead|wgpuBufferUsageCopyDst, bytes), bytes
+}
+
+// putReadback retains a successfully unmapped staging buffer for the next
+// download. The caller holds GPU.mu and wgpuMu.
+func (g *GPU) putReadback(buf uintptr, size uint64) {
+	if g.readback.buf != 0 {
+		fnBufferRelease(g.readback.buf)
+	}
+	g.readback = gpuReadbackBuffer{buf: buf, size: size}
+}
+
+// releaseReadback drops the retained staging buffer during GPU.Close. The
+// caller holds wgpuMu.
+func (g *GPU) releaseReadback() {
+	if g.readback.buf != 0 {
+		fnBufferRelease(g.readback.buf)
+	}
+	g.readback = gpuReadbackBuffer{}
+}
+
 // StorageLimit reports how many bytes a single GPU buffer may hold under
 // the device limits negotiated at OpenGPU time (0 when unknown). Tensor
 // operations return an error instead of touching the driver when a buffer
@@ -337,8 +379,18 @@ func (t *GPUTensor) Download() (*Tensor, error) {
 	}
 	out := NewTensor(t.shape...)
 	bytes := uint64(len(out.Data)) * 4
-	staging := g.newBuffer(wgpuBufferUsageMapRead|wgpuBufferUsageCopyDst, bytes)
-	defer fnBufferRelease(staging)
+	staging, stagingSize := g.takeReadback(bytes)
+	if staging == 0 {
+		return nil, errors.New("tensai: gpu readback buffer allocation failed")
+	}
+	reuse := false
+	defer func() {
+		if reuse {
+			g.putReadback(staging, stagingSize)
+		} else {
+			fnBufferRelease(staging)
+		}
+	}()
 
 	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
 	fnEncoderCopyBuffer(encoder, t.buf, 0, staging, 0, bytes)
@@ -353,6 +405,7 @@ func (t *GPUTensor) Download() (*Tensor, error) {
 	}
 	copy(out.Data, unsafe.Slice((*Float)(src), len(out.Data)))
 	fnBufferUnmap(staging)
+	reuse = true
 	return out, nil
 }
 


### PR DESCRIPTION
`Download` allocated a fresh MapRead staging buffer on every call and released it on the way out, so a chain of small kernels paid a buffer creation and destruction per result. This keeps one per GPU instead: `takeReadback` hands out the retained buffer when it is large enough and allocates a bigger one otherwise, `putReadback` takes it back after a successful unmap, and `Close` drops it. A buffer that failed to map or unmap is released rather than retained, so a broken one never reaches the next download. The retained buffer grows to the largest download a GPU has seen and stays there, which is the point — the steady state allocates nothing.

Resident-input timings from `_example/wgpu -sweep` on a Radeon 780M with wgpu-native v22:

| shape | before | after |
| --- | --- | --- |
| `1x128x128@128x128` | 4.934ms | 383µs |
| `1x100x784@784x128` | 4.091ms | 583µs |
| `1x512x512@512x512` | 10.493ms | 2.115ms |
| `32x512x512@512x512` | 70.903ms | 63.540ms |

Small products were dominated by the allocation and speed up by an order of magnitude; large ones were already compute-bound and gain a few percent. The GPU now overtakes the AVX2 CPU kernel at 4 MFLOP rather than 45. Verified on Windows against both bindings — `-tags wgpu` with v22 and `-tags wgpu24` with v29.0.1.1 — all GPU tests pass.

Note that this PR also carries the already-local commit `e7f33e9` ("wgpu example: benchmark resident inputs"), which had not been pushed yet.

https://claude.ai/code/session_01RNgLhsGwJpDqD2r9kc8VYh
