### PR TITLE
examples: add gpt2, running the published 124M checkpoint in pure Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _example/dataset/dataset
 /.agents/
 /.codex/
 _example/mnist/data/
+_example/gpt2/data/
 /charrnn.json
 /graph.png
 /graph.svg

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ _example/plasma     Demoscene-style terminal plasma rendered by a neural network
 _example/dot        Graphviz DOT export of the z = x + y graph
 _example/tensor     Tour of the n-d Tensor: broadcasting, batched MatMul, attention
 _example/wgpu       WebGPU MatMul: adapter info, CPU cross-check, GPU vs CPU sweep
+_example/gpt2       The published GPT-2 (124M) checkpoint generating text in pure Go
 ```
 
 ## Usage
@@ -157,6 +158,15 @@ w, err := f.Tensor("model.layers.0.attention.wq.weight") // *tensai.Tensor
 ```
 
 `Names`, `Info`, and `Metadata` inspect a checkpoint without loading it; `Save`/`SaveFile` write F32 checkpoints that the reference implementation reads back bit-for-bit.
+
+`_example/gpt2` puts the reader to work on a real model: it downloads the published GPT-2 small (124M) checkpoint from Hugging Face, loads the weights through this package, tokenizes with a from-scratch byte-level BPE, and decodes with a KV cache — every matvec running on the same `Dot` kernel as the rest of tensai, at ~30 tok/s with the AVX2 build:
+
+```
+$ GOEXPERIMENT=simd go run ./_example/gpt2 -n 20
+Hello, I'm a language model, not a programming language. I'm a language model. ...
+```
+
+The greedy continuation matches GPT-2's well-known reference output token for token, which pins the whole pipeline — reader, tokenizer, and forward pass — in one check.
 
 ### Automatic differentiation
 
@@ -331,6 +341,7 @@ go run ./_example/iris
 go run ./_example/charrnn
 go run ./_example/plasma
 go run ./_example/tensor
+GOEXPERIMENT=simd go run ./_example/gpt2   # downloads the GPT-2 checkpoint (~550MB) on first run
 go run -tags wgpu ./_example/wgpu          # needs wgpu-native, see above
 go run -tags wgpu ./_example/wgpu -sweep  # GPU vs CPU across sizes
 go test ./...

