### PR TITLE
move the int4 matvec onto the integer pairwise kernel, 1.4x faster

### DIFF
--- a/quant4.go
+++ b/quant4.go
@@ -5,39 +5,35 @@ import (
 	"sync"
 )
 
-// q4Group is the number of input rows sharing one scale. Smaller groups
-// track the weight distribution closer but pay more per-group folding
-// traffic in the kernel; 64 keeps Qwen-class models accurate while
-// halving the fold cost of the conventional 32.
+// q4Group is the number of input rows sharing one scale. 64 keeps
+// Qwen-class models accurate while halving the per-group folding work of
+// the conventional 32.
 const q4Group = 64
 
 // Q4Matrix is a weight matrix quantized to 4 bits with one scale per
-// (row group, output column) — the group-wise weight-only scheme that
-// keeps int4 usable for real models. Nibbles pack column-split: the byte
-// at (row, j) holds column j in its low nibble and column j+Cols/2 in its
-// high one, so a vector load unpacks into two runs of consecutive
-// columns. Values are stored offset-binary (0..15 encodes -8..7).
+// (64-row group, output column). The byte at (i/2)*Cols + j holds column j
+// of an interleaved row pair — row i (even) in the low nibble, row i+1 in
+// the high one, offset-binary (0..15 encodes -8..7), with a zero row
+// appended when Rows is odd. That pairing matches the u8 x s8 pairwise
+// multiply-add the AVX2 kernel is built on, the same W-A7 scheme as
+// QMatrix: activations quantize per call to 7 bits, and since nibbles are
+// at most 15 the i16 pair sums sit far inside saturation.
 type Q4Matrix struct {
 	Rows, Cols int
-	Q          []byte // Rows x Cols/2, padded so 16-byte loads stay in bounds
+	Q          []uint8 // row pairs x Cols, padded for 16-byte loads
 	Scale      []Float
 }
 
 // QuantizeMatrix4 quantizes group-wise, symmetric with round-to-nearest.
