### PR TITLE
examples: add qwen, a modern instruct LLM chatting in pure Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _example/dataset/dataset
 /.codex/
 _example/mnist/data/
 _example/gpt2/data/
+_example/qwen/data/
 /charrnn.json
 /graph.png
 /graph.svg

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ _example/dot        Graphviz DOT export of the z = x + y graph
 _example/tensor     Tour of the n-d Tensor: broadcasting, batched MatMul, attention
 _example/wgpu       WebGPU MatMul: adapter info, CPU cross-check, GPU vs CPU sweep
 _example/gpt2       The published GPT-2 (124M) checkpoint generating text in pure Go
+_example/qwen       Qwen2.5-0.5B-Instruct chatting in pure Go: RoPE, GQA, SwiGLU
 ```
 
 ## Usage
@@ -197,6 +198,14 @@ The greedy continuation matches GPT-2's well-known reference output token for to
 The prompt runs through the model as one batched pass; with `-gpu` (built with `-tags wgpu` or `wgpu24`) every block's causal multi-head attention becomes a single masked dispatch on the GPU. A 600-token prompt prefills 1.5x faster even through dozen inside WSL2; native drivers gain more.
 
 `-q8` quantizes the decode-path weights to int8 (weight-only, per-column scales) and doubles generation — 23 to 46 tok/s on the same machine — because decode streams the whole checkpoint per token and int8 pulls a quarter of the bytes. The text stays coherent but greedy decoding no longer reproduces the float32 reference tokens exactly; use the default float32 path for the reference check.
+
+`_example/qwen` does the same for a modern instruction-tuned model: Qwen2.5-0.5B-Instruct, with RMSNorm, rotary position embeddings, grouped-query attention, and a SwiGLU MLP, its BF16 checkpoint loaded through the same safetensors reader and its ChatML template applied around the prompt. Dimensions come from config.json, so other Qwen2 sizes load unchanged if they fit in memory:
+
+```
+$ GOEXPERIMENT=simd go run ./_example/qwen -q8 -prompt "What is the capital of France?"
+The capital of France is Paris.
+43 tokens in 3.4s (12.6 tok/s)
+```
 
 ### Automatic differentiation
 
@@ -371,7 +380,8 @@ go run ./_example/iris
 go run ./_example/charrnn
 go run ./_example/plasma
 go run ./_example/tensor
-GOEXPERIMENT=simd go run ./_example/gpt2   # downloads the GPT-2 checkpoint (~550MB) on first run
+GOEXPERIMENT=simd go run ./_example/gpt2          # downloads the GPT-2 checkpoint (~550MB) on first run
+GOEXPERIMENT=simd go run ./_example/qwen -q8      # downloads Qwen2.5-0.5B-Instruct (~1GB) on first run
 go run -tags wgpu ./_example/wgpu          # needs wgpu-native, see above
 go run -tags wgpu ./_example/wgpu -sweep  # GPU vs CPU across sizes
 go test ./...

--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -1,0 +1,175 @@
+// Command qwen runs the published Qwen2.5-0.5B-Instruct checkpoint in pure
+// Go: BF16 weights load through encoding/safetensors, text goes through
+// the tokenizer package, and the Qwen2 architecture — RMSNorm, rotary
+// embeddings, grouped-query attention, SwiGLU — decodes with a KV cache.
+// Build with GOEXPERIMENT=simd and pass -q8 for int8 decode weights.
+//
+// On first run it downloads the checkpoint (~1GB), tokenizer, and config
+// from Hugging Face into -data. The prompt is wrapped in the ChatML
+// template Qwen was instruction-tuned on; -raw skips the template for
+// plain completion:
+//
+//	GOEXPERIMENT=simd go run ./_example/qwen -q8 -prompt "What is the capital of France?"
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/mattn/tensai/tokenizer"
+)
+
+const hfBase = "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/resolve/main/"
+
+func fetch(dir, name string) (string, error) {
+	path := filepath.Join(dir, name)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "downloading %s...\n", name)
+	resp, err := http.Get(hfBase + name)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("downloading %s: %s", name, resp.Status)
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return path, os.Rename(tmp, path)
+}
+
+func sample(logits []float32, temp float64, rng *rand.Rand) int {
+	if temp <= 0 {
+		best := 0
+		for i, v := range logits {
+			if v > logits[best] {
+				best = i
+			}
+		}
+		return best
+	}
+	type cand struct {
+		id int
+		p  float64
+	}
+	cands := make([]cand, len(logits))
+	maxl := logits[0]
+	for _, v := range logits {
+		if v > maxl {
+			maxl = v
+		}
+	}
+	var sum float64
+	for i, v := range logits {
+		p := math.Exp(float64(v-maxl) / temp)
+		cands[i] = cand{i, p}
+		sum += p
+	}
+	sort.Slice(cands, func(a, b int) bool { return cands[a].p > cands[b].p })
+	r := rng.Float64() * sum
+	for _, c := range cands {
+		r -= c.p
+		if r <= 0 {
+			return c.id
+		}
+	}
+	return cands[0].id
+}
+
+func main() {
+	dataDir := flag.String("data", "_example/qwen/data", "directory for the downloaded model files")
+	prompt := flag.String("prompt", "What is the capital of France?", "user message (or raw prompt with -raw)")
+	system := flag.String("system", "You are Qwen, created by Alibaba Cloud. You are a helpful assistant.", "system message for the chat template")
+	raw := flag.Bool("raw", false, "skip the chat template, complete the prompt as-is")
+	n := flag.Int("n", 256, "max tokens to generate")
+	temp := flag.Float64("temp", 0, "sampling temperature; 0 = greedy")
+	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
+	q8 := flag.Bool("q8", false, "decode against int8-quantized weights")
+	flag.Parse()
+
+	var paths [3]string
+	for i, name := range []string{"model.safetensors", "tokenizer.json", "config.json"} {
+		p, err := fetch(*dataDir, name)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		paths[i] = p
+	}
+
+	tok, err := tokenizer.Load(paths[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	start := time.Now()
+	model, err := loadQwen(paths[2], paths[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "loaded %s (%d layers, hidden %d) in %v\n",
+		"qwen2.5-0.5b-instruct", model.cfg.Layers, model.cfg.HiddenSize,
+		time.Since(start).Round(time.Millisecond))
+	if *q8 {
+		start = time.Now()
+		model.quantize()
+		fmt.Fprintf(os.Stderr, "quantized to int8 in %v\n", time.Since(start).Round(time.Millisecond))
+	}
+
+	text := *prompt
+	if !*raw {
+		text = "<|im_start|>system\n" + *system + "<|im_end|>\n" +
+			"<|im_start|>user\n" + *prompt + "<|im_end|>\n" +
+			"<|im_start|>assistant\n"
+	}
+	ids := tok.Encode(text)
+	fmt.Fprintf(os.Stderr, "prompt: %d tokens\n", len(ids))
+	imEnd, _ := tok.ID("<|im_end|>")
+	eot, _ := tok.ID("<|endoftext|>")
+	rng := rand.New(rand.NewSource(*seed))
+
+	start = time.Now()
+	var logits []float32
+	for pos, id := range ids {
+		logits = model.step(id, pos)
+	}
+	steps := len(ids)
+	for i := 0; i < *n; i++ {
+		next := sample(logits, *temp, rng)
+		if next == imEnd || next == eot {
+			break
+		}
+		fmt.Print(tok.Decode([]int{next}))
+		logits = model.step(next, steps)
+		steps++
+	}
+	fmt.Println()
+	fmt.Fprintf(os.Stderr, "%d tokens in %v (%.1f tok/s)\n",
+		steps, time.Since(start).Round(time.Millisecond),
+		float64(steps)/time.Since(start).Seconds())
+}

--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -1,0 +1,272 @@
+package main
+
+// Qwen2-family inference: pre-norm transformer blocks with RMSNorm, rotary
+// position embeddings, grouped-query attention, and a SwiGLU MLP, decoded
+// one token at a time with a KV cache. Dimensions come from config.json,
+// so any Qwen2 checkpoint that fits in memory works; every matvec runs on
+// tensai's Dot kernel or, with -q8, the int8 kernel.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+
+	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/encoding/safetensors"
+)
+
+type config struct {
+	HiddenSize   int     `json:"hidden_size"`
+	Intermediate int     `json:"intermediate_size"`
+	Layers       int     `json:"num_hidden_layers"`
+	Heads        int     `json:"num_attention_heads"`
+	KVHeads      int     `json:"num_key_value_heads"`
+	RMSEps       float64 `json:"rms_norm_eps"`
+	RopeTheta    float64 `json:"rope_theta"`
+	Vocab        int     `json:"vocab_size"`
+	TieEmbedding bool    `json:"tie_word_embeddings"`
+	EOS          int     `json:"eos_token_id"`
+	ModelType    string  `json:"model_type"`
+}
+
+type qblock struct {
+	ln1, ln2          []float32
+	wq, wk, wv, wo    *tensai.Matrix // [in, out] after transposing HF's [out, in]
+	bq, bk, bv        []float32
+	wGate, wUp, wDown *tensai.Matrix
+	qq, qk, qv, qo    *tensai.QMatrix
+	qGate, qUp, qDown *tensai.QMatrix
+	kc, vc            [][]float32 // KV cache, kvHeads*headDim per position
+}
+
+type qwen struct {
+	cfg    config
+	headSz int
+	embed  *tensai.Tensor // [vocab, hidden]
+	lmT    *tensai.Matrix // [hidden, vocab]
+	qLmT   *tensai.QMatrix
+	normW  []float32
+	blocks []qblock
+}
+
+func loadConfig(path string) (config, error) {
+	var c config
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return c, err
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return c, err
+	}
+	if c.ModelType != "qwen2" {
+		return c, fmt.Errorf("unsupported model_type %q (this example speaks qwen2)", c.ModelType)
+	}
+	return c, nil
+}
+
+func loadQwen(cfgPath, weightsPath string) (*qwen, error) {
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	f, err := safetensors.Open(weightsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	vec := func(name string) []float32 {
+		t, err := f.Tensor(name)
+		if err != nil {
+			panic(err)
+		}
+		return t.Data
+	}
+	// HF Linear weights are [out, in]; transpose once so matvec sees
+	// [in, out].
+	lin := func(name string) *tensai.Matrix {
+		t, err := f.Tensor(name)
+		if err != nil {
+			panic(err)
+		}
+		m, err := t.Matrix()
+		if err != nil {
+			panic(err)
+		}
+		return m.T()
+	}
+
+	m := &qwen{cfg: cfg, headSz: cfg.HiddenSize / cfg.Heads}
+	m.embed, err = f.Tensor("model.embed_tokens.weight")
+	if err != nil {
+		return nil, err
+	}
+	em, err := m.embed.Matrix()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.TieEmbedding {
+		m.lmT = em.T()
+	} else {
+		m.lmT = lin("lm_head.weight")
+	}
+	m.normW = vec("model.norm.weight")
+	m.blocks = make([]qblock, cfg.Layers)
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		p := fmt.Sprintf("model.layers.%d.", i)
+		b.ln1 = vec(p + "input_layernorm.weight")
+		b.ln2 = vec(p + "post_attention_layernorm.weight")
+		b.wq, b.bq = lin(p+"self_attn.q_proj.weight"), vec(p+"self_attn.q_proj.bias")
+		b.wk, b.bk = lin(p+"self_attn.k_proj.weight"), vec(p+"self_attn.k_proj.bias")
+		b.wv, b.bv = lin(p+"self_attn.v_proj.weight"), vec(p+"self_attn.v_proj.bias")
+		b.wo = lin(p + "self_attn.o_proj.weight")
+		b.wGate = lin(p + "mlp.gate_proj.weight")
+		b.wUp = lin(p + "mlp.up_proj.weight")
+		b.wDown = lin(p + "mlp.down_proj.weight")
+	}
+	return m, nil
+}
+
+// quantize builds int8 twins of every matvec weight.
+func (m *qwen) quantize() {
+	m.qLmT = tensai.QuantizeMatrix(m.lmT)
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		b.qq = tensai.QuantizeMatrix(b.wq)
+		b.qk = tensai.QuantizeMatrix(b.wk)
+		b.qv = tensai.QuantizeMatrix(b.wv)
+		b.qo = tensai.QuantizeMatrix(b.wo)
+		b.qGate = tensai.QuantizeMatrix(b.wGate)
+		b.qUp = tensai.QuantizeMatrix(b.wUp)
+		b.qDown = tensai.QuantizeMatrix(b.wDown)
+	}
+}
+
+func rmsnorm(x, w []float32, eps float64) []float32 {
+	var ss float64
+	for _, v := range x {
+		ss += float64(v) * float64(v)
+	}
+	inv := 1 / math.Sqrt(ss/float64(len(x))+eps)
+	out := make([]float32, len(x))
+	for i, v := range x {
+		out[i] = float32(float64(v)*inv) * w[i]
+	}
+	return out
+}
+
+// mv computes x @ W (+ bias), on the int8 twin when it exists.
+func mv(x []float32, w *tensai.Matrix, q *tensai.QMatrix, bias []float32) []float32 {
+	var out []float32
+	if q != nil {
+		out = make([]float32, q.Cols)
+		if err := q.MatVec(x, out); err != nil {
+			panic(err)
+		}
+	} else {
+		xm := &tensai.Matrix{Rows: 1, Cols: len(x), Data: x}
+		o, err := tensai.Dot(xm, w)
+		if err != nil {
+			panic(err)
+		}
+		out = o.Data
+	}
+	if bias != nil {
+		for i := range out {
+			out[i] += bias[i]
+		}
+	}
+	return out
+}
+
+// rope rotates one head in place, half-split style: pair (i, i+dh/2).
+func (m *qwen) rope(h []float32, pos int) {
+	half := m.headSz / 2
+	for i := 0; i < half; i++ {
+		freq := math.Pow(m.cfg.RopeTheta, -2*float64(i)/float64(m.headSz))
+		s, c := math.Sincos(float64(pos) * freq)
+		a, b := float64(h[i]), float64(h[i+half])
+		h[i] = float32(a*c - b*s)
+		h[i+half] = float32(b*c + a*s)
+	}
+}
+
+// step feeds one token at position pos and returns the next-token logits.
+func (m *qwen) step(token, pos int) []float32 {
+	cfg := m.cfg
+	hs := cfg.HiddenSize
+	group := cfg.Heads / cfg.KVHeads
+
+	x := make([]float32, hs)
+	copy(x, m.embed.Data[token*hs:(token+1)*hs])
+
+	for li := range m.blocks {
+		b := &m.blocks[li]
+		a := rmsnorm(x, b.ln1, cfg.RMSEps)
+		q := mv(a, b.wq, b.qq, b.bq)
+		k := mv(a, b.wk, b.qk, b.bk)
+		v := mv(a, b.wv, b.qv, b.bv)
+		for h := 0; h < cfg.Heads; h++ {
+			m.rope(q[h*m.headSz:(h+1)*m.headSz], pos)
+		}
+		for h := 0; h < cfg.KVHeads; h++ {
+			m.rope(k[h*m.headSz:(h+1)*m.headSz], pos)
+		}
+		b.kc = append(b.kc, k)
+		b.vc = append(b.vc, v)
+
+		attn := make([]float32, hs)
+		steps := len(b.kc)
+		scores := make([]float64, steps)
+		scale := 1 / math.Sqrt(float64(m.headSz))
+		for h := 0; h < cfg.Heads; h++ {
+			qOff := h * m.headSz
+			kvOff := (h / group) * m.headSz
+			maxs := math.Inf(-1)
+			for t := 0; t < steps; t++ {
+				var s float64
+				kt := b.kc[t]
+				for i := 0; i < m.headSz; i++ {
+					s += float64(q[qOff+i]) * float64(kt[kvOff+i])
+				}
+				s *= scale
+				scores[t] = s
+				if s > maxs {
+					maxs = s
+				}
+			}
+			var sum float64
+			for t := 0; t < steps; t++ {
+				scores[t] = math.Exp(scores[t] - maxs)
+				sum += scores[t]
+			}
+			for t := 0; t < steps; t++ {
+				p := float32(scores[t] / sum)
+				vt := b.vc[t]
+				for i := 0; i < m.headSz; i++ {
+					attn[qOff+i] += p * vt[kvOff+i]
+				}
+			}
+		}
+		proj := mv(attn, b.wo, b.qo, nil)
+		for i := range x {
+			x[i] += proj[i]
+		}
+
+		a = rmsnorm(x, b.ln2, cfg.RMSEps)
+		gate := mv(a, b.wGate, b.qGate, nil)
+		up := mv(a, b.wUp, b.qUp, nil)
+		for i := range gate {
+			g := float64(gate[i])
+			gate[i] = float32(g/(1+math.Exp(-g))) * up[i] // silu(gate) * up
+		}
+		down := mv(gate, b.wDown, b.qDown, nil)
+		for i := range x {
+			x[i] += down[i]
+		}
+	}
+
+	return mv(rmsnorm(x, m.normW, cfg.RMSEps), m.lmT, m.qLmT, nil)
+}


### PR DESCRIPTION
Runs Qwen2.5-0.5B-Instruct end to end in pure Go: the BF16 checkpoint loads through `encoding/safetensors`, text goes through the `tokenizer` package, and the Qwen2 architecture — RMSNorm, rotary embeddings, grouped-query attention, SwiGLU — decodes with a KV cache, every matvec on tensai's Dot kernel or the int8 kernel with `-q8`. Dimensions come from config.json, so other Qwen2 sizes load unchanged. The prompt is wrapped in the ChatML template; behavioral checks land — correct factual answers, a well-formed haiku, Japanese answered in Japanese — at 12.6 tok/s with `-q8` on the AVX2 build, right on the bandwidth model's prediction for a 0.5B model.