### PR TITLE
add encoding/onnx: export Sequential models to ONNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Serialization** - `Save`/`Load` (and `SaveFile`/`LoadFile`) round-trip trained Sequential parameters as JSON, including BatchNorm running statistics; `SaveParams`/`LoadParams` do the same for autograd parameters (RNN/LSTM/attention cells)
 - **TFLite export** - the `encoding/tflite` package marshals Sequential models (FP32, NHWC) into `.tflite` flatbuffers that run on the TFLite/LiteRT runtimes and [go-tflite](https://github.com/mattn/go-tflite), with the FlatBuffers writer implemented in-tree — still no dependencies
 - **safetensors** - `encoding/safetensors` reads the checkpoint format most published model weights ship in — lazily, one tensor at a time, with F16/BF16/F64 converted to float32 — and writes F32 checkpoints; interoperability is verified against the reference implementation in both directions. Also dependency-free
+- **ONNX export** - `encoding/onnx` marshals Sequential models into ONNX (opset 13, FP32) with a hand-written protobuf encoder; onnxruntime reproduces `Predict` to ~1e-7 relative error. ONNX convolutions are NCHW, which is tensai's own row layout, so nothing is reordered
 
 ## Layout
 
@@ -134,6 +135,16 @@ model.LoadFile("model.json")
 `Conv2D` and `MaxPool2D` treat each row as a channel-major image: `index = (channel*height + y)*width + x`. `Dropout` and `BatchNorm` switch automatically between training behavior (inside `Fit`/`FitStep`) and inference behavior (inside `Predict`).
 
 `Embedding` keeps the current matrix-only API: each input row is a token-id sequence, and the layer concatenates the looked-up embedding vectors across columns. For example, `Compile(4, ...)` plus `NewEmbedding(vocab, 8)` turns an `Mx4` token-id matrix into an `Mx32` dense feature matrix that can feed `LayerNorm`, `GELU`, and `Dense`.
+
+### ONNX export
+
+```go
+import tensaionnx "github.com/mattn/tensai/encoding/onnx"
+
+err := tensaionnx.MarshalFile("model.onnx", model)
+```
+
+Same layer support as the TFLite export (Dense, Conv2D, MaxPool2D, BatchNorm folded to Mul+Add, Dropout dropped, Softmax on dense features, and the ReLU/LeakyReLU/Sigmoid/Tanh activations), but no layout gotcha: ONNX convolutions are NCHW, which is exactly tensai's channel-major row layout, so the exported model consumes the same flattened rows tensai does, as a `[1, C, H, W]` tensor. Verified against onnxruntime to ~1e-7 relative error (see `encoding/onnx/verify_onnxruntime.py`).
 
 ### TFLite export
 

--- a/encoding/onnx/marshal.go
+++ b/encoding/onnx/marshal.go
@@ -1,0 +1,298 @@
+// Package onnx marshals trained tensai Sequential models into the ONNX
+// format (opset 13, FP32, batch size 1), with the protobuf writer
+// implemented in-tree — no dependencies. Exported models run on
+// onnxruntime and anything else that speaks ONNX.
+//
+// Layout note: ONNX convolutions are NCHW, which is exactly tensai's own
+// row layout (channel-major rows), so unlike the TFLite export no data or
+// weight reordering is visible to the caller: feed the exported model the
+// same flattened rows tensai's Conv2D consumes, as a [1, C, H, W] tensor.
+//
+// Supported layers: Dense (Gemm), Conv2D (Conv), MaxPool2D (MaxPool),
+// BatchNorm (folded to Mul+Add), Dropout (dropped), Softmax (dense inputs
+// only), and the ReLU / LeakyReLU / Sigmoid / Tanh activations.
+package onnx
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+
+	tensai "github.com/mattn/tensai"
+)
+
+const (
+	irVersion    = 8
+	opsetVersion = 13
+	dtFloat      = 1 // TensorProto.DataType FLOAT
+
+	// AttributeProto.AttributeType
+	attrFloat = 1
+	attrInt   = 2
+	attrInts  = 7
+)
+
+type node struct {
+	op     string
+	inputs []string
+	output string
+	attr   func(*pbuf) // extra AttributeProto fields, or nil
+}
+
+type initializer struct {
+	name string
+	dims []int64
+	data []float32
+}
+
+type graph struct {
+	nodes []node
+	inits []initializer
+	n     int
+}
+
+func (g *graph) add(op string, inputs []string, attr func(*pbuf)) string {
+	out := fmt.Sprintf("t%d", g.n)
+	g.n++
+	g.nodes = append(g.nodes, node{op: op, inputs: inputs, output: out, attr: attr})
+	return out
+}
+
+func (g *graph) tensor(name string, dims []int64, data []float32) string {
+	g.inits = append(g.inits, initializer{name: name, dims: dims, data: data})
+	return name
+}
+
+func attrIntv(name string, v int64) func(*pbuf) {
+	return func(p *pbuf) {
+		p.Msg(5, func(a *pbuf) {
+			a.Str(1, name)
+			a.Int(3, v)
+			a.Int(20, attrInt)
+		})
+	}
+}
+
+func attrIntsv(name string, vs []int64) func(*pbuf) {
+	return func(p *pbuf) {
+		p.Msg(5, func(a *pbuf) {
+			a.Str(1, name)
+			a.Ints(8, vs)
+			a.Int(20, attrInts)
+		})
+	}
+}
+
+func attrFloatv(name string, v float32) func(*pbuf) {
+	return func(p *pbuf) {
+		p.Msg(5, func(a *pbuf) {
+			a.Str(1, name)
+			a.Float(2, v)
+			a.Int(20, attrFloat)
+		})
+	}
+}
+
+func attrs(fns ...func(*pbuf)) func(*pbuf) {
+	return func(p *pbuf) {
+		for _, fn := range fns {
+			fn(p)
+		}
+	}
+}
+
+// Marshal encodes a trained Sequential model as an ONNX ModelProto.
+func Marshal(m *tensai.Sequential) ([]byte, error) {
+	layers := m.Layers()
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("onnx: model has no layers")
+	}
+	g := &graph{}
+
+	// The graph input's shape comes from the first parameterized layer.
+	var inputDims []int64
+	var h, w, c, features int
+	spatial := false
+	switch l := layers[0].(type) {
+	case *tensai.Conv2D:
+		h, w, c, _, _, _, _ = l.Shape()
+		spatial = true
+		inputDims = []int64{1, int64(c), int64(h), int64(w)}
+	case *tensai.Dense:
+		weights, _ := l.Params()
+		features = weights.Rows
+		inputDims = []int64{1, int64(features)}
+	default:
+		return nil, fmt.Errorf("onnx: first layer must be Dense or Conv2D, got %T", layers[0])
+	}
+	cur := "input"
+
+	for li, layer := range layers {
+		name := fmt.Sprintf("l%d", li)
+		switch l := layer.(type) {
+		case *tensai.Dense:
+			weights, bias := l.Params()
+			if spatial {
+				if h*w*c != weights.Rows {
+					return nil, fmt.Errorf("onnx: %s: dense input %d != %dx%dx%d", name, weights.Rows, c, h, w)
+				}
+				cur = g.add("Flatten", []string{cur}, attrIntv("axis", 1))
+				spatial = false
+			}
+			wName := g.tensor(name+"_w", []int64{int64(weights.Rows), int64(weights.Cols)}, weights.Data)
+			bName := g.tensor(name+"_b", []int64{int64(len(bias))}, bias)
+			cur = g.add("Gemm", []string{cur, wName, bName}, nil)
+			features = weights.Cols
+		case *tensai.Conv2D:
+			inH, inW, inC, outC, k, stride, pad := l.Shape()
+			if li != 0 && (!spatial || inH != h || inW != w || inC != c) {
+				return nil, fmt.Errorf("onnx: %s: conv input mismatch", name)
+			}
+			weights, bias := l.Params()
+			// tensai stores [(inC*k+ky)*k+kx][outC]; ONNX wants [outC][inC][ky][kx].
+			wd := make([]float32, outC*inC*k*k)
+			for row := 0; row < inC*k*k; row++ {
+				for oc := 0; oc < outC; oc++ {
+					wd[oc*inC*k*k+row] = weights.Data[row*outC+oc]
+				}
+			}
+			wName := g.tensor(name+"_w", []int64{int64(outC), int64(inC), int64(k), int64(k)}, wd)
+			bName := g.tensor(name+"_b", []int64{int64(outC)}, bias)
+			cur = g.add("Conv", []string{cur, wName, bName}, attrs(
+				attrIntsv("kernel_shape", []int64{int64(k), int64(k)}),
+				attrIntsv("strides", []int64{int64(stride), int64(stride)}),
+				attrIntsv("pads", []int64{int64(pad), int64(pad), int64(pad), int64(pad)}),
+			))
+			h = (inH+2*pad-k)/stride + 1
+			w = (inW+2*pad-k)/stride + 1
+			c = outC
+			spatial = true
+		case *tensai.MaxPool2D:
+			ph, pw, pc, size := l.Shape()
+			if !spatial || ph != h || pw != w || pc != c {
+				return nil, fmt.Errorf("onnx: %s: maxpool input mismatch", name)
+			}
+			cur = g.add("MaxPool", []string{cur}, attrs(
+				attrIntsv("kernel_shape", []int64{int64(size), int64(size)}),
+				attrIntsv("strides", []int64{int64(size), int64(size)}),
+			))
+			h, w = h/size, w/size
+		case *tensai.BatchNorm:
+			// tensai's BatchNorm normalizes every flattened column, so it
+			// folds into an element-wise scale and offset; in NCHW those
+			// constants carry shape [C, H, W] and broadcast over the batch.
+			mean, variance := l.RunningStats()
+			gamma, beta := l.Params()
+			n := gamma.Cols
+			scale := make([]float32, n)
+			offset := make([]float32, n)
+			for i := 0; i < n; i++ {
+				s := gamma.Data[i] / float32(math.Sqrt(float64(variance[i]+l.Eps)))
+				scale[i] = s
+				offset[i] = beta[i] - mean[i]*s
+			}
+			dims := []int64{int64(n)}
+			if spatial {
+				if n != c*h*w {
+					return nil, fmt.Errorf("onnx: %s: batchnorm width %d != %dx%dx%d", name, n, c, h, w)
+				}
+				dims = []int64{int64(c), int64(h), int64(w)}
+			}
+			sName := g.tensor(name+"_scale", dims, scale)
+			oName := g.tensor(name+"_offset", dims, offset)
+			cur = g.add("Mul", []string{cur, sName}, nil)
+			cur = g.add("Add", []string{cur, oName}, nil)
+		case *tensai.Dropout:
+			// Identity at inference time.
+		case *tensai.ReLU:
+			cur = g.add("Relu", []string{cur}, nil)
+		case *tensai.LeakyReLU:
+			cur = g.add("LeakyRelu", []string{cur}, attrFloatv("alpha", float32(l.Alpha)))
+		case *tensai.Sigmoid:
+			cur = g.add("Sigmoid", []string{cur}, nil)
+		case *tensai.Tanh:
+			cur = g.add("Tanh", []string{cur}, nil)
+		case *tensai.Softmax:
+			if spatial {
+				return nil, fmt.Errorf("onnx: %s: softmax needs flattened features", name)
+			}
+			cur = g.add("Softmax", []string{cur}, nil) // axis defaults to -1
+		default:
+			return nil, fmt.Errorf("onnx: unsupported layer %T", layer)
+		}
+	}
+
+	outDims := []int64{1, int64(features)}
+	if spatial {
+		outDims = []int64{1, int64(c), int64(h), int64(w)}
+	}
+	return encode(g, inputDims, cur, outDims), nil
+}
+
+func valueInfo(p *pbuf, field int, name string, dims []int64) {
+	p.Msg(field, func(v *pbuf) {
+		v.Str(1, name)
+		v.Msg(2, func(t *pbuf) {
+			t.Msg(1, func(tt *pbuf) {
+				tt.Int(1, dtFloat)
+				tt.Msg(2, func(sh *pbuf) {
+					for _, d := range dims {
+						sh.Msg(1, func(dim *pbuf) { dim.Int(1, d) })
+					}
+				})
+			})
+		})
+	})
+}
+
+func encode(g *graph, inputDims []int64, output string, outputDims []int64) []byte {
+	var p pbuf
+	p.Int(1, irVersion)
+	p.Str(2, "tensai")
+	p.Msg(8, func(op *pbuf) {
+		op.Str(1, "")
+		op.Int(2, opsetVersion)
+	})
+	p.Msg(7, func(gr *pbuf) {
+		gr.Str(2, "tensai")
+		for _, n := range g.nodes {
+			gr.Msg(1, func(np *pbuf) {
+				for _, in := range n.inputs {
+					np.Str(1, in)
+				}
+				np.Str(2, n.output)
+				np.Str(4, n.op)
+				if n.attr != nil {
+					n.attr(np)
+				}
+			})
+		}
+		for _, ini := range g.inits {
+			gr.Msg(5, func(tp *pbuf) {
+				for _, d := range ini.dims {
+					tp.Int(1, d)
+				}
+				tp.Int(2, dtFloat)
+				tp.Str(8, ini.name)
+				raw := make([]byte, 0, len(ini.data)*4)
+				for _, f := range ini.data {
+					raw = binary.LittleEndian.AppendUint32(raw, math.Float32bits(f))
+				}
+				tp.Bytes(9, raw)
+			})
+		}
+		valueInfo(gr, 11, "input", inputDims)
+		valueInfo(gr, 12, output, outputDims)
+	})
+	return p.b
+}
+
+// MarshalFile writes the marshaled model to a file.
+func MarshalFile(path string, m *tensai.Sequential) error {
+	data, err := Marshal(m)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/encoding/onnx/marshal_test.go
+++ b/encoding/onnx/marshal_test.go
@@ -1,0 +1,122 @@
+package onnx
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	tensai "github.com/mattn/tensai"
+)
+
+func trainStep(t *testing.T, m *tensai.Sequential, in, out int, classes bool, rng *rand.Rand) {
+	t.Helper()
+	x := tensai.NewMatrix(8, in)
+	for i := range x.Data {
+		x.Data[i] = float32(rng.NormFloat64())
+	}
+	var y *tensai.Matrix
+	if classes {
+		y = tensai.NewMatrix(8, 1)
+		for i := range y.Data {
+			y.Data[i] = float32(rng.Intn(out))
+		}
+	} else {
+		y = tensai.NewMatrix(8, out)
+		for i := range y.Data {
+			y.Data[i] = float32(rng.NormFloat64())
+		}
+	}
+	if _, err := m.FitStep(x, y); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMarshalMLP(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	m := tensai.NewSequential()
+	m.Add(tensai.NewDense(16))
+	m.Add(&tensai.Tanh{})
+	m.Add(tensai.NewBatchNorm())
+	m.Add(tensai.NewDropout(0.5))
+	m.Add(tensai.NewDense(8))
+	m.Add(&tensai.LeakyReLU{Alpha: 0.1})
+	m.Add(tensai.NewDense(3))
+	m.Add(&tensai.Softmax{})
+	if err := m.Compile(10, tensai.MeanSquaredError{}, tensai.NewAdam(0.01)); err != nil {
+		t.Fatal(err)
+	}
+	trainStep(t, m, 10, 3, false, rng)
+
+	data, err := Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(data) == 0 || !bytes.Contains(data, []byte("tensai")) {
+		t.Fatal("marshaled model looks wrong")
+	}
+	for _, op := range []string{"Gemm", "Tanh", "Mul", "Add", "LeakyRelu", "Softmax"} {
+		if !bytes.Contains(data, []byte(op)) {
+			t.Fatalf("missing op %s", op)
+		}
+	}
+	if bytes.Contains(data, []byte("Dropout")) {
+		t.Fatal("dropout must be dropped")
+	}
+	// Marshal must be deterministic.
+	again, err := Marshal(m)
+	if err != nil || !bytes.Equal(data, again) {
+		t.Fatal("marshal is not deterministic")
+	}
+}
+
+func TestMarshalCNN(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	m := tensai.NewSequential()
+	m.Add(tensai.NewConv2D(8, 8, 2, 6, 3, 1, 1))
+	m.Add(&tensai.ReLU{})
+	m.Add(tensai.NewMaxPool2D(8, 8, 6, 2))
+	m.Add(tensai.NewConv2D(4, 4, 6, 4, 3, 1, 0))
+	m.Add(&tensai.Sigmoid{})
+	m.Add(tensai.NewDense(5))
+	if err := m.Compile(8*8*2, tensai.SoftmaxCrossEntropy{}, tensai.NewAdam(0.01)); err != nil {
+		t.Fatal(err)
+	}
+	trainStep(t, m, 8*8*2, 5, true, rng)
+
+	data, err := Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, op := range []string{"Conv", "MaxPool", "Flatten", "Gemm"} {
+		if !bytes.Contains(data, []byte(op)) {
+			t.Fatalf("missing op %s", op)
+		}
+	}
+}
+
+func TestMarshalErrors(t *testing.T) {
+	if _, err := Marshal(tensai.NewSequential()); err == nil {
+		t.Fatal("expected error for empty model")
+	}
+
+	m := tensai.NewSequential()
+	m.Add(&tensai.ReLU{})
+	if err := m.Compile(4, tensai.MeanSquaredError{}, tensai.NewSGD(0.1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Marshal(m); err == nil {
+		t.Fatal("expected error for activation-first model")
+	}
+
+	rng := rand.New(rand.NewSource(3))
+	sm := tensai.NewSequential()
+	sm.Add(tensai.NewConv2D(4, 4, 1, 2, 3, 1, 1))
+	sm.Add(&tensai.Softmax{})
+	if err := sm.Compile(16, tensai.MeanSquaredError{}, tensai.NewAdam(0.01)); err != nil {
+		t.Fatal(err)
+	}
+	trainStep(t, sm, 16, 32, false, rng)
+	if _, err := Marshal(sm); err == nil {
+		t.Fatal("expected error for softmax on spatial features")
+	}
+}

--- a/encoding/onnx/proto.go
+++ b/encoding/onnx/proto.go
@@ -1,0 +1,62 @@
+package onnx
+
+// A minimal protocol-buffers writer — varints, fixed32, and
+// length-delimited fields are all ONNX needs — so the encoder stays
+// dependency-free like the rest of tensai.
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+type pbuf struct {
+	b []byte
+}
+
+func (p *pbuf) varint(v uint64) {
+	p.b = binary.AppendUvarint(p.b, v)
+}
+
+func (p *pbuf) key(field, wire int) {
+	p.varint(uint64(field)<<3 | uint64(wire))
+}
+
+// Int emits an int64 field (wire type 0).
+func (p *pbuf) Int(field int, v int64) {
+	p.key(field, 0)
+	p.varint(uint64(v))
+}
+
+// Float emits a float field (wire type 5).
+func (p *pbuf) Float(field int, f float32) {
+	p.key(field, 5)
+	p.b = binary.LittleEndian.AppendUint32(p.b, math.Float32bits(f))
+}
+
+// Bytes emits a length-delimited field (wire type 2).
+func (p *pbuf) Bytes(field int, b []byte) {
+	p.key(field, 2)
+	p.varint(uint64(len(b)))
+	p.b = append(p.b, b...)
+}
+
+// Str emits a string field.
+func (p *pbuf) Str(field int, s string) {
+	p.Bytes(field, []byte(s))
+}
+
+// Msg emits a nested message built by fn.
+func (p *pbuf) Msg(field int, fn func(*pbuf)) {
+	var sub pbuf
+	fn(&sub)
+	p.Bytes(field, sub.b)
+}
+
+// Ints emits a packed repeated int64 field.
+func (p *pbuf) Ints(field int, vs []int64) {
+	var sub pbuf
+	for _, v := range vs {
+		sub.varint(uint64(v))
+	}
+	p.Bytes(field, sub.b)
+}

--- a/encoding/onnx/verify_onnxruntime.py
+++ b/encoding/onnx/verify_onnxruntime.py
@@ -1,0 +1,32 @@
+"""Numeric verification of exported models against onnxruntime.
+
+Not run in CI (needs `pip install onnx onnxruntime numpy`). Generate the
+model/reference files with a small Go program that calls MarshalFile and
+writes the input and tensai.Predict output as JSON {"input": [...],
+"output": [...]}, then run: python verify_onnxruntime.py name (1,C,H,W)
+"""
+import ast
+import json
+import sys
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+
+def run(name, shape):
+    model = onnx.load(f"{name}.onnx")
+    onnx.checker.check_model(model)
+    ref = json.load(open(f"{name}.json"))
+    x = np.array(ref["input"], dtype=np.float32).reshape(shape)
+    sess = ort.InferenceSession(f"{name}.onnx", providers=["CPUExecutionProvider"])
+    out = sess.run(None, {"input": x})[0].reshape(-1)
+    want = np.array(ref["output"], dtype=np.float32)
+    err = np.max(np.abs(out - want) / (1 + np.abs(want)))
+    print(f"{name}: checker OK, max rel err vs tensai Predict = {err:.2e}")
+    assert err < 1e-5, (out[:5], want[:5])
+
+
+if __name__ == "__main__":
+    run(sys.argv[1], ast.literal_eval(sys.argv[2]))
+    print("onnxruntime output matches tensai")


### PR DESCRIPTION
Completes the encoding trilogy: `encoding/onnx` marshals trained Sequential models into ONNX (opset 13, FP32) through a hand-written protobuf writer, keeping the package dependency-free like tflite and safetensors. Layer support matches the TFLite export, but with no layout conversion anywhere — ONNX convolutions are NCHW, which is exactly tensai's channel-major row layout, so only Conv weights transpose. onnx.checker accepts the output and onnxruntime reproduces `tensai.Predict` to ~3e-8 relative error on an MLP and a two-conv CNN (procedure in `verify_onnxruntime.py`); unit tests cover the op inventory, determinism, and unsupported-shape errors.