--- a/_example/gpt2/main.go
+++ b/_example/gpt2/main.go
@@ -1,0 +1,160 @@
+// Command gpt2 runs the real, published GPT-2 small (124M) checkpoint in
+// pure Go: the weights load through tensai's encoding/safetensors reader,
+// the byte-level BPE tokenizer is implemented from vocab.json and
+// merges.txt, and every matvec in the transformer runs on tensai's Dot
+// kernel — build with GOEXPERIMENT=simd for the AVX2 version.
+//
+// On first run it downloads the checkpoint (~550MB), vocabulary, and
+// merges from Hugging Face into -data. Then:
+//
+//	GOEXPERIMENT=simd go run ./_example/gpt2 -prompt "The meaning of life is" -n 40
+//
+// -temp 0 (the default) decodes greedily and deterministically; a positive
+// temperature samples.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+const hfBase = "https://huggingface.co/openai-community/gpt2/resolve/main/"
+
+func fetch(dir, name string) (string, error) {
+	path := filepath.Join(dir, name)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "downloading %s...\n", name)
+	resp, err := http.Get(hfBase + name)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("downloading %s: %s", name, resp.Status)
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return path, os.Rename(tmp, path)
+}
+
+// sample picks the next token: argmax at temperature 0, otherwise a draw
+// from the tempered distribution.
+func sample(logits []float32, temp float64, rng *rand.Rand) int {
+	if temp <= 0 {
+		best := 0
+		for i, v := range logits {
+			if v > logits[best] {
+				best = i
+			}
+		}
+		return best
+	}
+	type cand struct {
+		id int
+		p  float64
+	}
+	cands := make([]cand, len(logits))
+	var maxl float32 = logits[0]
+	for _, v := range logits {
+		if v > maxl {
+			maxl = v
+		}
+	}
+	var sum float64
+	for i, v := range logits {
+		p := math.Exp(float64(v-maxl) / temp)
+		cands[i] = cand{i, p}
+		sum += p
+	}
+	sort.Slice(cands, func(a, b int) bool { return cands[a].p > cands[b].p })
+	r := rng.Float64() * sum
+	for _, c := range cands {
+		r -= c.p
+		if r <= 0 {
+			return c.id
+		}
+	}
+	return cands[0].id
+}
+
+func main() {
+	dataDir := flag.String("data", "_example/gpt2/data", "directory for the downloaded model files")
+	prompt := flag.String("prompt", "Hello, I'm a language model,", "prompt text")
+	n := flag.Int("n", 40, "tokens to generate")
+	temp := flag.Float64("temp", 0, "sampling temperature; 0 = greedy")
+	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
+	flag.Parse()
+
+	var paths [3]string
+	for i, name := range []string{"model.safetensors", "vocab.json", "merges.txt"} {
+		p, err := fetch(*dataDir, name)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		paths[i] = p
+	}
+
+	tok, err := newTokenizer(paths[1], paths[2])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	start := time.Now()
+	model, err := loadModel(paths[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "loaded gpt2 (124M) in %v\n", time.Since(start).Round(time.Millisecond))
+
+	ids := tok.Encode(*prompt)
+	if len(ids) == 0 || len(ids) >= nCtx {
+		fmt.Fprintf(os.Stderr, "prompt must be 1..%d tokens, got %d\n", nCtx-1, len(ids))
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "prompt tokens: %v\n", ids)
+	rng := rand.New(rand.NewSource(*seed))
+
+	fmt.Print(*prompt)
+	start = time.Now()
+	var logits []float32
+	for pos, id := range ids {
+		logits = model.step(id, pos)
+	}
+	steps := len(ids)
+	for i := 0; i < *n && steps < nCtx; i++ {
+		next := sample(logits, *temp, rng)
+		fmt.Print(tok.Decode([]int{next}))
+		logits = model.step(next, steps)
+		steps++
+	}
+	fmt.Println()
+	fmt.Fprintf(os.Stderr, "%d tokens in %v (%.1f tok/s)\n",
+		steps, time.Since(start).Round(time.Millisecond),
+		float64(steps)/time.Since(start).Seconds())
+}

--- a/_example/gpt2/model.go
+++ b/_example/gpt2/model.go
@@ -1,0 +1,217 @@
+package main
+
+// GPT-2 small (124M) inference: 12 pre-norm transformer blocks with a KV
+// cache, decoded one token at a time. The heavy lifting — every matvec
+// against the checkpoint weights — runs on tensai's Dot kernel, so the
+// same AVX2 path that trains the MNIST examples now drives a real
+// published model.
+
+import (
+	"fmt"
+	"math"
+
+	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/encoding/safetensors"
+)
+
+const (
+	nLayer = 12
+	nHead  = 12
+	nEmbd  = 768
+	nCtx   = 1024
+	headSz = nEmbd / nHead
+	lnEps  = 1e-5
+)
+
+type block struct {
+	ln1w, ln1b, ln2w, ln2b []float32
+	attnW, projW           *tensai.Matrix // [768,2304], [768,768]
+	fcW, fc2W              *tensai.Matrix // [768,3072], [3072,768]
+	attnB, projB           []float32
+	fcB, fc2B              []float32
+	kc, vc                 [][]float32 // KV cache, one [768] per position
+}
+
+type gpt2 struct {
+	wte, wpe   *tensai.Tensor // [50257,768], [1024,768]
+	wteT       *tensai.Matrix // [768,50257], for the tied lm head
+	lnfW, lnfB []float32
+	blocks     [nLayer]block
+	vocab      int
+}
+
+func loadModel(path string) (*gpt2, error) {
+	f, err := safetensors.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	vec := func(name string) []float32 {
+		t, err := f.Tensor(name)
+		if err != nil {
+			panic(err)
+		}
+		return t.Data
+	}
+	mat := func(name string) *tensai.Matrix {
+		t, err := f.Tensor(name)
+		if err != nil {
+			panic(err)
+		}
+		m, err := t.Matrix()
+		if err != nil {
+			panic(err)
+		}
+		return m
+	}
+
+	m := &gpt2{}
+	m.wte, err = f.Tensor("wte.weight")
+	if err != nil {
+		return nil, err
+	}
+	m.wpe, err = f.Tensor("wpe.weight")
+	if err != nil {
+		return nil, err
+	}
+	m.vocab = m.wte.Shape[0]
+	wteM, err := m.wte.Matrix()
+	if err != nil {
+		return nil, err
+	}
+	m.wteT = wteM.T() // one-time transpose for x @ wte^T
+	m.lnfW, m.lnfB = vec("ln_f.weight"), vec("ln_f.bias")
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		p := fmt.Sprintf("h.%d.", i)
+		b.ln1w, b.ln1b = vec(p+"ln_1.weight"), vec(p+"ln_1.bias")
+		b.ln2w, b.ln2b = vec(p+"ln_2.weight"), vec(p+"ln_2.bias")
+		b.attnW, b.attnB = mat(p+"attn.c_attn.weight"), vec(p+"attn.c_attn.bias")
+		b.projW, b.projB = mat(p+"attn.c_proj.weight"), vec(p+"attn.c_proj.bias")
+		b.fcW, b.fcB = mat(p+"mlp.c_fc.weight"), vec(p+"mlp.c_fc.bias")
+		b.fc2W, b.fc2B = mat(p+"mlp.c_proj.weight"), vec(p+"mlp.c_proj.bias")
+	}
+	return m, nil
+}
+
+func layernorm(x, w, b []float32) []float32 {
+	var mean float64
+	for _, v := range x {
+		mean += float64(v)
+	}
+	mean /= float64(len(x))
+	var variance float64
+	for _, v := range x {
+		d := float64(v) - mean
+		variance += d * d
+	}
+	variance /= float64(len(x))
+	inv := 1 / math.Sqrt(variance+lnEps)
+	out := make([]float32, len(x))
+	for i, v := range x {
+		out[i] = float32((float64(v)-mean)*inv)*w[i] + b[i]
+	}
+	return out
+}
+
+// matvec computes x @ W (+ b when given) on tensai's Dot kernel.
+func matvec(x []float32, w *tensai.Matrix, b []float32) []float32 {
+	xm := &tensai.Matrix{Rows: 1, Cols: len(x), Data: x}
+	out, err := tensai.Dot(xm, w)
+	if err != nil {
+		panic(err)
+	}
+	if b != nil {
+		for i := range out.Data {
+			out.Data[i] += b[i]
+		}
+	}
+	return out.Data
+}
+
+// geluNew is the tanh approximation GPT-2 was trained with.
+func geluNew(x []float32) {
+	for i, v := range x {
+		f := float64(v)
+		x[i] = float32(0.5 * f * (1 + math.Tanh(0.7978845608028654*(f+0.044715*f*f*f))))
+	}
+}
+
+// step feeds one token at position pos through the model and returns the
+// logits for the next token.
+func (m *gpt2) step(token, pos int) []float32 {
+	x := make([]float32, nEmbd)
+	for i := range x {
+		x[i] = m.wte.Data[token*nEmbd+i] + m.wpe.Data[pos*nEmbd+i]
+	}
+
+	for li := range m.blocks {
+		b := &m.blocks[li]
+
+		// Attention with the KV cache: the single query row attends over
+		// every cached position, so causality holds by construction.
+		qkv := matvec(layernorm(x, b.ln1w, b.ln1b), b.attnW, b.attnB)
+		k := make([]float32, nEmbd)
+		v := make([]float32, nEmbd)
+		copy(k, qkv[nEmbd:2*nEmbd])
+		copy(v, qkv[2*nEmbd:])
+		b.kc = append(b.kc, k)
+		b.vc = append(b.vc, v)
+		q := qkv[:nEmbd]
+
+		attn := make([]float32, nEmbd)
+		steps := len(b.kc)
+		scores := make([]float64, steps)
+		for h := 0; h < nHead; h++ {
+			off := h * headSz
+			var maxs float64 = math.Inf(-1)
+			for t := 0; t < steps; t++ {
+				var s float64
+				kt := b.kc[t]
+				for i := 0; i < headSz; i++ {
+					s += float64(q[off+i]) * float64(kt[off+i])
+				}
+				s /= 8 // sqrt(headSz)
+				scores[t] = s
+				if s > maxs {
+					maxs = s
+				}
+			}
+			var sum float64
+			for t := 0; t < steps; t++ {
+				scores[t] = math.Exp(scores[t] - maxs)
+				sum += scores[t]
+			}
+			for t := 0; t < steps; t++ {
+				p := float32(scores[t] / sum)
+				vt := b.vc[t]
+				for i := 0; i < headSz; i++ {
+					attn[off+i] += p * vt[off+i]
+				}
+			}
+		}
+		proj := matvec(attn, b.projW, b.projB)
+		for i := range x {
+			x[i] += proj[i]
+		}
+
+		// MLP.
+		h := matvec(layernorm(x, b.ln2w, b.ln2b), b.fcW, b.fcB)
+		geluNew(h)
+		out := matvec(h, b.fc2W, b.fc2B)
+		for i := range x {
+			x[i] += out[i]
+		}
+	}
+
+	return matvec(layernorm(x, m.lnfW, m.lnfB), m.wteT, nil)
+}
+
+// reset clears the KV cache for a fresh sequence.
+func (m *gpt2) reset() {
+	for i := range m.blocks {
+		m.blocks[i].kc = nil
+		m.blocks[i].vc = nil
+	}
+}

