### PR TITLE
add encoding/safetensors: read and write safetensors checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **Recurrence and attention** - `RNNCell`, `LSTMCell`, and single-head `SelfAttention` built on the autograd engine, with backpropagation through time handled automatically
 - **Serialization** - `Save`/`Load` (and `SaveFile`/`LoadFile`) round-trip trained Sequential parameters as JSON, including BatchNorm running statistics; `SaveParams`/`LoadParams` do the same for autograd parameters (RNN/LSTM/attention cells)
 - **TFLite export** - the `encoding/tflite` package marshals Sequential models (FP32, NHWC) into `.tflite` flatbuffers that run on the TFLite/LiteRT runtimes and [go-tflite](https://github.com/mattn/go-tflite), with the FlatBuffers writer implemented in-tree — still no dependencies
+- **safetensors** - `encoding/safetensors` reads the checkpoint format most published model weights ship in — lazily, one tensor at a time, with F16/BF16/F64 converted to float32 — and writes F32 checkpoints; interoperability is verified against the reference implementation in both directions. Also dependency-free
 
 ## Layout
 
@@ -142,6 +143,20 @@ err := tensaitflite.MarshalFile("model.tflite", model)
 ```
 
 Supported layers: Dense, Conv2D (VALID/SAME padding), MaxPool2D, BatchNorm (folded into Mul+Add), Dropout (dropped), Softmax, and the ReLU/LeakyReLU/Sigmoid/Tanh activations. Exported convolutions follow TFLite's NHWC layout — feed the exported model NHWC input; weight reordering is handled during export. Outputs have been verified to match `Predict` to ~1e-7 relative error on the LiteRT interpreter (see `encoding/tflite/verify_litert.py`). Alias the import when combining with go-tflite, which also names its package `tflite`.
+
+### safetensors checkpoints
+
+`encoding/safetensors` opens the format published model weights usually ship in. Open parses only the header; each `Tensor` call reads just that tensor's bytes, so single tensors come out of multi-gigabyte checkpoints without loading the rest. F32 loads as-is and F16/BF16/F64 convert to tensai's float32:
+
+```go
+import "github.com/mattn/tensai/encoding/safetensors"
+
+f, err := safetensors.Open("model.safetensors")
+defer f.Close()
+w, err := f.Tensor("model.layers.0.attention.wq.weight") // *tensai.Tensor
+```
+
+`Names`, `Info`, and `Metadata` inspect a checkpoint without loading it; `Save`/`SaveFile` write F32 checkpoints that the reference implementation reads back bit-for-bit.
 
 ### Automatic differentiation
 

--- a/encoding/safetensors/safetensors.go
+++ b/encoding/safetensors/safetensors.go
@@ -1,0 +1,310 @@
+// Package safetensors reads and writes the safetensors checkpoint format
+// (https://github.com/huggingface/safetensors) — the plain "8-byte header
+// length, JSON header, raw little-endian buffer" layout most published
+// model weights ship in — with no dependencies beyond the standard
+// library.
+//
+// Reading is lazy: Open parses only the header, and each Tensor call reads
+// just that tensor's bytes, so single tensors can be pulled out of a
+// multi-gigabyte checkpoint without loading the rest. F32 is returned
+// as-is; F16, BF16, and F64 are converted to tensai's float32 on the way
+// out. Save writes F32 tensors, which round-trips everything tensai
+// produces.
+package safetensors
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+
+	tensai "github.com/mattn/tensai"
+)
+
+// maxHeaderSize bounds the JSON header; the reference implementation
+// refuses 100MB and larger.
+const maxHeaderSize = 100 << 20
+
+type entry struct {
+	Dtype       string   `json:"dtype"`
+	Shape       []int    `json:"shape"`
+	DataOffsets [2]int64 `json:"data_offsets"`
+}
+
+// File is an open safetensors checkpoint. It keeps the underlying reader
+// and loads tensor data on demand.
+type File struct {
+	r       io.ReaderAt
+	closer  io.Closer
+	entries map[string]entry
+	names   []string
+	meta    map[string]string
+	dataOff int64 // where the byte buffer starts
+}
+
+// Open opens a safetensors file, parsing its header. Close the returned
+// File when done.
+func Open(path string) (*File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	sf, err := NewFile(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	sf.closer = f
+	return sf, nil
+}
+
+// NewFile parses a safetensors header from r. Tensor data is read from r
+// on demand.
+func NewFile(r io.ReaderAt) (*File, error) {
+	var lenBuf [8]byte
+	if _, err := r.ReadAt(lenBuf[:], 0); err != nil {
+		return nil, fmt.Errorf("safetensors: reading header length: %w", err)
+	}
+	headerLen := binary.LittleEndian.Uint64(lenBuf[:])
+	if headerLen == 0 || headerLen >= maxHeaderSize {
+		return nil, fmt.Errorf("safetensors: implausible header length %d", headerLen)
+	}
+	header := make([]byte, headerLen)
+	if _, err := r.ReadAt(header, 8); err != nil {
+		return nil, fmt.Errorf("safetensors: reading header: %w", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(header, &raw); err != nil {
+		return nil, fmt.Errorf("safetensors: parsing header: %w", err)
+	}
+	f := &File{
+		r:       r,
+		entries: make(map[string]entry, len(raw)),
+		dataOff: int64(8 + headerLen),
+	}
+	for name, msg := range raw {
+		if name == "__metadata__" {
+			if err := json.Unmarshal(msg, &f.meta); err != nil {
+				return nil, fmt.Errorf("safetensors: parsing __metadata__: %w", err)
+			}
+			continue
+		}
+		var e entry
+		if err := json.Unmarshal(msg, &e); err != nil {
+			return nil, fmt.Errorf("safetensors: parsing entry %q: %w", name, err)
+		}
+		if e.DataOffsets[0] < 0 || e.DataOffsets[1] < e.DataOffsets[0] {
+			return nil, fmt.Errorf("safetensors: entry %q has invalid offsets %v", name, e.DataOffsets)
+		}
+		n := 1
+		for _, d := range e.Shape {
+			if d < 0 {
+				return nil, fmt.Errorf("safetensors: entry %q has negative dimension in %v", name, e.Shape)
+			}
+			n *= d
+		}
+		size, err := dtypeSize(e.Dtype)
+		if err == nil && int64(n)*size != e.DataOffsets[1]-e.DataOffsets[0] {
+			return nil, fmt.Errorf("safetensors: entry %q: shape %v does not match %d bytes",
+				name, e.Shape, e.DataOffsets[1]-e.DataOffsets[0])
+		}
+		f.entries[name] = e
+		f.names = append(f.names, name)
+	}
+	sort.Strings(f.names)
+	return f, nil
+}
+
+// Close closes the underlying file when the File came from Open; it is a
+// no-op otherwise.
+func (f *File) Close() error {
+	if f.closer != nil {
+		return f.closer.Close()
+	}
+	return nil
+}
+
+// Names lists the tensor names, sorted.
+func (f *File) Names() []string { return append([]string(nil), f.names...) }
+
+// Metadata returns the free-form __metadata__ strings, or nil.
+func (f *File) Metadata() map[string]string { return f.meta }
+
+// Info reports a tensor's dtype and shape without loading its data.
+func (f *File) Info(name string) (dtype string, shape []int, ok bool) {
+	e, ok := f.entries[name]
+	if !ok {
+		return "", nil, false
+	}
+	return e.Dtype, append([]int(nil), e.Shape...), true
+}
+
+func dtypeSize(dtype string) (int64, error) {
+	switch dtype {
+	case "F32":
+		return 4, nil
+	case "F16", "BF16":
+		return 2, nil
+	case "F64":
+		return 8, nil
+	default:
+		return 0, fmt.Errorf("safetensors: unsupported dtype %q", dtype)
+	}
+}
+
+// Tensor loads one tensor, converting F16, BF16, and F64 to tensai's
+// float32. A safetensors scalar (empty shape) comes back as shape [1].
+func (f *File) Tensor(name string) (*tensai.Tensor, error) {
+	e, ok := f.entries[name]
+	if !ok {
+		return nil, fmt.Errorf("safetensors: no tensor %q", name)
+	}
+	if _, err := dtypeSize(e.Dtype); err != nil {
+		return nil, fmt.Errorf("%w (tensor %q)", err, name)
+	}
+	buf := make([]byte, e.DataOffsets[1]-e.DataOffsets[0])
+	if _, err := f.r.ReadAt(buf, f.dataOff+e.DataOffsets[0]); err != nil {
+		return nil, fmt.Errorf("safetensors: reading tensor %q: %w", name, err)
+	}
+	shape := e.Shape
+	if len(shape) == 0 {
+		shape = []int{1}
+	}
+	out := tensai.NewTensor(shape...)
+	switch e.Dtype {
+	case "F32":
+		for i := range out.Data {
+			out.Data[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:]))
+		}
+	case "F16":
+		for i := range out.Data {
+			out.Data[i] = f16to32(binary.LittleEndian.Uint16(buf[i*2:]))
+		}
+	case "BF16":
+		for i := range out.Data {
+			out.Data[i] = math.Float32frombits(uint32(binary.LittleEndian.Uint16(buf[i*2:])) << 16)
+		}
+	case "F64":
+		for i := range out.Data {
+			out.Data[i] = float32(math.Float64frombits(binary.LittleEndian.Uint64(buf[i*8:])))
+		}
+	}
+	return out, nil
+}
+
+// f16to32 widens an IEEE 754 binary16 value, including subnormals,
+// infinities, and NaNs.
+func f16to32(h uint16) float32 {
+	sign := uint32(h>>15) << 31
+	exp := uint32(h>>10) & 0x1f
+	frac := uint32(h) & 0x3ff
+	switch exp {
+	case 0:
+		if frac == 0 {
+			return math.Float32frombits(sign) // signed zero
+		}
+		// Subnormal: normalize into the f32 exponent range.
+		e := uint32(127 - 15 + 1)
+		for frac&0x400 == 0 {
+			frac <<= 1
+			e--
+		}
+		return math.Float32frombits(sign | e<<23 | (frac&0x3ff)<<13)
+	case 0x1f:
+		return math.Float32frombits(sign | 0xff<<23 | frac<<13) // inf / NaN
+	default:
+		return math.Float32frombits(sign | (exp+127-15)<<23 | frac<<13)
+	}
+}
+
+// Save writes tensors as an F32 safetensors checkpoint, names sorted, with
+// optional __metadata__ strings.
+func Save(w io.Writer, tensors map[string]*tensai.Tensor, meta map[string]string) error {
+	names := make([]string, 0, len(tensors))
+	for name := range tensors {
+		if name == "__metadata__" {
+			return fmt.Errorf("safetensors: %q is a reserved name", name)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Build the JSON header by hand to keep the key order deterministic.
+	header := []byte{'{'}
+	if len(meta) > 0 {
+		m, err := json.Marshal(meta)
+		if err != nil {
+			return err
+		}
+		header = append(header, `"__metadata__":`...)
+		header = append(header, m...)
+		if len(names) > 0 {
+			header = append(header, ',')
+		}
+	}
+	var off int64
+	for i, name := range names {
+		t := tensors[name]
+		if err := t.Validate(); err != nil {
+			return fmt.Errorf("safetensors: tensor %q: %w", name, err)
+		}
+		end := off + int64(len(t.Data))*4
+		e, err := json.Marshal(entry{Dtype: "F32", Shape: t.Shape, DataOffsets: [2]int64{off, end}})
+		if err != nil {
+			return err
+		}
+		n, err := json.Marshal(name)
+		if err != nil {
+			return err
+		}
+		header = append(header, n...)
+		header = append(header, ':')
+		header = append(header, e...)
+		if i < len(names)-1 {
+			header = append(header, ',')
+		}
+		off = end
+	}
+	header = append(header, '}')
+	// Pad with spaces so the byte buffer starts 8-aligned, as the
+	// reference implementation does.
+	for (8+len(header))%8 != 0 {
+		header = append(header, ' ')
+	}
+
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(header)))
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	buf := make([]byte, 0, 1<<16)
+	for _, name := range names {
+		buf = buf[:0]
+		for _, v := range tensors[name].Data {
+			buf = binary.LittleEndian.AppendUint32(buf, math.Float32bits(v))
+		}
+		if _, err := w.Write(buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SaveFile writes tensors to path via Save.
+func SaveFile(path string, tensors map[string]*tensai.Tensor, meta map[string]string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := Save(f, tensors, meta); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/encoding/safetensors/safetensors_test.go
+++ b/encoding/safetensors/safetensors_test.go
@@ -1,0 +1,178 @@
+package safetensors
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	tensai "github.com/mattn/tensai"
+)
+
+func TestRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	tensors := map[string]*tensai.Tensor{}
+	for _, c := range []struct {
+		name  string
+		shape []int
+	}{
+		{"model.embed", []int{7, 5}},
+		{"model.layers.0.weight", []int{5, 5}},
+		{"bias", []int{5}},
+	} {
+		x := tensai.NewTensor(c.shape...)
+		for i := range x.Data {
+			x.Data[i] = float32(rng.NormFloat64())
+		}
+		tensors[c.name] = x
+	}
+	path := filepath.Join(t.TempDir(), "model.safetensors")
+	meta := map[string]string{"format": "pt", "producer": "tensai"}
+	if err := SaveFile(path, tensors, meta); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	f, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if got := f.Names(); len(got) != 3 || got[0] != "bias" || got[1] != "model.embed" {
+		t.Fatalf("names: %v", got)
+	}
+	if f.Metadata()["producer"] != "tensai" {
+		t.Fatalf("metadata: %v", f.Metadata())
+	}
+	dtype, shape, ok := f.Info("model.embed")
+	if !ok || dtype != "F32" || len(shape) != 2 || shape[0] != 7 {
+		t.Fatalf("info: %v %v %v", dtype, shape, ok)
+	}
+	for name, want := range tensors {
+		got, err := f.Tensor(name)
+		if err != nil {
+			t.Fatalf("tensor %q: %v", name, err)
+		}
+		if len(got.Data) != len(want.Data) {
+			t.Fatalf("tensor %q: length %d != %d", name, len(got.Data), len(want.Data))
+		}
+		for i := range want.Data {
+			if got.Data[i] != want.Data[i] {
+				t.Fatalf("tensor %q element %d: %v != %v", name, i, got.Data[i], want.Data[i])
+			}
+		}
+	}
+	if _, err := f.Tensor("missing"); err == nil {
+		t.Fatal("expected error for missing tensor")
+	}
+}
+
+// build assembles a raw safetensors file from a header object and buffer.
+func build(t *testing.T, header map[string]any, data []byte) []byte {
+	t.Helper()
+	h, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]byte, 8)
+	binary.LittleEndian.PutUint64(out, uint64(len(h)))
+	out = append(out, h...)
+	return append(out, data...)
+}
+
+func TestDtypeConversions(t *testing.T) {
+	// F16: 1.0, -2.5, smallest subnormal (~5.96e-8), +inf.
+	f16 := []uint16{0x3c00, 0xc100, 0x0001, 0x7c00}
+	// BF16: 1.0, -3.140625 (0xc049).
+	bf16 := []uint16{0x3f80, 0xc049}
+	// F64: pi.
+	f64 := []uint64{math.Float64bits(math.Pi)}
+
+	var buf []byte
+	for _, v := range f16 {
+		buf = binary.LittleEndian.AppendUint16(buf, v)
+	}
+	for _, v := range bf16 {
+		buf = binary.LittleEndian.AppendUint16(buf, v)
+	}
+	for _, v := range f64 {
+		buf = binary.LittleEndian.AppendUint64(buf, v)
+	}
+	raw := build(t, map[string]any{
+		"h": map[string]any{"dtype": "F16", "shape": []int{4}, "data_offsets": []int{0, 8}},
+		"b": map[string]any{"dtype": "BF16", "shape": []int{2}, "data_offsets": []int{8, 12}},
+		"d": map[string]any{"dtype": "F64", "shape": []int{}, "data_offsets": []int{12, 20}},
+	}, buf)
+
+	f, err := NewFile(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	h, err := f.Tensor("h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Data[0] != 1 || h.Data[1] != -2.5 {
+		t.Fatalf("f16: %v", h.Data)
+	}
+	if diff := math.Abs(float64(h.Data[2]) - 5.960464477539063e-8); diff > 1e-15 {
+		t.Fatalf("f16 subnormal: %v", h.Data[2])
+	}
+	if !math.IsInf(float64(h.Data[3]), 1) {
+		t.Fatalf("f16 inf: %v", h.Data[3])
+	}
+	b, err := f.Tensor("b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Data[0] != 1 || b.Data[1] != -3.140625 {
+		t.Fatalf("bf16: %v", b.Data)
+	}
+	d, err := f.Tensor("d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Data) != 1 || math.Abs(float64(d.Data[0])-math.Pi) > 1e-7 {
+		t.Fatalf("f64 scalar: %v", d.Data)
+	}
+}
+
+func TestHeaderErrors(t *testing.T) {
+	if _, err := NewFile(bytes.NewReader([]byte{1, 2, 3})); err == nil {
+		t.Fatal("expected error for truncated file")
+	}
+	huge := make([]byte, 8)
+	binary.LittleEndian.PutUint64(huge, 1<<40)
+	if _, err := NewFile(bytes.NewReader(huge)); err == nil {
+		t.Fatal("expected error for implausible header length")
+	}
+	if _, err := NewFile(bytes.NewReader(build(t, map[string]any{
+		"x": map[string]any{"dtype": "F32", "shape": []int{3}, "data_offsets": []int{0, 8}},
+	}, make([]byte, 8)))); err == nil {
+		t.Fatal("expected error for shape/bytes mismatch")
+	}
+
+	// Unsupported dtypes parse but refuse to load.
+	f, err := NewFile(bytes.NewReader(build(t, map[string]any{
+		"q": map[string]any{"dtype": "I8", "shape": []int{4}, "data_offsets": []int{0, 4}},
+	}, make([]byte, 4))))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := f.Tensor("q"); err == nil {
+		t.Fatal("expected unsupported dtype error")
+	}
+
+	// Truncated data surfaces as a read error, not garbage.
+	f, err = NewFile(bytes.NewReader(build(t, map[string]any{
+		"x": map[string]any{"dtype": "F32", "shape": []int{4}, "data_offsets": []int{0, 16}},
+	}, make([]byte, 8))))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := f.Tensor("x"); err == nil {
+		t.Fatal("expected error for truncated tensor data")
+	}
+}


### PR DESCRIPTION
Adds `encoding/safetensors`, a dependency-free reader and writer for the checkpoint format published model weights usually ship in. Open parses only the JSON header and each `Tensor` call reads just that tensor's bytes, so single tensors come out of multi-gigabyte checkpoints without loading the rest; F32 loads as-is and F16/BF16/F64 convert to tensai's float32. `Save` writes F32 checkpoints with a deterministic sorted header. Interop is verified against the reference Python implementation in both directions — files written by `safetensors.numpy` load with matching values, and tensai-written files load back equal in Python — alongside unit tests for the round trip, bit-level dtype conversions, and malformed input.