### PR TITLE
add int8 weight quantization, doubling gpt2 decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Low-allocation training** - layers reuse their forward/backward scratch buffers across training steps (a full MLP step runs in ~29 allocations), so GC stays out of the training loop; `Predict` always returns freshly allocated results
 - **Layers** - `Embedding`, `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `LayerNorm`, `Dropout`, plus `ReLU`, `LeakyReLU`, `GELU`, `Sigmoid`, `Tanh`, and `Softmax` activations
 - **WebGPU backend (experimental)** - build with `-tags wgpu` (linux, macOS, Windows) and `OpenGPU()` runs batched `MatMul` as a WGSL compute shader on any GPU wgpu-native reaches (Vulkan, Metal, D3D12 — AMD, Intel, Apple, NVIDIA). The bindings go through `ebitengine/purego`, so there is still no cgo and no C compiler: the wgpu-native shared library is dlopen-ed at runtime
+- **int8 quantization** - `QuantizeMatrix` / `QMatrix.MatVec` implement weight-only int8 with per-column scales and float32 accumulation. Inference matvecs are memory-bandwidth bound, and int8 weights stream four times less: the AVX2 kernel widens them in-register and roughly doubles decode throughput out of cache
 - **Loss functions** - `MeanSquaredError` for regression, `SoftmaxCrossEntropy` for multi-class classification, and `BinaryCrossEntropy` for binary targets
 - **Optimizers** - momentum `SGD`, `Adam`, and `AdamW` (decoupled weight decay)
 - **k-NN baseline** - a `KNN` classifier whose distance matrix runs on the same SIMD matmul kernel; useful as a no-training baseline next to the networks
@@ -169,6 +170,8 @@ Hello, I'm a language model, not a programming language. I'm a language model. .
 The greedy continuation matches GPT-2's well-known reference output token for token, which pins the whole pipeline — reader, tokenizer, and forward pass — in one check.
 
 The prompt runs through the model as one batched pass; with `-gpu` (built with `-tags wgpu` or `wgpu24`) every block's causal multi-head attention becomes a single masked dispatch on the GPU. A 600-token prompt prefills 1.5x faster even through dozen inside WSL2; native drivers gain more.
+
+`-q8` quantizes the decode-path weights to int8 (weight-only, per-column scales) and doubles generation — 23 to 46 tok/s on the same machine — because decode streams the whole checkpoint per token and int8 pulls a quarter of the bytes. The text stays coherent but greedy decoding no longer reproduces the float32 reference tokens exactly; use the default float32 path for the reference check.
 
 ### Automatic differentiation
 

--- a/_example/gpt2/main.go
+++ b/_example/gpt2/main.go
@@ -110,6 +110,7 @@ func main() {
 	temp := flag.Float64("temp", 0, "sampling temperature; 0 = greedy")
 	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
 	useGPU := flag.Bool("gpu", false, "run prompt-prefill attention on the GPU (build with -tags wgpu or wgpu24)")
+	q8 := flag.Bool("q8", false, "decode against int8-quantized weights (weight-only, per-column scales)")
 	flag.Parse()
 
 	var gpu *tensai.GPU
@@ -146,6 +147,11 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stderr, "loaded gpt2 (124M) in %v\n", time.Since(start).Round(time.Millisecond))
+	if *q8 {
+		start = time.Now()
+		model.quantize()
+		fmt.Fprintf(os.Stderr, "quantized decode weights to int8 in %v\n", time.Since(start).Round(time.Millisecond))
+	}
 
 	ids := tok.Encode(*prompt)
 	if len(ids) == 0 || len(ids) >= nCtx {

--- a/_example/gpt2/model.go
+++ b/_example/gpt2/model.go
@@ -30,14 +30,50 @@ type block struct {
 	attnB, projB           []float32
 	fcB, fc2B              []float32
 	kc, vc                 [][]float32 // KV cache, one [768] per position
+
+	// int8 twins of the four weight matrices, used by decode when -q8.
+	qAttnW, qProjW, qFcW, qFc2W *tensai.QMatrix
 }
 
 type gpt2 struct {
 	wte, wpe   *tensai.Tensor // [50257,768], [1024,768]
 	wteT       *tensai.Matrix // [768,50257], for the tied lm head
+	qWteT      *tensai.QMatrix
 	lnfW, lnfB []float32
 	blocks     [nLayer]block
 	vocab      int
+}
+
+// quantize builds int8 twins of every decode-path weight. Prefill keeps
+// the float32 originals: it is one batched pass where the matmuls are
+// compute bound, while decode streams the whole checkpoint per token and
+// is bandwidth bound — exactly where int8 pays.
+func (m *gpt2) quantize() {
+	m.qWteT = tensai.QuantizeMatrix(m.wteT)
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		b.qAttnW = tensai.QuantizeMatrix(b.attnW)
+		b.qProjW = tensai.QuantizeMatrix(b.projW)
+		b.qFcW = tensai.QuantizeMatrix(b.fcW)
+		b.qFc2W = tensai.QuantizeMatrix(b.fc2W)
+	}
+}
+
+// mv routes a decode matvec through the int8 weights when they exist.
+func mv(x []float32, w *tensai.Matrix, q *tensai.QMatrix, bias []float32) []float32 {
+	if q == nil {
+		return matvec(x, w, bias)
+	}
+	out := make([]float32, q.Cols)
+	if err := q.MatVec(x, out); err != nil {
+		panic(err)
+	}
+	if bias != nil {
+		for i := range out {
+			out[i] += bias[i]
+		}
+	}
+	return out
 }
 
 func loadModel(path string) (*gpt2, error) {
@@ -151,7 +187,7 @@ func (m *gpt2) step(token, pos int) []float32 {
 
 		// Attention with the KV cache: the single query row attends over
 		// every cached position, so causality holds by construction.
-		qkv := matvec(layernorm(x, b.ln1w, b.ln1b), b.attnW, b.attnB)
+		qkv := mv(layernorm(x, b.ln1w, b.ln1b), b.attnW, b.qAttnW, b.attnB)
 		k := make([]float32, nEmbd)
 		v := make([]float32, nEmbd)
 		copy(k, qkv[nEmbd:2*nEmbd])
@@ -191,21 +227,21 @@ func (m *gpt2) step(token, pos int) []float32 {
 				}
 			}
 		}
-		proj := matvec(attn, b.projW, b.projB)
+		proj := mv(attn, b.projW, b.qProjW, b.projB)
 		for i := range x {
 			x[i] += proj[i]
 		}
 
 		// MLP.
-		h := matvec(layernorm(x, b.ln2w, b.ln2b), b.fcW, b.fcB)
+		h := mv(layernorm(x, b.ln2w, b.ln2b), b.fcW, b.qFcW, b.fcB)
 		geluNew(h)
-		out := matvec(h, b.fc2W, b.fc2B)
+		out := mv(h, b.fc2W, b.qFc2W, b.fc2B)
 		for i := range x {
 			x[i] += out[i]
 		}
 	}
 
-	return matvec(layernorm(x, m.lnfW, m.lnfB), m.wteT, nil)
+	return mv(layernorm(x, m.lnfW, m.lnfB), m.wteT, m.qWteT, nil)
 }
 
 // reset clears the KV cache for a fresh sequence.

--- a/quant.go
+++ b/quant.go
@@ -1,0 +1,106 @@
+package tensai
+
+import (
+	"fmt"
+	"sync"
+)
+
+// QMatrix is a weight matrix quantized to int8 with one scale per output
+// column: W[i][j] ~= Float(Q[i*Cols+j]) * Scale[j]. Inference matvecs are
+// memory-bandwidth bound, so weight-only quantization — activations stay
+// float32 — quarters their traffic while keeping the accumulation in
+// float32.
+type QMatrix struct {
+	Rows, Cols int
+	Q          []int8 // row-major, padded so 16-byte loads never run off the end
+	Scale      []Float
+}
+
+// QuantizeMatrix quantizes column-wise, symmetric around zero with
+// round-to-nearest, so each output column keeps its own dynamic range.
+func QuantizeMatrix(m *Matrix) *QMatrix {
+	q := &QMatrix{
+		Rows:  m.Rows,
+		Cols:  m.Cols,
+		Q:     make([]int8, m.Rows*m.Cols+16),
+		Scale: make([]Float, m.Cols),
+	}
+	for j := 0; j < m.Cols; j++ {
+		var maxAbs Float
+		for i := 0; i < m.Rows; i++ {
+			v := m.Data[i*m.Cols+j]
+			if v < 0 {
+				v = -v
+			}
+			if v > maxAbs {
+				maxAbs = v
+			}
+		}
+		s := maxAbs / 127
+		q.Scale[j] = s
+		if s == 0 {
+			continue
+		}
+		inv := 1 / s
+		for i := 0; i < m.Rows; i++ {
+			v := m.Data[i*m.Cols+j] * inv
+			if v >= 0 {
+				v += 0.5
+			} else {
+				v -= 0.5
+			}
+			q.Q[i*m.Cols+j] = int8(v)
+		}
+	}
+	return q
+}
+
+// MatVec computes out = x @ Q for a single activation row: len(x) must be
+// Rows and len(out) Cols. Output columns are split across CPUs for large
+// matrices, mirroring DotInto.
+func (q *QMatrix) MatVec(x, out []Float) error {
+	if len(x) != q.Rows || len(out) != q.Cols {
+		return fmt.Errorf("tensai: qmatvec shape mismatch: x=%d out=%d, want %dx%d",
+			len(x), len(out), q.Rows, q.Cols)
+	}
+	workers := dotWorkerCount(q.Cols, q.Rows, 1)
+	if workers == 1 {
+		qmatvecCols(out, x, q.Q, q.Scale, q.Cols, 0, q.Cols)
+		return nil
+	}
+	// Chunks stay multiples of 8 so only the last one has a scalar tail.
+	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
+	var wg sync.WaitGroup
+	for lo := 0; lo < q.Cols; lo += chunk {
+		hi := lo + chunk
+		if hi > q.Cols {
+			hi = q.Cols
+		}
+		wg.Add(1)
+		go func(lo, hi int) {
+			defer wg.Done()
+			qmatvecCols(out, x, q.Q, q.Scale, q.Cols, lo, hi)
+		}(lo, hi)
+	}
+	wg.Wait()
+	return nil
+}
+
+// qmatvecColsGeneric accumulates out[lo:hi] of out = x @ Q in pure Go and
+// applies the column scales. qmatvecCols (see quant_simd.go and
+// quant_generic.go) dispatches to the AVX2 kernel when available.
+func qmatvecColsGeneric(out, x []Float, qw []int8, scale []Float, cols, lo, hi int) {
+	clear(out[lo:hi])
+	for i, xi := range x {
+		if xi == 0 {
+			continue
+		}
+		row := qw[i*cols : i*cols+cols]
+		for j := lo; j < hi; j++ {
+			out[j] += xi * Float(row[j])
+		}
+	}
+	for j := lo; j < hi; j++ {
+		out[j] *= scale[j]
+	}
+}

--- a/quant_generic.go
+++ b/quant_generic.go
@@ -1,0 +1,10 @@
+//go:build !goexperiment.simd || !amd64
+
+package tensai
+
+// Portable dispatcher for the quantized matvec kernel; build with
+// GOEXPERIMENT=simd on amd64 for the AVX2 version in quant_simd.go.
+
+func qmatvecCols(out, x []Float, qw []int8, scale []Float, cols, lo, hi int) {
+	qmatvecColsGeneric(out, x, qw, scale, cols, lo, hi)
+}

--- a/quant_simd.go
+++ b/quant_simd.go
@@ -1,0 +1,48 @@
+//go:build goexperiment.simd && amd64
+
+package tensai
+
+import "simd/archsimd"
+
+// AVX2 kernel for the quantized matvec: 16-byte int8 loads (the QMatrix
+// padding keeps them in bounds), the low 8 lanes widened to int32,
+// converted to float32, and FMA'd against the broadcast activation. The
+// scalar tail runs after the vector state is cleared, mirroring the
+// discipline in dot_simd.go.
+func qmatvecCols(out, x []Float, qw []int8, scale []Float, cols, lo, hi int) {
+	if !hasAVX2 {
+		qmatvecColsGeneric(out, x, qw, scale, cols, lo, hi)
+		return
+	}
+	wide := lo + ((hi - lo) &^ 31)
+	vecEnd := lo + ((hi - lo) &^ 7)
+	clear(out[lo:hi])
+	if vecEnd > lo {
+		for i := range x {
+			xv := archsimd.BroadcastFloat32x8(x[i])
+			row := qw[i*cols:]
+			j := lo
+			for ; j < wide; j += 32 {
+				w0 := loadI8x16(row[j:]).ExtendLo8ToInt32().ConvertToFloat32()
+				w1 := loadI8x16(row[j+8:]).ExtendLo8ToInt32().ConvertToFloat32()
+				w2 := loadI8x16(row[j+16:]).ExtendLo8ToInt32().ConvertToFloat32()
+				w3 := loadI8x16(row[j+24:]).ExtendLo8ToInt32().ConvertToFloat32()
+				storeF32x8(w0.MulAdd(xv, loadF32x8(out[j:])), out[j:])
+				storeF32x8(w1.MulAdd(xv, loadF32x8(out[j+8:])), out[j+8:])
+				storeF32x8(w2.MulAdd(xv, loadF32x8(out[j+16:])), out[j+16:])
+				storeF32x8(w3.MulAdd(xv, loadF32x8(out[j+24:])), out[j+24:])
+			}
+			for ; j < vecEnd; j += 8 {
+				w := loadI8x16(row[j:]).ExtendLo8ToInt32().ConvertToFloat32()
+				storeF32x8(w.MulAdd(xv, loadF32x8(out[j:])), out[j:])
+			}
+		}
+		for j := lo; j < vecEnd; j += 8 {
+			storeF32x8(loadF32x8(out[j:]).Mul(loadF32x8(scale[j:])), out[j:])
+		}
+	}
+	archsimd.ClearAVXUpperBits()
+	if vecEnd < hi {
+		qmatvecColsGeneric(out, x, qw, scale, cols, vecEnd, hi)
+	}
+}

--- a/quant_test.go
+++ b/quant_test.go
@@ -1,0 +1,141 @@
+package tensai
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestQuantizeMatVec(t *testing.T) {
+	rng := rand.New(rand.NewSource(31))
+	for _, c := range []struct{ rows, cols int }{
+		{768, 2304}, // big enough for the parallel path
+		{16, 16},
+		{7, 13}, // scalar tails on every chunk
+		{1, 9},
+	} {
+		m := RandomMatrix(c.rows, c.cols, rng)
+		q := QuantizeMatrix(m)
+		x := make([]Float, c.rows)
+		for i := range x {
+			x[i] = Float(rng.NormFloat64())
+		}
+		out := make([]Float, c.cols)
+		if err := q.MatVec(x, out); err != nil {
+			t.Fatalf("%dx%d: %v", c.rows, c.cols, err)
+		}
+
+		// Exact reference over the same quantized weights: the kernel must
+		// match it to float rounding.
+		want := make([]float64, c.cols)
+		for i := 0; i < c.rows; i++ {
+			for j := 0; j < c.cols; j++ {
+				want[j] += float64(x[i]) * float64(q.Q[i*c.cols+j])
+			}
+		}
+		var worst float64
+		for j := range want {
+			want[j] *= float64(q.Scale[j])
+			diff := math.Abs(float64(out[j]) - want[j])
+			if diff > 1e-3*(1+math.Abs(want[j])) {
+				t.Fatalf("%dx%d col %d: got %v want %v", c.rows, c.cols, j, out[j], want[j])
+			}
+			// And it must stay close to the full-precision product.
+			var full float64
+			for i := 0; i < c.rows; i++ {
+				full += float64(x[i]) * float64(m.Data[i*c.cols+j])
+			}
+			if d := math.Abs(want[j] - full); d > worst {
+				worst = d
+			}
+		}
+		if worst > 0.5 { // int8 error over a few hundred accumulations stays small
+			t.Fatalf("%dx%d: quantization error %v too large", c.rows, c.cols, worst)
+		}
+	}
+
+	q := QuantizeMatrix(NewMatrix(4, 4)) // all zeros: scales are zero
+	out := make([]Float, 4)
+	if err := q.MatVec(make([]Float, 4), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range out {
+		if v != 0 {
+			t.Fatalf("zero matrix produced %v", out)
+		}
+	}
+	if err := q.MatVec(make([]Float, 3), out); err == nil {
+		t.Fatal("expected shape mismatch error")
+	}
+}
+
+// The Big pair exceeds the L3 cache, which is the regime inference decode
+// lives in: there the f32 matvec is memory-bandwidth bound and the int8
+// weights pull four times less.
+func BenchmarkMatVecF32Big(b *testing.B) {
+	rng := rand.New(rand.NewSource(33))
+	w := RandomMatrix(4096, 16384, rng)
+	x := NewMatrix(1, 4096)
+	for i := range x.Data {
+		x.Data[i] = Float(rng.NormFloat64())
+	}
+	out := NewMatrix(1, 16384)
+	b.SetBytes(4096 * 16384 * 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := DotInto(out, x, w); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMatVecQ8Big(b *testing.B) {
+	rng := rand.New(rand.NewSource(33))
+	q := QuantizeMatrix(RandomMatrix(4096, 16384, rng))
+	x := make([]Float, 4096)
+	for i := range x {
+		x[i] = Float(rng.NormFloat64())
+	}
+	out := make([]Float, 16384)
+	b.SetBytes(4096 * 16384)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := q.MatVec(x, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMatVecF32(b *testing.B) {
+	rng := rand.New(rand.NewSource(32))
+	w := RandomMatrix(768, 2304, rng)
+	x := NewMatrix(1, 768)
+	for i := range x.Data {
+		x.Data[i] = Float(rng.NormFloat64())
+	}
+	out := NewMatrix(1, 2304)
+	b.SetBytes(768 * 2304 * 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := DotInto(out, x, w); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMatVecQ8(b *testing.B) {
+	rng := rand.New(rand.NewSource(32))
+	q := QuantizeMatrix(RandomMatrix(768, 2304, rng))
+	x := make([]Float, 768)
+	for i := range x {
+		x[i] = Float(rng.NormFloat64())
+	}
+	out := make([]Float, 2304)
+	b.SetBytes(768 * 2304)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := q.MatVec(x, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/simd_compat_go126.go
+++ b/simd_compat_go126.go
@@ -11,6 +11,10 @@ func loadF32x8(s []Float) archsimd.Float32x8 {
 	return archsimd.LoadFloat32x8Slice(s)
 }
 
+func loadI8x16(s []int8) archsimd.Int8x16 {
+	return archsimd.LoadInt8x16Slice(s)
+}
+
 func loadF32x8Part(s []Float) archsimd.Float32x8 {
 	return archsimd.LoadFloat32x8SlicePart(s)
 }

--- a/simd_compat_go127.go
+++ b/simd_compat_go127.go
@@ -23,6 +23,10 @@ func storeF32x8(v archsimd.Float32x8, s []Float) {
 	v.Store(s)
 }
 
+func loadI8x16(s []int8) archsimd.Int8x16 {
+	return archsimd.LoadInt8x16(s)
+}
+
 func storeF32x8Part(v archsimd.Float32x8, s []Float) {
 	v.StorePart(s)
 }


### PR DESCRIPTION
Adds weight-only int8 quantization: `QuantizeMatrix` builds an int8 twin with one symmetric per-column scale, and `QMatrix.MatVec` runs a single activation row against it with float32 accumulation, columns split across CPUs. The AVX2 kernel widens int8 weights in-register (int8 → int32 → float32) and FMAs four vectors per iteration. Decode is memory-bandwidth bound and int8 pulls a quarter of the bytes: past the L3 the matvec runs 2.2x faster, and `gpt2 -q8` doubles generation from 23 to 46 tok/s. Output stays coherent but greedy decoding no longer matches the float32 reference exactly, so the reference check stays on the default path. Tests pin the kernel to an exact requantized reference on both the portable and AVX2 builds.