--- a/_example/gpt2/tokenizer.go
+++ b/_example/gpt2/tokenizer.go
@@ -1,0 +1,207 @@
+package main
+
+// The GPT-2 byte-level BPE tokenizer, from vocab.json and merges.txt: bytes
+// are mapped to printable unicode stand-ins, pre-tokenized with the GPT-2
+// splitting rules, and merged greedily by rank.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+)
+
+type tokenizer struct {
+	vocab    map[string]int
+	inverse  map[int]string
+	ranks    map[[2]string]int
+	byteEnc  [256]rune
+	byteDec  map[rune]byte
+	wordSeen map[string][]int // per-word BPE cache
+}
+
+func newTokenizer(vocabPath, mergesPath string) (*tokenizer, error) {
+	t := &tokenizer{
+		vocab:    map[string]int{},
+		inverse:  map[int]string{},
+		ranks:    map[[2]string]int{},
+		byteDec:  map[rune]byte{},
+		wordSeen: map[string][]int{},
+	}
+
+	raw, err := os.ReadFile(vocabPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(raw, &t.vocab); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", vocabPath, err)
+	}
+	for s, id := range t.vocab {
+		t.inverse[id] = s
+	}
+
+	f, err := os.Open(mergesPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	rank := 0
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" || strings.HasPrefix(line, "#version") {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		t.ranks[[2]string{parts[0], parts[1]}] = rank
+		rank++
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	// bytes_to_unicode: printable bytes map to themselves, the rest to
+	// 256 and up, so every byte has a visible stand-in character.
+	n := 0
+	for b := 0; b < 256; b++ {
+		if (b >= '!' && b <= '~') || (b >= 0xa1 && b <= 0xac) || (b >= 0xae && b <= 0xff) {
+			t.byteEnc[b] = rune(b)
+		} else {
+			t.byteEnc[b] = rune(256 + n)
+			n++
+		}
+		t.byteDec[t.byteEnc[b]] = byte(b)
+	}
+	return t, nil
+}
+
+// preTokenize reproduces the GPT-2 splitting regex
+// 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
+// which Go's regexp cannot express because of the lookahead.
+func preTokenize(s string) []string {
+	rs := []rune(s)
+	var out []string
+	i := 0
+	for i < len(rs) {
+		// Contractions.
+		if rs[i] == '\'' {
+			rest := string(rs[i:])
+			matched := false
+			for _, c := range []string{"'s", "'t", "'re", "'ve", "'m", "'ll", "'d"} {
+				if strings.HasPrefix(rest, c) {
+					out = append(out, c)
+					i += len([]rune(c))
+					matched = true
+					break
+				}
+			}
+			if matched {
+				continue
+			}
+		}
+		start := i
+		j := i
+		if rs[j] == ' ' && j+1 < len(rs) && !unicode.IsSpace(rs[j+1]) {
+			j++ // the optional leading space of the next class
+		}
+		switch {
+		case j < len(rs) && unicode.IsLetter(rs[j]):
+			for j < len(rs) && unicode.IsLetter(rs[j]) {
+				j++
+			}
+			out = append(out, string(rs[start:j]))
+		case j < len(rs) && unicode.IsNumber(rs[j]):
+			for j < len(rs) && unicode.IsNumber(rs[j]) {
+				j++
+			}
+			out = append(out, string(rs[start:j]))
+		case j < len(rs) && !unicode.IsSpace(rs[j]):
+			for j < len(rs) && !unicode.IsSpace(rs[j]) && !unicode.IsLetter(rs[j]) && !unicode.IsNumber(rs[j]) && rs[j] != '\'' {
+				j++
+			}
+			if j == start || (j == start+1 && rs[start] == ' ') {
+				// An apostrophe that did not start a contraction.
+				j++
+			}
+			out = append(out, string(rs[start:j]))
+		default:
+			// Whitespace run. \s+(?!\S) keeps the last whitespace char
+			// for the following token when something follows.
+			for j < len(rs) && unicode.IsSpace(rs[j]) {
+				j++
+			}
+			if j < len(rs) && j-start > 1 {
+				j--
+			}
+			if j > start {
+				out = append(out, string(rs[start:j]))
+			} else {
+				j++ // lone space directly before another space-led class
+				out = append(out, string(rs[start:j]))
+			}
+		}
+		i = j
+	}
+	return out
+}
+
+// bpe merges one pre-token's stand-in characters by rank.
+func (t *tokenizer) bpe(word string) []int {
+	if ids, ok := t.wordSeen[word]; ok {
+		return ids
+	}
+	parts := make([]string, 0, len(word))
+	for _, r := range word {
+		parts = append(parts, string(r))
+	}
+	for len(parts) > 1 {
+		best, bestRank := -1, int(^uint(0)>>1)
+		for i := 0; i < len(parts)-1; i++ {
+			if r, ok := t.ranks[[2]string{parts[i], parts[i+1]}]; ok && r < bestRank {
+				best, bestRank = i, r
+			}
+		}
+		if best < 0 {
+			break
+		}
+		merged := parts[best] + parts[best+1]
+		parts = append(parts[:best], append([]string{merged}, parts[best+2:]...)...)
+	}
+	ids := make([]int, 0, len(parts))
+	for _, p := range parts {
+		if id, ok := t.vocab[p]; ok {
+			ids = append(ids, id)
+		}
+	}
+	t.wordSeen[word] = ids
+	return ids
+}
+
+// Encode turns text into GPT-2 token ids.
+func (t *tokenizer) Encode(s string) []int {
+	var ids []int
+	for _, word := range preTokenize(s) {
+		var sb strings.Builder
+		for _, b := range []byte(word) {
+			sb.WriteRune(t.byteEnc[b])
+		}
+		ids = append(ids, t.bpe(sb.String())...)
+	}
+	return ids
+}
+
+// Decode turns token ids back into text.
+func (t *tokenizer) Decode(ids []int) string {
+	var bs []byte
+	for _, id := range ids {
+		for _, r := range t.inverse[id] {
+			bs = append(bs, t.byteDec[r])
+		}
+	}
+	return string(bs)
+}


### PR DESCRIPTION
Puts the safetensors reader to work on a real model: `_example/gpt2` downloads the published GPT-2 small (124M) checkpoint from Hugging Face, loads it through `encoding/safetensors`, tokenizes with a from-scratch byte-level BPE, and generates with a KV cache — every matvec on tensai's Dot kernel, ~30 tok/s with the AVX2 build, zero dependencies. The greedy continuation of "Hello, I'm a language model," matches GPT-2's well-known reference output token for token, pinning the reader, tokenizer, and forward pass in one check.