-// The column count must be even.
 func QuantizeMatrix4(m *Matrix) (*Q4Matrix, error) {
-	if m.Cols%2 != 0 {
-		return nil, fmt.Errorf("tensai: quantize4 needs an even column count, got %d", m.Cols)
-	}
-	half := m.Cols / 2
+	pairs := (m.Rows + 1) / 2
 	groups := (m.Rows + q4Group - 1) / q4Group
 	q := &Q4Matrix{
 		Rows:  m.Rows,
 		Cols:  m.Cols,
-		Q:     make([]byte, m.Rows*half+16),
+		Q:     make([]uint8, pairs*m.Cols+16),
 		Scale: make([]Float, groups*m.Cols),
 	}
-	nib := make([]uint8, m.Rows)
 	for j := 0; j < m.Cols; j++ {
 		for g := 0; g < groups; g++ {
 			rlo := g * q4Group
@@ -54,101 +50,96 @@ func QuantizeMatrix4(m *Matrix) (*Q4Matrix, error) {
 			}
 			s := maxAbs / 7
 			q.Scale[g*m.Cols+j] = s
-			if s == 0 {
-				for i := rlo; i < rhi; i++ {
-					nib[i] = 8
-				}
-				continue
+			inv := Float(0)
+			if s != 0 {
+				inv = 1 / s
 			}
-			inv := 1 / s
 			for i := rlo; i < rhi; i++ {
-				v := m.Data[i*m.Cols+j] * inv
-				if v >= 0 {
-					v += 0.5
-				} else {
-					v -= 0.5
+				n := 0
+				if inv != 0 {
+					v := m.Data[i*m.Cols+j] * inv
+					if v >= 0 {
+						v += 0.5
+					} else {
+						v -= 0.5
+					}
+					n = int(v)
+					if n < -8 {
+						n = -8
+					} else if n > 7 {
+						n = 7
+					}
 				}
-				n := int(v)
-				if n < -8 {
-					n = -8
-				} else if n > 7 {
-					n = 7
-				}
-				nib[i] = uint8(n + 8)
+				q.Q[(i/2)*m.Cols+j] |= uint8(n+8) << (4 * (i % 2))
 			}
 		}
-		for i := 0; i < m.Rows; i++ {
-			if j < half {
-				q.Q[i*half+j] |= nib[i]
-			} else {
-				q.Q[i*half+j-half] |= nib[i] << 4
-			}
+		if m.Rows%2 == 1 {
+			q.Q[(m.Rows/2)*m.Cols+j] |= 8 << 4 // zero weight for the pad row
 		}
 	}
 	return q, nil
 }
 
 // MatVec computes out = x @ Q for a single activation row: len(x) must be
-// Rows and len(out) Cols. Column pairs are split across CPUs.
+// Rows and len(out) Cols. The activation row quantizes once per call, with
+// its per-group sums carrying the nibble offset correction.
 func (q *Q4Matrix) MatVec(x, out []Float) error {
 	if len(x) != q.Rows || len(out) != q.Cols {
 		return fmt.Errorf("tensai: q4matvec shape mismatch: x=%d out=%d, want %dx%d",
 			len(x), len(out), q.Rows, q.Cols)
 	}
-	half := q.Cols / 2
-	workers := matvecWorkerCount(half, q.Rows)
-	run := func(lo, hi int) {
-		q4matvecCols(out, x, q.Q, q.Scale, q.Cols, lo, hi, make([]Float, q.Cols))
+	xu, sx := quantizeActs(x)
+	gsum := make([]int32, (q.Rows+q4Group-1)/q4Group)
+	for i, u := range xu {
+		gsum[min(i/q4Group, len(gsum)-1)] += int32(u) - 64
 	}
+	workers := matvecWorkerCount(q.Cols, q.Rows)
 	if workers == 1 {
-		run(0, half)
+		q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.Cols, 0, q.Cols)
 		return nil
 	}
-	chunk := ((half+workers-1)/workers + 7) &^ 7
+	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
 	var wg sync.WaitGroup
-	for lo := 0; lo < half; lo += chunk {
-		hi := min(lo+chunk, half)
+	for lo := 0; lo < q.Cols; lo += chunk {
+		hi := min(lo+chunk, q.Cols)
 		wg.Add(1)
 		go func(lo, hi int) {
 			defer wg.Done()
-			run(lo, hi)
+			q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.Cols, lo, hi)
 		}(lo, hi)
 	}
 	wg.Wait()
 	return nil
 }
 
-// q4matvecColsGeneric accumulates the column pairs [lo,hi) and
-// [half+lo, half+hi) of out = x @ Q in pure Go: per 32-row group the
-// unscaled products gather in tmp, then fold into out under that group's
-// scales. q4matvecCols (see quant4_simd.go and quant4_generic.go)
-// dispatches to the AVX2 kernel when available.
-func q4matvecColsGeneric(out, x []Float, qw []byte, scale []Float, cols, lo, hi int, tmp []Float) {
-	half := cols / 2
+// q4matvecColsGeneric accumulates out[lo:hi] in pure Go over the same
+// 7-bit activations as the AVX2 kernel, so both builds agree exactly.
+// q4matvecCols (see quant4_simd.go and quant4_generic.go) dispatches to
+// the AVX2 kernel when available.
+func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, cols, lo, hi int) {
 	clear(out[lo:hi])
-	clear(out[half+lo : half+hi])
-	groups := (len(x) + q4Group - 1) / q4Group
-	for g := 0; g < groups; g++ {
-		rlo := g * q4Group
-		rhi := min(rlo+q4Group, len(x))
-		clear(tmp[lo:hi])
-		clear(tmp[half+lo : half+hi])
-		for i := rlo; i < rhi; i++ {
-			xi := x[i]
-			if xi == 0 {
-				continue
-			}
-			row := qw[i*half:]
+	pairs := len(xu) / 2
+	acc := make([]int32, hi-lo)
+	for g := 0; g < len(gsum); g++ {
+		ib := g * q4Group / 2
+		ie := min(ib+q4Group/2, pairs)
+		clear(acc)
+		for i2 := ib; i2 < ie; i2++ {
+			x0 := int32(xu[2*i2]) - 64
+			x1 := int32(xu[2*i2+1]) - 64
+			row := qw[i2*cols:]
 			for j := lo; j < hi; j++ {
 				b := row[j]
-				tmp[j] += xi * Float(int(b&0x0F)-8)
-				tmp[half+j] += xi * Float(int(b>>4)-8)
+				acc[j-lo] += int32(b&0x0F)*x0 + int32(b>>4)*x1
 			}
 		}
 		srow := scale[g*cols:]
+		corr := 8 * gsum[g]
 		for j := lo; j < hi; j++ {
-			out[j] += tmp[j] * srow[j]
-			out[half+j] += tmp[half+j] * srow[half+j]
+			out[j] += Float(acc[j-lo]-corr) * srow[j]
 		}
+	}
+	for j := lo; j < hi; j++ {
+		out[j] *= sx
 	}
 }

--- a/quant4_generic.go
+++ b/quant4_generic.go
@@ -5,6 +5,6 @@ package tensai
 // Portable dispatcher for the 4-bit matvec kernel; build with
 // GOEXPERIMENT=simd on amd64 for the AVX2 version in quant4_simd.go.
 
-func q4matvecCols(out, x []Float, qw []byte, scale []Float, cols, lo, hi int, tmp []Float) {
-	q4matvecColsGeneric(out, x, qw, scale, cols, lo, hi, tmp)
+func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, cols, lo, hi int) {
+	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, cols, lo, hi)
 }

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -2,56 +2,60 @@
 
 package tensai
 
-import (
-	"unsafe"
+import "simd/archsimd"
 
-	"simd/archsimd"
-)
-
-// AVX2 kernel for the 4-bit matvec: an 8-byte load carries 8 column pairs,
-// the low nibbles masked out directly and the high nibbles via a 16-bit
-// shift (AVX2 has no byte shift), both widened to float32 and FMA'd
-// against the broadcast activation. Group scales fold in vectorized at
-// each group boundary; the scalar tail runs through the generic body after
-// the vector state is cleared.
-func q4matvecCols(out, x []Float, qw []byte, scale []Float, cols, lo, hi int, tmp []Float) {
+// AVX2 kernel for the 4-bit matvec, sharing the u8 x s8 pairwise
+// multiply-add design of the int8 kernel: a load's low 8 bytes zero-extend
+// to u16 lanes, where masks and a shift split each byte's nibbles into the
+// adjacent-byte pair layout the multiply wants; the signed operand is the
+// broadcast 7-bit activation pair. Nibbles are at most 15, so pair sums
+// cannot approach saturation at any activation width. Each group of 32 row
+// pairs is one register-accumulated block: eight i32x8 accumulators cover
+// a 64-column tile (one cache line per pair row), and the group's scales
+// and offset correction fold in vectorized at the block boundary.
+func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, cols, lo, hi int) {
 	if !hasAVX2 {
-		q4matvecColsGeneric(out, x, qw, scale, cols, lo, hi, tmp)
+		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, cols, lo, hi)
 		return
 	}
-	half := cols / 2
-	vecEnd := lo + ((hi - lo) &^ 7)
+	pairs := len(xu) / 2
+	vecEnd := lo + ((hi - lo) &^ 63)
 	if vecEnd > lo {
-		mask := archsimd.BroadcastInt8x16(0x0F)
-		eight := archsimd.BroadcastFloat32x8(8)
+		mLo := archsimd.BroadcastUint16x8(0x000F)
+		mHi := archsimd.BroadcastUint16x8(0x0F00)
 		clear(out[lo:vecEnd])
-		clear(out[half+lo : half+vecEnd])
-		groups := (len(x) + q4Group - 1) / q4Group
-		for g := 0; g < groups; g++ {
-			rlo := g * q4Group
-			rhi := min(rlo+q4Group, len(x))
-			clear(tmp[lo:vecEnd])
-			clear(tmp[half+lo : half+vecEnd])
-			for i := rlo; i < rhi; i++ {
-				xv := archsimd.BroadcastFloat32x8(x[i])
-				row := qw[i*half:]
-				for j := lo; j < vecEnd; j += 8 {
-					v := loadI8x16(unsafe.Slice((*int8)(unsafe.Pointer(&row[j])), 16))
-					loNib := v.And(mask).ExtendLo8ToInt32().ConvertToFloat32().Sub(eight)
-					hiNib := v.AsUint16x8().ShiftAllRight(4).AsInt8x16().And(mask).ExtendLo8ToInt32().ConvertToFloat32().Sub(eight)
-					storeF32x8(loNib.MulAdd(xv, loadF32x8(tmp[j:])), tmp[j:])
-					storeF32x8(hiNib.MulAdd(xv, loadF32x8(tmp[half+j:])), tmp[half+j:])
+		for g := 0; g < len(gsum); g++ {
+			ib := g * q4Group / 2
+			ie := min(ib+q4Group/2, pairs)
+			corr := archsimd.BroadcastInt32x8(8 * gsum[g])
+			srow := scale[g*cols:]
+			for jt := lo; jt < vecEnd; jt += 64 {
+				var a [8]archsimd.Int32x8
+				for i2 := ib; i2 < ie; i2++ {
+					x0 := uint8(int8(int(xu[2*i2]) - 64))
+					x1 := uint8(int8(int(xu[2*i2+1]) - 64))
+					xp := archsimd.BroadcastUint16x8(uint16(x0) | uint16(x1)<<8).AsUint8x16().AsInt8x16()
+					row := qw[i2*cols+jt:]
+					for k := 0; k < 8; k++ {
+						v := loadU8x16(row[8*k:]).ExtendLo8ToUint16()
+						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi))
+						a[k] = a[k].Add(pair.AsUint8x16().DotProductPairsSaturated(xp).ExtendToInt32())
+					}
+				}
+				for k := 0; k < 8; k++ {
+					j := jt + 8*k
+					f := a[k].Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
+					storeF32x8(loadF32x8(out[j:]).Add(f), out[j:])
 				}
 			}
-			srow := scale[g*cols:]
-			for j := lo; j < vecEnd; j += 8 {
-				storeF32x8(loadF32x8(tmp[j:]).MulAdd(loadF32x8(srow[j:]), loadF32x8(out[j:])), out[j:])
-				storeF32x8(loadF32x8(tmp[half+j:]).MulAdd(loadF32x8(srow[half+j:]), loadF32x8(out[half+j:])), out[half+j:])
-			}
+		}
+		sxv := archsimd.BroadcastFloat32x8(sx)
+		for j := lo; j < vecEnd; j += 8 {
+			storeF32x8(loadF32x8(out[j:]).Mul(sxv), out[j:])
 		}
 	}
 	archsimd.ClearAVXUpperBits()
 	if vecEnd < hi {
-		q4matvecColsGeneric(out, x, qw, scale, cols, vecEnd, hi, tmp)
+		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, cols, vecEnd, hi)
 	}
 }

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -11,7 +11,8 @@ func TestQuantize4MatVec(t *testing.T) {
 	for _, c := range []struct{ rows, cols int }{
 		{768, 2304}, // parallel path
 		{64, 32},
-		{33, 10}, // partial final group, scalar tails
+		{33, 10}, // odd rows: pad pair, partial final group
+		{5, 7},   // odd columns, scalar tails everywhere
 		{1, 2},
 	} {
 		m := RandomMatrix(c.rows, c.cols, rng)
@@ -28,24 +29,23 @@ func TestQuantize4MatVec(t *testing.T) {
 			t.Fatalf("%dx%d: %v", c.rows, c.cols, err)
 		}
 
-		// Exact reference over the same quantized nibbles.
-		half := c.cols / 2
+		// Exact reference over the same nibbles and 7-bit activations.
+		xu, sx := quantizeActs(x)
 		groups := (c.rows + q4Group - 1) / q4Group
 		want := make([]float64, c.cols)
-		for g := 0; g < groups; g++ {
-			rlo, rhi := g*q4Group, min((g+1)*q4Group, c.rows)
-			for j := 0; j < c.cols; j++ {
-				var acc float64
+		for j := 0; j < c.cols; j++ {
+			for g := 0; g < groups; g++ {
+				rlo, rhi := g*q4Group, min((g+1)*q4Group, c.rows)
+				var acc, gs int64
 				for i := rlo; i < rhi; i++ {
-					b := q.Q[i*half+j%half]
-					n := int(b&0x0F) - 8
-					if j >= half {
-						n = int(b>>4) - 8
-					}
-					acc += float64(x[i]) * float64(n)
+					nib := int64(q.Q[(i/2)*c.cols+j]>>(4*(i%2))) & 0x0F
+					xs := int64(xu[i]) - 64
+					acc += nib * xs
+					gs += xs
 				}
-				want[j] += acc * float64(q.Scale[g*c.cols+j])
+				want[j] += float64(acc-8*gs) * float64(q.Scale[g*c.cols+j])
 			}
+			want[j] *= float64(sx)
 		}
 		var worst float64
 		for j := range want {
@@ -60,19 +60,25 @@ func TestQuantize4MatVec(t *testing.T) {
 				worst = d
 			}
 		}
-		if worst > 1.0 { // group-wise int4 stays close over these sizes
+		if worst > 2 { // int4 weights + 7-bit activations stay close
 			t.Fatalf("%dx%d: quantization error %v too large", c.rows, c.cols, worst)
 		}
 	}
 
-	if _, err := QuantizeMatrix4(NewMatrix(4, 3)); err == nil {
-		t.Fatal("expected error for odd column count")
-	}
-	q, err := QuantizeMatrix4(NewMatrix(4, 4))
+	q, err := QuantizeMatrix4(NewMatrix(4, 4)) // all zeros: scales are zero
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := q.MatVec(make([]Float, 3), make([]Float, 4)); err == nil {
+	out := make([]Float, 4)
+	if err := q.MatVec(make([]Float, 4), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range out {
+		if v != 0 {
+			t.Fatalf("zero matrix produced %v", out)
+		}
+	}
+	if err := q.MatVec(make([]Float, 3), out); err == nil {
 		t.Fatal("expected shape mismatch error")
 	}
 }

--- a/simd_compat_go126.go
+++ b/simd_compat_go126.go
@@ -19,6 +19,10 @@ func storeI32x8(v archsimd.Int32x8, s []int32) {
 	v.StoreSlice(s)
 }
 
+func loadU8x16(s []uint8) archsimd.Uint8x16 {
+	return archsimd.LoadUint8x16Slice(s)
+}
+
 func loadI8x16(s []int8) archsimd.Int8x16 {
 	return archsimd.LoadInt8x16Slice(s)
 }

--- a/simd_compat_go127.go
+++ b/simd_compat_go127.go
@@ -31,6 +31,10 @@ func storeI32x8(v archsimd.Int32x8, s []int32) {
 	v.Store(s)
 }
 
+func loadU8x16(s []uint8) archsimd.Uint8x16 {
+	return archsimd.LoadUint8x16(s)
+}
+
 func loadI8x16(s []int8) archsimd.Int8x16 {
 	return archsimd.LoadInt8x16(s)
 }


### PR DESCRIPTION
Gives Q4Matrix the same W-A7 integer design as the int8 kernel: bytes store interleaved row pairs of one column (even row low nibble, odd high), so two masks and a shift in u16 lanes produce exactly the adjacent-byte pairs one u8 × s8 pairwise multiply-add consumes, with the broadcast 7-bit activation pair as the signed operand. Nibbles are ≤15 so pair sums sit far from saturation, and the −8 offset folds out through per-group activation sums; each 64-row group is one register-accumulated block, which also removes the old scratch-strip fold pass and the even-column restriction.

| | before | after | |
|---|---|---|---|
| int4 matvec, out of cache (same machine state, back to back) | 5.5ms | **3.9ms** | **1.4x** |
| Qwen2.5-1.5B `-q4` decode (today's conditions) | ~3.8 tok/s | **~4.6 tok/s** | ~1.2x |

Quality checks unchanged (Paris, Tokyo, 7B answering at length). Both builds agree exactly, covered by a bit-exact reference test including odd rows, odd columns, and the pad pair.