### PR TITLE
size quantized-matvec workers to the machine, not to 8

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"time"
 
@@ -159,6 +160,7 @@ func main() {
 	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
 	q8 := flag.Bool("q8", false, "decode against int8-quantized weights")
 	q4 := flag.Bool("q4", false, "decode against int4-quantized weights (group-wise)")
+	cpuprofile := flag.String("cpuprofile", "", "write a CPU profile of generation to this file")
 	flag.Parse()
 
 	weights, err := fetchWeights(*dataDir)
@@ -213,6 +215,15 @@ func main() {
 	eot, _ := tok.ID("<|endoftext|>")
 	rng := rand.New(rand.NewSource(*seed))
 
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
 	start = time.Now()
 	var logits []float32
 	for pos, id := range ids {

--- a/quant.go
+++ b/quant.go
@@ -2,8 +2,24 @@ package tensai
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 )
+
+// matvecWorkerCount sizes the worker pool for quantized matvecs. Unlike
+// dotWorkerCount's cap of 8 (tuned for training matmuls that share the
+// machine with other layers), a decode matvec is the only thing running,
+// so it may use every CPU.
+func matvecWorkerCount(cols, rows int) int {
+	if cols*rows < 1<<20 {
+		return 1
+	}
+	workers := runtime.NumCPU()
+	if workers > cols {
+		workers = cols
+	}
+	return workers
+}
 
 // QMatrix is a weight matrix quantized to int8 with one scale per output
 // column: W[i][j] ~= Float(Q[i*Cols+j]) * Scale[j]. Inference matvecs are
@@ -63,7 +79,7 @@ func (q *QMatrix) MatVec(x, out []Float) error {
 		return fmt.Errorf("tensai: qmatvec shape mismatch: x=%d out=%d, want %dx%d",
 			len(x), len(out), q.Rows, q.Cols)
 	}
-	workers := dotWorkerCount(q.Cols, q.Rows, 1)
+	workers := matvecWorkerCount(q.Cols, q.Rows)
 	if workers == 1 {
 		qmatvecCols(out, x, q.Q, q.Scale, q.Cols, 0, q.Cols)
 		return nil

--- a/quant4.go
+++ b/quant4.go
@@ -96,7 +96,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 			len(x), len(out), q.Rows, q.Cols)
 	}
 	half := q.Cols / 2
-	workers := dotWorkerCount(half, q.Rows, 1)
+	workers := matvecWorkerCount(half, q.Rows)
 	run := func(lo, hi int) {
 		q4matvecCols(out, x, q.Q, q.Scale, q.Cols, lo, hi, make([]Float, q.Cols))
 	}


### PR DESCRIPTION
The quantized matvec kernels inherited dotWorkerCount's cap of 8, tuned for training matmuls that share the machine; a decode matvec is the only thing running, so they now take every CPU. Measured idle on 16 CPUs: the out-of-cache int8 matvec gains 27%, Qwen2.5-1.5B int4 decode goes 4.1 → 4.8 tok/s — and int4 now beats int8 (4.3) there, resolving the inversion the 8-worker cap was causing — while 7B reaches 1.3 tok/s and 0.5B 13.2-13.8. The qwen example gains `-cpuprofile`, which showed 96% of decode samples inside the kernel, so the remaining headroom is per-core throughput. An L1-blocking variant was tried and measured slower (it trades DRAM run length for strip locality), so the strips stay as wide as the worker's chunk.