### PR TITLE
add causal attention, and run the gpt2 prompt prefill on the GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Hello, I'm a language model, not a programming language. I'm a language model. .
 
 The greedy continuation matches GPT-2's well-known reference output token for token, which pins the whole pipeline — reader, tokenizer, and forward pass — in one check.
 
+The prompt runs through the model as one batched pass; with `-gpu` (built with `-tags wgpu` or `wgpu24`) every block's causal multi-head attention becomes a single masked dispatch on the GPU. A 600-token prompt prefills 1.5x faster even through dozen inside WSL2; native drivers gain more.
+
 ### Automatic differentiation
 
 When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients:
@@ -266,7 +268,7 @@ out, _ := gq.Attention(gk, gv)                 // softmax(q@k^T/sqrt(d))@v, no h
 out, _ = gq.MultiHeadAttention(gk, gv, heads)  // packed (batch, seq, heads*dh) layout
 ```
 
-Multi-head attention carves each head out of the packed layout with strided kernels — the matmul kernels take explicit row strides and per-batch offsets — so no permute is ever materialized.
+Multi-head attention carves each head out of the packed layout with strided kernels — the matmul kernels take explicit row strides and per-batch offsets — so no permute is ever materialized. The causal variants (`CausalAttention`, `CausalMultiHeadAttention`) mask future positions inside the softmax kernel itself, with k and v allowed to hold more positions than q — the prompt-prefill and chunked-decode patterns of autoregressive models — so no mask tensor is ever built either.
 
 There is no cgo involved: the bindings load the [wgpu-native](https://github.com/gfx-rs/wgpu-native) shared library at runtime via `ebitengine/purego` (`dlopen` on linux/macOS, `LoadLibrary` on Windows). Download a **v22.1.0.5** release binary (the C API these bindings target), then either install it where the loader finds it or point `TENSAI_WGPU_LIB` at it:
 

--- a/_example/gpt2/main.go
+++ b/_example/gpt2/main.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	tensai "github.com/mattn/tensai"
 )
 
 const hfBase = "https://huggingface.co/openai-community/gpt2/resolve/main/"
@@ -107,7 +109,20 @@ func main() {
 	n := flag.Int("n", 40, "tokens to generate")
 	temp := flag.Float64("temp", 0, "sampling temperature; 0 = greedy")
 	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
+	useGPU := flag.Bool("gpu", false, "run prompt-prefill attention on the GPU (build with -tags wgpu or wgpu24)")
 	flag.Parse()
+
+	var gpu *tensai.GPU
+	if *useGPU {
+		g, err := tensai.OpenGPU()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gpu unavailable, using cpu: %v\n", err)
+		} else {
+			defer g.Close()
+			fmt.Fprintf(os.Stderr, "gpu: %s\n", g.Name())
+			gpu = g
+		}
+	}
 
 	var paths [3]string
 	for i, name := range []string{"model.safetensors", "vocab.json", "merges.txt"} {
@@ -142,10 +157,8 @@ func main() {
 
 	fmt.Print(*prompt)
 	start = time.Now()
-	var logits []float32
-	for pos, id := range ids {
-		logits = model.step(id, pos)
-	}
+	logits := model.prefill(ids, gpu)
+	fmt.Fprintf(os.Stderr, "prefill: %d tokens in %v\n", len(ids), time.Since(start).Round(time.Millisecond))
 	steps := len(ids)
 	for i := 0; i < *n && steps < nCtx; i++ {
 		next := sample(logits, *temp, rng)

--- a/_example/gpt2/model.go
+++ b/_example/gpt2/model.go
@@ -215,3 +215,151 @@ func (m *gpt2) reset() {
 		m.blocks[i].vc = nil
 	}
 }
+
+func layernormRows(x *tensai.Matrix, w, b []float32) *tensai.Matrix {
+	out := tensai.NewMatrix(x.Rows, x.Cols)
+	for r := 0; r < x.Rows; r++ {
+		copy(out.Data[r*x.Cols:(r+1)*x.Cols], layernorm(x.Data[r*x.Cols:(r+1)*x.Cols], w, b))
+	}
+	return out
+}
+
+func addBiasRows(x *tensai.Matrix, b []float32) {
+	for r := 0; r < x.Rows; r++ {
+		row := x.Data[r*x.Cols : (r+1)*x.Cols]
+		for i := range row {
+			row[i] += b[i]
+		}
+	}
+}
+
+func addInPlace(x, y *tensai.Matrix) {
+	for i := range x.Data {
+		x.Data[i] += y.Data[i]
+	}
+}
+
+func matmul(a, w *tensai.Matrix, bias []float32) *tensai.Matrix {
+	out, err := tensai.Dot(a, w)
+	if err != nil {
+		panic(err)
+	}
+	if bias != nil {
+		addBiasRows(out, bias)
+	}
+	return out
+}
+
+// cpuCausalMHA is multi-head causal attention over full (T, 768) q/k/v
+// matrices, the CPU half of the prefill.
+func cpuCausalMHA(q, k, v *tensai.Matrix) *tensai.Matrix {
+	T := q.Rows
+	out := tensai.NewMatrix(T, nEmbd)
+	scores := make([]float64, T)
+	for h := 0; h < nHead; h++ {
+		off := h * headSz
+		for i := 0; i < T; i++ {
+			maxs := math.Inf(-1)
+			for j := 0; j <= i; j++ {
+				var s float64
+				for c := 0; c < headSz; c++ {
+					s += float64(q.Data[i*nEmbd+off+c]) * float64(k.Data[j*nEmbd+off+c])
+				}
+				s /= 8
+				scores[j] = s
+				if s > maxs {
+					maxs = s
+				}
+			}
+			var sum float64
+			for j := 0; j <= i; j++ {
+				scores[j] = math.Exp(scores[j] - maxs)
+				sum += scores[j]
+			}
+			for j := 0; j <= i; j++ {
+				p := float32(scores[j] / sum)
+				for c := 0; c < headSz; c++ {
+					out.Data[i*nEmbd+off+c] += p * v.Data[j*nEmbd+off+c]
+				}
+			}
+		}
+	}
+	return out
+}
+
+// gpuCausalMHA runs the same attention as one masked multi-head dispatch
+// on resident tensors.
+func gpuCausalMHA(g *tensai.GPU, q, k, v *tensai.Matrix) *tensai.Matrix {
+	upload := func(m *tensai.Matrix) *tensai.GPUTensor {
+		t, err := g.Upload(m.Tensor())
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+	gq, gk, gv := upload(q), upload(k), upload(v)
+	defer gq.Free()
+	defer gk.Free()
+	defer gv.Free()
+	got, err := gq.CausalMultiHeadAttention(gk, gv, nHead)
+	if err != nil {
+		panic(err)
+	}
+	defer got.Free()
+	t, err := got.Download()
+	if err != nil {
+		panic(err)
+	}
+	m, err := t.Matrix()
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// prefill runs the whole prompt through the model in one batched pass,
+// filling the KV cache and returning the logits after the last token. The
+// matmuls run on tensai's Dot kernel; with a non-nil GPU the causal
+// attention of every block runs as one masked multi-head dispatch on the
+// GPU instead of the CPU loops.
+func (m *gpt2) prefill(tokens []int, g *tensai.GPU) []float32 {
+	T := len(tokens)
+	x := tensai.NewMatrix(T, nEmbd)
+	for t, tok := range tokens {
+		row := x.Data[t*nEmbd : (t+1)*nEmbd]
+		for i := range row {
+			row[i] = m.wte.Data[tok*nEmbd+i] + m.wpe.Data[t*nEmbd+i]
+		}
+	}
+
+	for li := range m.blocks {
+		b := &m.blocks[li]
+
+		qkv := matmul(layernormRows(x, b.ln1w, b.ln1b), b.attnW, b.attnB)
+		q := tensai.NewMatrix(T, nEmbd)
+		k := tensai.NewMatrix(T, nEmbd)
+		v := tensai.NewMatrix(T, nEmbd)
+		for t := 0; t < T; t++ {
+			copy(q.Data[t*nEmbd:(t+1)*nEmbd], qkv.Data[t*3*nEmbd:t*3*nEmbd+nEmbd])
+			copy(k.Data[t*nEmbd:(t+1)*nEmbd], qkv.Data[t*3*nEmbd+nEmbd:t*3*nEmbd+2*nEmbd])
+			copy(v.Data[t*nEmbd:(t+1)*nEmbd], qkv.Data[t*3*nEmbd+2*nEmbd:(t+1)*3*nEmbd])
+			b.kc = append(b.kc, k.Data[t*nEmbd:(t+1)*nEmbd])
+			b.vc = append(b.vc, v.Data[t*nEmbd:(t+1)*nEmbd])
+		}
+
+		var attn *tensai.Matrix
+		if g != nil {
+			attn = gpuCausalMHA(g, q, k, v)
+		} else {
+			attn = cpuCausalMHA(q, k, v)
+		}
+		addInPlace(x, matmul(attn, b.projW, b.projB))
+
+		h := matmul(layernormRows(x, b.ln2w, b.ln2b), b.fcW, b.fcB)
+		geluNew(h.Data)
+		addInPlace(x, matmul(h, b.fc2W, b.fc2B))
+	}
+
+	last := x.Data[(T-1)*nEmbd:]
+	return matvec(layernorm(last, m.lnfW, m.lnfB), m.wteT, nil)
+}

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -63,6 +63,14 @@ func (q *GPUTensor) MultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, 
 	return nil, errNoWGPU
 }
 
+// CausalAttention always fails in builds without the wgpu tag.
+func (q *GPUTensor) CausalAttention(k, v *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// CausalMultiHeadAttention always fails in builds without the wgpu tag.
+func (q *GPUTensor) CausalMultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, error) {
+	return nil, errNoWGPU
+}
+
 // Download always fails in builds without the wgpu tag.
 func (t *GPUTensor) Download() (*Tensor, error) { return nil, errNoWGPU }
 

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -463,6 +463,150 @@ func TestGPUMultiHeadAttention(t *testing.T) {
 	}
 }
 
+// cpuCausalAttention is single-head causal attention on the CPU: query i
+// attends to key positions 0..i+(seqKV-seqQ).
+func cpuCausalAttention(t *testing.T, q, k, v *Tensor) *Tensor {
+	t.Helper()
+	seq, d := q.Shape[0], q.Shape[1]
+	seqKV := k.Shape[0]
+	out := NewTensor(seq, d)
+	scores := make([]float64, seqKV)
+	for i := 0; i < seq; i++ {
+		limit := i + seqKV - seq + 1
+		maxs := math.Inf(-1)
+		for j := 0; j < limit; j++ {
+			var s float64
+			for c := 0; c < d; c++ {
+				s += float64(q.Data[i*d+c]) * float64(k.Data[j*d+c])
+			}
+			s /= math.Sqrt(float64(d))
+			scores[j] = s
+			if s > maxs {
+				maxs = s
+			}
+		}
+		var sum float64
+		for j := 0; j < limit; j++ {
+			scores[j] = math.Exp(scores[j] - maxs)
+			sum += scores[j]
+		}
+		for j := 0; j < limit; j++ {
+			p := float32(scores[j] / sum)
+			for c := 0; c < d; c++ {
+				out.Data[i*d+c] += p * v.Data[j*d+c]
+			}
+		}
+	}
+	return out
+}
+
+func TestGPUCausalAttention(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(19))
+
+	// Prefill shape: seqQ == seqKV, single head.
+	q, k, v := randTensor(rng, 6, 8), randTensor(rng, 6, 8), randTensor(rng, 6, 8)
+	gq, _ := g.Upload(q)
+	gk, _ := g.Upload(k)
+	gv, _ := g.Upload(v)
+	defer gq.Free()
+	defer gk.Free()
+	defer gv.Free()
+	out, err := gq.CausalAttention(gk, gv)
+	if err != nil {
+		t.Fatalf("causal attention: %v", err)
+	}
+	defer out.Free()
+	got, err := out.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := cpuCausalAttention(t, q, k, v)
+	for i := range want.Data {
+		if diff := math.Abs(float64(got.Data[i] - want.Data[i])); diff > 1e-4 {
+			t.Fatalf("element %d: gpu=%v cpu=%v", i, got.Data[i], want.Data[i])
+		}
+	}
+
+	// Chunked decode: 3 fresh queries against 7 cached positions.
+	q2, k2, v2 := randTensor(rng, 3, 8), randTensor(rng, 7, 8), randTensor(rng, 7, 8)
+	gq2, _ := g.Upload(q2)
+	gk2, _ := g.Upload(k2)
+	gv2, _ := g.Upload(v2)
+	defer gq2.Free()
+	defer gk2.Free()
+	defer gv2.Free()
+	out2, err := gq2.CausalAttention(gk2, gv2)
+	if err != nil {
+		t.Fatalf("causal attention kv>q: %v", err)
+	}
+	defer out2.Free()
+	got2, err := out2.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want2 := cpuCausalAttention(t, q2, k2, v2)
+	for i := range want2.Data {
+		if diff := math.Abs(float64(got2.Data[i] - want2.Data[i])); diff > 1e-4 {
+			t.Fatalf("kv>q element %d: gpu=%v cpu=%v", i, got2.Data[i], want2.Data[i])
+		}
+	}
+
+	if _, err := gq2.CausalAttention(gq2, gq2); err != nil {
+		t.Fatalf("seqKV == seqQ must be accepted: %v", err)
+	}
+	if _, err := gk2.CausalAttention(gq2, gq2); err == nil {
+		t.Fatal("expected error for seqKV < seqQ")
+	}
+}
+
+func TestGPUCausalMultiHead(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(20))
+
+	const seq, seqKV, heads, dh = 5, 9, 3, 4
+	const d = heads * dh
+	q, k, v := randTensor(rng, seq, d), randTensor(rng, seqKV, d), randTensor(rng, seqKV, d)
+	gq, _ := g.Upload(q)
+	gk, _ := g.Upload(k)
+	gv, _ := g.Upload(v)
+	defer gq.Free()
+	defer gk.Free()
+	defer gv.Free()
+	out, err := gq.CausalMultiHeadAttention(gk, gv, heads)
+	if err != nil {
+		t.Fatalf("causal mha: %v", err)
+	}
+	defer out.Free()
+	got, err := out.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference: slice heads out, run single-head causal attention.
+	want := NewTensor(seq, d)
+	for h := 0; h < heads; h++ {
+		slice := func(x *Tensor, rows int) *Tensor {
+			s := NewTensor(rows, dh)
+			for r := 0; r < rows; r++ {
+				copy(s.Data[r*dh:(r+1)*dh], x.Data[r*d+h*dh:r*d+(h+1)*dh])
+			}
+			return s
+		}
+		ho := cpuCausalAttention(t, slice(q, seq), slice(k, seqKV), slice(v, seqKV))
+		for r := 0; r < seq; r++ {
+			copy(want.Data[r*d+h*dh:r*d+(h+1)*dh], ho.Data[r*dh:(r+1)*dh])
+		}
+	}
+	for i := range want.Data {
+		if diff := math.Abs(float64(got.Data[i] - want.Data[i])); diff > 1e-4 {
+			t.Fatalf("element %d: gpu=%v cpu=%v", i, got.Data[i], want.Data[i])
+		}
+	}
+}
+
 func TestGPUDispatch2D(t *testing.T) {
 	g := openTestGPU(t)
 	defer g.Close()

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -283,7 +283,7 @@ fn scale_ip(@builtin(workgroup_id) wg: vec3<u32>,
     }
 }
 
-struct SoftParams { rows: u32, cols: u32 }
+struct SoftParams { rows: u32, cols: u32, qmod: u32, off: u32 }
 @group(0) @binding(7) var<uniform> sp: SoftParams;
 @group(0) @binding(8) var<storage, read> sx: array<f32>;
 @group(0) @binding(9) var<storage, read_write> sy: array<f32>;
@@ -302,8 +302,16 @@ fn softmax_last(@builtin(workgroup_id) wid: vec3<u32>,
         return;
     }
     let base = row * sp.cols;
+    // Causal masking: with qmod > 0, row's query index is row % qmod and
+    // it may attend to the first (query index + off + 1) columns; the rest
+    // get probability zero. limit is workgroup-uniform, so the barriers
+    // below stay in uniform control flow.
+    var limit = sp.cols;
+    if (sp.qmod > 0u) {
+        limit = min(sp.cols, (row % sp.qmod) + sp.off + 1u);
+    }
     var m = -3.40282e38;
-    for (var i = lid.x; i < sp.cols; i = i + 256u) {
+    for (var i = lid.x; i < limit; i = i + 256u) {
         m = max(m, sx[base + i]);
     }
     red[lid.x] = m;
@@ -315,10 +323,13 @@ fn softmax_last(@builtin(workgroup_id) wid: vec3<u32>,
     let rowMax = red[0];
     workgroupBarrier();
     var sum = 0.0;
-    for (var i = lid.x; i < sp.cols; i = i + 256u) {
+    for (var i = lid.x; i < limit; i = i + 256u) {
         let e = exp(sx[base + i] - rowMax);
         sy[base + i] = e;
         sum = sum + e;
+    }
+    for (var i = limit + lid.x; i < sp.cols; i = i + 256u) {
+        sy[base + i] = 0.0;
     }
     red[lid.x] = sum;
     workgroupBarrier();
@@ -327,7 +338,7 @@ fn softmax_last(@builtin(workgroup_id) wid: vec3<u32>,
         workgroupBarrier();
     }
     let total = red[0];
-    for (var i = lid.x; i < sp.cols; i = i + 256u) {
+    for (var i = lid.x; i < limit; i = i + 256u) {
         sy[base + i] = sy[base + i] / total;
     }
 }
@@ -757,6 +768,13 @@ func (t *GPUTensor) Scale(s Float) error {
 // Softmax applies a numerically stable softmax over the last axis,
 // returning a new GPU-resident tensor.
 func (t *GPUTensor) Softmax() (*GPUTensor, error) {
+	return t.softmax(0, 0)
+}
+
+// softmax optionally applies a causal mask: with qmod > 0, row r is query
+// index r%qmod and attends to the first r%qmod+off+1 columns; masked
+// columns come out as exactly zero.
+func (t *GPUTensor) softmax(qmod, off int) (*GPUTensor, error) {
 	if t.freed {
 		return nil, errors.New("tensai: gpu tensor already freed")
 	}
@@ -776,7 +794,7 @@ func (t *GPUTensor) Softmax() (*GPUTensor, error) {
 	uncapturedCB = ""
 
 	bytes := uint64(t.Size()) * 4
-	params := [4]uint32{uint32(rows), uint32(cols)}
+	params := [4]uint32{uint32(rows), uint32(cols), uint32(qmod), uint32(off)}
 	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
 	bufOut := g.newBuffer(gpuTensorUsage, bytes)
 	defer fnBufferRelease(bufParams)
@@ -803,18 +821,40 @@ func (t *GPUTensor) Softmax() (*GPUTensor, error) {
 // entirely on the GPU — the resident counterpart of the autograd Attention.
 // q, k, v are (batch..., seqLen, d) tensors; nothing touches host memory.
 func (q *GPUTensor) Attention(k, v *GPUTensor) (*GPUTensor, error) {
-	if len(q.shape) < 2 {
+	return q.attention(k, v, false)
+}
+
+// CausalAttention is Attention with a causal mask: query i attends only to
+// key positions 0..i+(seqKV-seqQ), so k and v may hold seqKV >= seqQ
+// positions with the queries aligned to their end — the prompt-prefill
+// pattern of autoregressive models.
+func (q *GPUTensor) CausalAttention(k, v *GPUTensor) (*GPUTensor, error) {
+	return q.attention(k, v, true)
+}
+
+func (q *GPUTensor) attention(k, v *GPUTensor, causal bool) (*GPUTensor, error) {
+	nq := len(q.shape)
+	if nq < 2 {
 		return nil, fmt.Errorf("tensai: attention needs at least 2 axes: %v", q.shape)
+	}
+	seq := q.shape[nq-2]
+	seqKV := k.shape[len(k.shape)-2]
+	if causal && seqKV < seq {
+		return nil, fmt.Errorf("tensai: causal attention needs seqKV >= seqQ, got %d < %d", seqKV, seq)
 	}
 	scores, err := q.MatMulT(k)
 	if err != nil {
 		return nil, err
 	}
 	defer scores.Free()
-	if err := scores.Scale(1 / sqrtF(Float(q.shape[len(q.shape)-1]))); err != nil {
+	if err := scores.Scale(1 / sqrtF(Float(q.shape[nq-1]))); err != nil {
 		return nil, err
 	}
-	weights, err := scores.Softmax()
+	qmod, off := 0, 0
+	if causal {
+		qmod, off = seq, seqKV-seq
+	}
+	weights, err := scores.softmax(qmod, off)
 	if err != nil {
 		return nil, err
 	}
@@ -828,6 +868,18 @@ func (q *GPUTensor) Attention(k, v *GPUTensor) (*GPUTensor, error) {
 // the result is (batch..., seqQ, d). Heads are carved out of the packed
 // layout with strided kernels, so no permute is ever materialized.
 func (q *GPUTensor) MultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, error) {
+	return q.multiHeadAttention(k, v, heads, false)
+}
+
+// CausalMultiHeadAttention is MultiHeadAttention with a causal mask: query
+// i attends only to key positions 0..i+(seqKV-seqQ), so k and v may hold
+// seqKV >= seqQ positions with the queries aligned to their end — the
+// prompt-prefill pattern of autoregressive models.
+func (q *GPUTensor) CausalMultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, error) {
+	return q.multiHeadAttention(k, v, heads, true)
+}
+
+func (q *GPUTensor) multiHeadAttention(k, v *GPUTensor, heads int, causal bool) (*GPUTensor, error) {
 	if q.freed || k.freed || v.freed {
 		return nil, errors.New("tensai: gpu tensor already freed")
 	}
@@ -850,6 +902,9 @@ func (q *GPUTensor) MultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, 
 	}
 	seq := q.shape[nq-2]
 	seqKV := k.shape[nq-2]
+	if causal && seqKV < seq {
+		return nil, fmt.Errorf("tensai: causal attention needs seqKV >= seqQ, got %d < %d", seqKV, seq)
+	}
 	batch := prodDims(q.shape[:nq-2])
 	dh := d / heads
 	bh := batch * heads
@@ -874,7 +929,11 @@ func (q *GPUTensor) MultiHeadAttention(k, v *GPUTensor, heads int) (*GPUTensor, 
 	if err := scores.Scale(1 / sqrtF(Float(dh))); err != nil {
 		return nil, err
 	}
-	weights, err := scores.Softmax()
+	qmod, off := 0, 0
+	if causal {
+		qmod, off = seq, seqKV-seq
+	}
+	weights, err := scores.softmax(qmod, off)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Gives the softmax kernel a causal mode — masked columns come out exactly zero, and the per-row limit is workgroup-uniform so the reduction barriers stay in uniform control flow — exposed as `CausalAttention` and `CausalMultiHeadAttention`, with k/v allowed to hold more positions than q for prefill and chunked decode against a KV cache; no mask tensor is ever materialized. The gpt2 example now runs its prompt as one batched pass (lifting generation to ~36 tok/s by itself), and with `-gpu` each block's causal attention becomes a single masked dispatch on resident tensors: a 601-token prompt prefills 1.5x faster even through dozen inside WSL2, with the greedy reference output unchanged. Causal kernels are verified against CPU references for seqKV == seqQ and seqKV > seqQ, single and multi-head, on lavapipe under both bindings and on the real GPU.