### PR TITLE
Full GPU decode with a resident KV cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Arithmetic no longer dominates the convenient path — `gpu+xfer` at `large` spe
 
 Quantized weights stay quantized on the device too: `UploadQ8` packs a `QMatrix` four int8 weights per u32, and `GPUQMatrix.MatMul` dequantizes them in registers, so a decode matvec — whose cost is streaming the weights — moves a quarter of the f32 bytes. On the same iGPU through dozen it runs the matvec 2.2x faster than the resident f32 kernel.
 
+The rest of a transformer decode step is there as well — `RMSNorm`, in-place `RoPE`, `Add`, `SiluMul`, `GroupedCausalAttention` (a KV cache packing fewer heads than the queries, read up to a valid length), and `CopyRowsInto` to append fresh k/v rows to a resident cache — so `_example/qwen -q8 -gpu` runs every block on the device and only the hidden state comes back per token. `BeginBatch`/`Flush` record a whole token's dispatches into one submission, and freed intermediates recycle through a buffer pool, which together took a dozen-translated decode from 1.2 to ~17 tok/s steady state on the machine above.
+
 wgpu-native picks Vulkan on Linux, Vulkan or D3D12 on Windows, and Metal on macOS, so AMD, Intel, Apple, and NVIDIA GPUs all work — as do CPU Vulkan implementations like lavapipe, which is how the tests run on machines without a GPU. `gpu.MatMul` uploads the operands and reads the product back on every call; `Upload` plus `GPUTensor.MatMul` keeps inputs and intermediates resident, so only the final result needs to cross the bus. Without the build tag `OpenGPU` returns an error and nothing else changes.
 
 #### `-tags wgpu24`: the new wgpu-native API, and the real GPU inside WSL2

--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -1,0 +1,174 @@
+package main
+
+// GPU decode: every transformer block runs on the device — int8 weights
+// resident via GPUQMatrix, the KV cache resident in two preallocated
+// buffers per layer — so one token costs a handful of dispatches and a
+// single download of the hidden state. The final norm, the lm_head matvec
+// (whose weight would exceed modest per-buffer storage limits), and
+// sampling stay on the CPU. The prompt still prefills through the batched
+// CPU path; syncCache then copies the caches up once before decoding.
+
+import (
+	"fmt"
+
+	tensai "github.com/mattn/tensai"
+)
+
+type gpuLayer struct {
+	ln1, ln2                          *tensai.GPUTensor
+	bq, bk, bv                        *tensai.GPUTensor
+	qq, qk, qv, qo, qGate, qUp, qDown *tensai.GPUQMatrix
+	kc, vc                            *tensai.GPUTensor // [nCtx, kvDim]
+}
+
+type gpuQwen struct {
+	m      *qwen
+	g      *tensai.GPU
+	layers []gpuLayer
+	nCtx   int
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// newGPUQwen uploads the model's transformer blocks to the GPU: the int8
+// weight twins, the norm weights and biases, and zeroed KV caches sized
+// for nCtx positions.
+func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
+	kvDim := m.cfg.KVHeads * m.headSz
+	vec := func(v []float32) *tensai.GPUTensor {
+		return must(g.Upload(&tensai.Tensor{Shape: []int{len(v)}, Data: v}))
+	}
+	gq := &gpuQwen{m: m, g: g, nCtx: nCtx, layers: make([]gpuLayer, len(m.blocks))}
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		if b.qq == nil || b.qq.q8 == nil {
+			return nil, fmt.Errorf("gpu decode needs int8 weights (run with -q8)")
+		}
+		l := &gq.layers[i]
+		l.ln1, l.ln2 = vec(b.ln1), vec(b.ln2)
+		l.bq, l.bk, l.bv = vec(b.bq), vec(b.bk), vec(b.bv)
+		l.qq = must(g.UploadQ8(b.qq.q8))
+		l.qk = must(g.UploadQ8(b.qk.q8))
+		l.qv = must(g.UploadQ8(b.qv.q8))
+		l.qo = must(g.UploadQ8(b.qo.q8))
+		l.qGate = must(g.UploadQ8(b.qGate.q8))
+		l.qUp = must(g.UploadQ8(b.qUp.q8))
+		l.qDown = must(g.UploadQ8(b.qDown.q8))
+		l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+		l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+	}
+	return gq, nil
+}
+
+// syncCache copies the CPU-side KV cache — the prompt prefill — into the
+// GPU caches, one upload per layer.
+func (gq *gpuQwen) syncCache() error {
+	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
+	for i := range gq.layers {
+		cb := &gq.m.blocks[i]
+		if len(cb.kc) > gq.nCtx {
+			return fmt.Errorf("prefill of %d tokens exceeds gpu cache of %d", len(cb.kc), gq.nCtx)
+		}
+		for _, pair := range [2]struct {
+			rows [][]float32
+			dst  *tensai.GPUTensor
+		}{{cb.kc, gq.layers[i].kc}, {cb.vc, gq.layers[i].vc}} {
+			if len(pair.rows) == 0 {
+				continue
+			}
+			flat := &tensai.Tensor{Shape: []int{len(pair.rows), kvDim}, Data: make([]float32, len(pair.rows)*kvDim)}
+			for t, row := range pair.rows {
+				copy(flat.Data[t*kvDim:], row)
+			}
+			tmp, err := gq.g.Upload(flat)
+			if err != nil {
+				return err
+			}
+			err = tmp.CopyRowsInto(pair.dst, 0)
+			tmp.Free()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// step feeds one token at position pos through the GPU-resident blocks and
+// returns the next-token logits. Same signature as the CPU step, so the
+// decode loop swaps between them freely.
+func (gq *gpuQwen) step(token, pos int) []float32 {
+	m := gq.m
+	cfg := m.cfg
+	hs := cfg.HiddenSize
+	kvDim := cfg.KVHeads * m.headSz
+
+	x := must(gq.g.Upload(&tensai.Tensor{Shape: []int{1, hs}, Data: m.embed.Data[token*hs : (token+1)*hs]}))
+	defer x.Free()
+	// One submission for the whole token: every dispatch below is recorded
+	// into a single command buffer, and the Download at the end flushes it.
+	if err := gq.g.BeginBatch(); err != nil {
+		panic(err)
+	}
+	for i := range gq.layers {
+		l := &gq.layers[i]
+		a := must(x.RMSNorm(l.ln1, cfg.RMSEps))
+		q := must(l.qq.MatMul(a))
+		k := must(l.qk.MatMul(a))
+		v := must(l.qv.MatMul(a))
+		a.Free()
+		if err := q.Add(l.bq); err != nil {
+			panic(err)
+		}
+		if err := k.Add(l.bk); err != nil {
+			panic(err)
+		}
+		if err := v.Add(l.bv); err != nil {
+			panic(err)
+		}
+		if err := q.RoPE(m.headSz, pos, cfg.RopeTheta); err != nil {
+			panic(err)
+		}
+		if err := k.RoPE(m.headSz, pos, cfg.RopeTheta); err != nil {
+			panic(err)
+		}
+		if err := k.CopyRowsInto(l.kc, pos*kvDim); err != nil {
+			panic(err)
+		}
+		if err := v.CopyRowsInto(l.vc, pos*kvDim); err != nil {
+			panic(err)
+		}
+		k.Free()
+		v.Free()
+		attn := must(q.GroupedCausalAttention(l.kc, l.vc, cfg.Heads, cfg.KVHeads, pos+1))
+		q.Free()
+		proj := must(l.qo.MatMul(attn))
+		attn.Free()
+		if err := x.Add(proj); err != nil {
+			panic(err)
+		}
+		proj.Free()
+
+		a = must(x.RMSNorm(l.ln2, cfg.RMSEps))
+		gate := must(l.qGate.MatMul(a))
+		up := must(l.qUp.MatMul(a))
+		a.Free()
+		if err := gate.SiluMul(up); err != nil {
+			panic(err)
+		}
+		up.Free()
+		down := must(l.qDown.MatMul(gate))
+		gate.Free()
+		if err := x.Add(down); err != nil {
+			panic(err)
+		}
+		down.Free()
+	}
+	xt := must(x.Download())
+	return mv(rmsnorm(xt.Data, m.normW, cfg.RMSEps), m.lmT, m.qLmT, nil)
+}

--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	tensai "github.com/mattn/tensai"
 	"github.com/mattn/tensai/tokenizer"
 )
 
@@ -163,6 +164,7 @@ func main() {
 	q8 := flag.Bool("q8", false, "decode against int8-quantized weights")
 	q4 := flag.Bool("q4", false, "decode against int4-quantized weights (group-wise)")
 	chat := flag.Bool("chat", false, "interactive multi-turn chat on stdin (the KV cache carries the conversation)")
+	gpu := flag.Bool("gpu", false, "decode on the GPU (requires -q8 and a wgpu build tag)")
 	cpuprofile := flag.String("cpuprofile", "", "write a CPU profile of generation to this file")
 	flag.Parse()
 
@@ -225,11 +227,38 @@ func main() {
 		nCtx = 4096
 	}
 
+	// With -gpu the transformer blocks decode on the device; the prompt
+	// still prefills on the CPU, and syncCache carries it over below.
+	var gq *gpuQwen
+	if *gpu {
+		if *chat {
+			fmt.Fprintln(os.Stderr, "-gpu does not support -chat yet (the CPU and GPU caches would diverge)")
+			os.Exit(1)
+		}
+		if bits != 8 {
+			fmt.Fprintln(os.Stderr, "-gpu requires -q8")
+			os.Exit(1)
+		}
+		g, err := tensai.OpenGPU(tensai.GPUHighPerformance)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		defer g.Close()
+		start := time.Now()
+		if gq, err = newGPUQwen(model, g, nCtx); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "uploaded to %s in %v\n", g.Name(), time.Since(start).Round(time.Millisecond))
+	}
+
 	// feed pushes tokens through the model, extending the KV cache;
 	// generate then samples until an end token, which is also fed so the
 	// cache stays aligned with the template for the next turn.
 	steps := 0
 	var logits []float32
+	stepFn := model.step
 	feed := func(ids []int) {
 		if len(ids) > 1 {
 			logits = model.prefill(ids, steps)
@@ -237,7 +266,7 @@ func main() {
 			return
 		}
 		for _, id := range ids {
-			logits = model.step(id, steps)
+			logits = stepFn(id, steps)
 			steps++
 		}
 	}
@@ -289,6 +318,13 @@ func main() {
 	start = time.Now()
 	feed(ids)
 	fmt.Fprintf(os.Stderr, "prefill: %v\n", time.Since(start).Round(time.Millisecond))
+	if gq != nil {
+		if err := gq.syncCache(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		stepFn = gq.step
+	}
 	generate(*n)
 	fmt.Fprintf(os.Stderr, "%d tokens total in %v\n",
 		steps, time.Since(start).Round(time.Millisecond))

--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -40,13 +40,14 @@ type qmat struct {
 	cols int
 	f    func(x, out []float32) error
 	mm   func(x, out *tensai.Matrix) error
+	q8   *tensai.QMatrix // retained for GPU upload; nil for int4
 }
 
 func quantizeMat(m *tensai.Matrix, bits int) *qmat {
 	switch bits {
 	case 8:
 		q := tensai.QuantizeMatrix(m)
-		return &qmat{cols: q.Cols, f: q.MatVec, mm: q.MatMul}
+		return &qmat{cols: q.Cols, f: q.MatVec, mm: q.MatMul, q8: q}
 	case 4:
 		q, err := tensai.QuantizeMatrix4(m)
 		if err != nil {

--- a/wgpu.go
+++ b/wgpu.go
@@ -40,6 +40,8 @@ type GPU struct {
 	module     uintptr
 	pipes      gpuPipelines
 	readback   gpuReadbackBuffer
+	pool       gpuBufferPool
+	batchEnc   uintptr // open command encoder while batching, see BeginBatch
 	name       string
 	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
 	closed     bool
@@ -505,6 +507,7 @@ func (g *GPU) Close() {
 	}
 	g.closed = true
 	g.releaseReadback()
+	g.releasePool()
 	g.releasePipelines()
 	for _, r := range []struct {
 		fn func(uintptr)

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -45,6 +45,8 @@ type GPU struct {
 	module     uintptr
 	pipes      gpuPipelines
 	readback   gpuReadbackBuffer
+	pool       gpuBufferPool
+	batchEnc   uintptr // open command encoder while batching, see BeginBatch
 	name       string
 	maxStorage uint64 // usable bytes per storage buffer, 0 = unknown
 	closed     bool
@@ -578,6 +580,7 @@ func (g *GPU) Close() {
 	}
 	g.closed = true
 	g.releaseReadback()
+	g.releasePool()
 	g.releasePipelines()
 	for _, r := range []struct {
 		fn func(uintptr)

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -82,3 +82,45 @@ func (t *GPUTensor) Shape() []int { return nil }
 
 // Size returns 0 in builds without the wgpu tag.
 func (t *GPUTensor) Size() int { return 0 }
+
+// RMSNorm always fails in builds without the wgpu tag.
+func (t *GPUTensor) RMSNorm(w *GPUTensor, eps float64) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// RoPE always fails in builds without the wgpu tag.
+func (t *GPUTensor) RoPE(headSz, pos0 int, theta float64) error { return errNoWGPU }
+
+// Add always fails in builds without the wgpu tag.
+func (t *GPUTensor) Add(o *GPUTensor) error { return errNoWGPU }
+
+// SiluMul always fails in builds without the wgpu tag.
+func (t *GPUTensor) SiluMul(o *GPUTensor) error { return errNoWGPU }
+
+// CopyRowsInto always fails in builds without the wgpu tag.
+func (t *GPUTensor) CopyRowsInto(dst *GPUTensor, off int) error { return errNoWGPU }
+
+// GroupedCausalAttention always fails in builds without the wgpu tag.
+func (q *GPUTensor) GroupedCausalAttention(k, v *GPUTensor, heads, kvHeads, seqKV int) (*GPUTensor, error) {
+	return nil, errNoWGPU
+}
+
+// GPUQMatrix is a GPU-resident int8 weight matrix. This build has it
+// disabled; build with -tags wgpu or -tags wgpu24 to enable it.
+type GPUQMatrix struct{}
+
+// UploadQ8 always fails in builds without the wgpu tag.
+func (g *GPU) UploadQ8(q *QMatrix) (*GPUQMatrix, error) { return nil, errNoWGPU }
+
+// MatMul always fails in builds without the wgpu tag.
+func (q *GPUQMatrix) MatMul(x *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// Shape returns zeros in builds without the wgpu tag.
+func (q *GPUQMatrix) Shape() (int, int) { return 0, 0 }
+
+// Free is a no-op in builds without the wgpu tag.
+func (q *GPUQMatrix) Free() {}
+
+// BeginBatch always fails in builds without the wgpu tag.
+func (g *GPU) BeginBatch() error { return errNoWGPU }
+
+// Flush is a no-op in builds without the wgpu tag.
+func (g *GPU) Flush() error { return nil }

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -807,3 +807,232 @@ func BenchmarkGPUF32MatVec(b *testing.B) {
 		out.Free()
 	}
 }
+
+func TestGPUDecodeOps(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(71))
+
+	// RMSNorm against the scalar definition.
+	x := randTensor(rng, 3, 64)
+	w := randTensor(rng, 64)
+	gx, err := g.Upload(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gx.Free()
+	gw, err := g.Upload(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gw.Free()
+	gn, err := gx.RMSNorm(gw, 1e-6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gn.Free()
+	norm, err := gn.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for r := 0; r < 3; r++ {
+		var ss float64
+		for i := 0; i < 64; i++ {
+			v := float64(x.Data[r*64+i])
+			ss += v * v
+		}
+		inv := 1 / math.Sqrt(ss/64+1e-6)
+		for i := 0; i < 64; i++ {
+			want := float64(x.Data[r*64+i]) * inv * float64(w.Data[i])
+			if diff := math.Abs(float64(norm.Data[r*64+i]) - want); diff > 1e-4 {
+				t.Fatalf("rmsnorm row %d elem %d: got %v want %v", r, i, norm.Data[r*64+i], want)
+			}
+		}
+	}
+
+	// RoPE against the half-split rotation, rows at successive positions.
+	const headSz, d, rows, pos0 = 8, 16, 3, 5
+	rx := randTensor(rng, rows, d)
+	grx, err := g.Upload(rx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer grx.Free()
+	if err := grx.RoPE(headSz, pos0, 10000); err != nil {
+		t.Fatal(err)
+	}
+	rot, err := grx.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for r := 0; r < rows; r++ {
+		for h := 0; h < d/headSz; h++ {
+			for c := 0; c < headSz/2; c++ {
+				freq := math.Pow(10000, -2*float64(c)/float64(headSz))
+				sn, cs := math.Sincos(float64(pos0+r) * freq)
+				i := r*d + h*headSz + c
+				a, b := float64(rx.Data[i]), float64(rx.Data[i+headSz/2])
+				wantA := a*cs - b*sn
+				wantB := b*cs + a*sn
+				if math.Abs(float64(rot.Data[i])-wantA) > 1e-4 || math.Abs(float64(rot.Data[i+headSz/2])-wantB) > 1e-4 {
+					t.Fatalf("rope row %d head %d pair %d: got (%v,%v) want (%v,%v)",
+						r, h, c, rot.Data[i], rot.Data[i+headSz/2], wantA, wantB)
+				}
+			}
+		}
+	}
+
+	// Add with a broadcast bias, then SiluMul.
+	a := randTensor(rng, 3, 32)
+	bias := randTensor(rng, 32)
+	up := randTensor(rng, 3, 32)
+	ga, err := g.Upload(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ga.Free()
+	gb, err := g.Upload(bias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gb.Free()
+	gu, err := g.Upload(up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gu.Free()
+	if err := ga.Add(gb); err != nil {
+		t.Fatal(err)
+	}
+	if err := ga.SiluMul(gu); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ga.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for r := 0; r < 3; r++ {
+		for i := 0; i < 32; i++ {
+			gv := float64(a.Data[r*32+i]) + float64(bias.Data[i])
+			want := gv / (1 + math.Exp(-gv)) * float64(up.Data[r*32+i])
+			if diff := math.Abs(float64(got.Data[r*32+i]) - want); diff > 1e-4 {
+				t.Fatalf("silu(add) row %d elem %d: got %v want %v", r, i, got.Data[r*32+i], want)
+			}
+		}
+	}
+
+	// CopyRowsInto: append rows into a larger cache at an offset.
+	cache, err := g.Upload(randTensor(rng, 8, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cache.Free()
+	rowsT := randTensor(rng, 2, 16)
+	grows, err := g.Upload(rowsT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer grows.Free()
+	if err := grows.CopyRowsInto(cache, 3*16); err != nil {
+		t.Fatal(err)
+	}
+	back, err := cache.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 32; i++ {
+		if back.Data[3*16+i] != rowsT.Data[i] {
+			t.Fatalf("copy elem %d: got %v want %v", i, back.Data[3*16+i], rowsT.Data[i])
+		}
+	}
+	if err := grows.CopyRowsInto(cache, 7*16); err == nil {
+		t.Fatal("expected overflow error")
+	}
+}
+
+func TestGPUGroupedCausalAttention(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(72))
+
+	const heads, kvHeads, dh = 4, 2, 8
+	const d, kvDim = heads * dh, kvHeads * dh
+	const seqKV, capacity = 6, 9 // cache holds more rows than are valid
+	group := heads / kvHeads
+	k := randTensor(rng, capacity, kvDim)
+	v := randTensor(rng, capacity, kvDim)
+	gk, err := g.Upload(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gk.Free()
+	gv, err := g.Upload(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gv.Free()
+
+	for _, seq := range []int{1, 3} { // decode and chunked prefill
+		q := randTensor(rng, seq, d)
+		gq, err := g.Upload(q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := gq.GroupedCausalAttention(gk, gv, heads, kvHeads, seqKV)
+		if err != nil {
+			t.Fatalf("seq %d: %v", seq, err)
+		}
+		out, err := got.Download()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Scalar reference: same math as the CPU decode loop.
+		scale := 1 / math.Sqrt(dh)
+		for qi := 0; qi < seq; qi++ {
+			limit := qi + seqKV - seq + 1
+			for h := 0; h < heads; h++ {
+				kvOff := (h / group) * dh
+				scores := make([]float64, limit)
+				maxs := math.Inf(-1)
+				for j := 0; j < limit; j++ {
+					var s float64
+					for c := 0; c < dh; c++ {
+						s += float64(q.Data[qi*d+h*dh+c]) * float64(k.Data[j*kvDim+kvOff+c])
+					}
+					scores[j] = s * scale
+					maxs = math.Max(maxs, scores[j])
+				}
+				var sum float64
+				for j := range scores {
+					scores[j] = math.Exp(scores[j] - maxs)
+					sum += scores[j]
+				}
+				for c := 0; c < dh; c++ {
+					var want float64
+					for j := 0; j < limit; j++ {
+						want += scores[j] / sum * float64(v.Data[j*kvDim+kvOff+c])
+					}
+					gotv := float64(out.Data[qi*d+h*dh+c])
+					if diff := math.Abs(gotv - want); diff > 1e-4 {
+						t.Fatalf("seq %d query %d head %d chan %d: got %v want %v", seq, qi, h, c, gotv, want)
+					}
+				}
+			}
+		}
+		got.Free()
+		gq.Free()
+	}
+
+	gq, err := g.Upload(randTensor(rng, 1, d))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gq.Free()
+	if _, err := gq.GroupedCausalAttention(gk, gv, 3, 2, seqKV); err == nil {
+		t.Fatal("expected error: kv heads do not divide heads")
+	}
+	if _, err := gq.GroupedCausalAttention(gk, gv, heads, kvHeads, capacity+1); err == nil {
+		t.Fatal("expected error: seqKV beyond cache")
+	}
+}

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -350,11 +350,12 @@ fn softmax_last(@builtin(workgroup_id) wid: vec3<u32>,
 // reduce its max and sum, then switch axes and each accumulate one or two
 // output channels (dh up to 128), rescaling the running state as the max
 // grows. offs (binding 3) holds per-batch*head element offsets
-// (q, kv, out); rows in q, k, v, and out all stride by ap.d, so heads
-// stay packed.
+// (q, kv, out); rows in q and out stride by ap.d and rows in k and v by
+// ap.dkv, so heads stay packed and k/v may pack fewer heads than q
+// (grouped-query attention).
 struct AttnParams {
     seqQ: u32, seqKV: u32, dh: u32, d: u32,
-    rows: u32, off: u32, pad0: u32, pad1: u32,
+    rows: u32, off: u32, dkv: u32, pad1: u32,
 }
 @group(0) @binding(10) var<uniform> ap: AttnParams;
 @group(0) @binding(11) var<storage, read> aq: array<f32>;
@@ -399,7 +400,7 @@ fn attn_causal(@builtin(workgroup_id) wid: vec3<u32>,
         if (j < limit) {
             var dot = 0.0;
             for (var c = 0u; c < ap.dh; c = c + 1u) {
-                dot = dot + qrow[c] * ak[offKV + j * ap.d + c];
+                dot = dot + qrow[c] * ak[offKV + j * ap.dkv + c];
             }
             s = dot * scale;
         }
@@ -434,10 +435,10 @@ fn attn_causal(@builtin(workgroup_id) wid: vec3<u32>,
         for (var jj = tt * AT; jj < jEnd; jj = jj + 1u) {
             let pj = ap_sc[jj - tt * AT];
             if (t < ap.dh) {
-                acc0 = acc0 + pj * av[offKV + jj * ap.d + t];
+                acc0 = acc0 + pj * av[offKV + jj * ap.dkv + t];
             }
             if (64u + t < ap.dh) {
-                acc1 = acc1 + pj * av[offKV + jj * ap.d + 64u + t];
+                acc1 = acc1 + pj * av[offKV + jj * ap.dkv + 64u + t];
             }
         }
         workgroupBarrier();
@@ -507,6 +508,96 @@ fn qmatmul(@builtin(workgroup_id) wid: vec3<u32>,
         }
     }
 }
+
+// rmsnorm_row: one workgroup per row computes out = x * w / rms(x).
+struct NormParams { rows: u32, n: u32, eps: f32, pad: u32 }
+@group(0) @binding(20) var<uniform> np: NormParams;
+@group(0) @binding(21) var<storage, read> nx: array<f32>;
+@group(0) @binding(22) var<storage, read> nw: array<f32>;
+@group(0) @binding(23) var<storage, read_write> nout: array<f32>;
+
+var<workgroup> nred: array<f32, 256>;
+
+@compute @workgroup_size(256, 1, 1)
+fn rmsnorm_row(@builtin(workgroup_id) wid: vec3<u32>,
+               @builtin(num_workgroups) nwg: vec3<u32>,
+               @builtin(local_invocation_id) lid: vec3<u32>) {
+    let row = wid.y * nwg.x + wid.x;
+    if (row >= np.rows) {
+        return;
+    }
+    let base = row * np.n;
+    var ss = 0.0;
+    for (var i = lid.x; i < np.n; i = i + 256u) {
+        let v = nx[base + i];
+        ss = ss + v * v;
+    }
+    nred[lid.x] = ss;
+    workgroupBarrier();
+    for (var s = 128u; s > 0u; s = s >> 1u) {
+        if (lid.x < s) { nred[lid.x] = nred[lid.x] + nred[lid.x + s]; }
+        workgroupBarrier();
+    }
+    let inv = inverseSqrt(nred[0] / f32(np.n) + np.eps);
+    for (var i = lid.x; i < np.n; i = i + 256u) {
+        nout[base + i] = nx[base + i] * inv * nw[i];
+    }
+}
+
+// rope_rows rotates every head of every row in place, half-split style:
+// element pair (c, c+headSz/2) of each head rotates by pos*theta^(-2c/headSz),
+// where row r sits at position pos0 + r.
+struct RopeParams { rows: u32, d: u32, headSz: u32, pos0: u32, theta: f32 }
+@group(0) @binding(24) var<uniform> rp: RopeParams;
+@group(0) @binding(25) var<storage, read_write> rx: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn rope_rows(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let half = rp.headSz / 2u;
+    let pairs = (rp.d / rp.headSz) * half;
+    if (gid.x >= pairs || gid.y >= rp.rows) {
+        return;
+    }
+    let h = gid.x / half;
+    let c = gid.x % half;
+    let base = gid.y * rp.d + h * rp.headSz + c;
+    let freq = pow(rp.theta, -2.0 * f32(c) / f32(rp.headSz));
+    let ang = f32(rp.pos0 + gid.y) * freq;
+    let sn = sin(ang);
+    let cs = cos(ang);
+    let a = rx[base];
+    let b = rx[base + half];
+    rx[base] = a * cs - b * sn;
+    rx[base + half] = b * cs + a * sn;
+}
+
+// add_ip: dst += src, with src repeating when shorter (a row bias applied
+// to every row). silu_mul_ip: dst = silu(dst) * src, the SwiGLU joint.
+struct EltParams { count: u32, srcCount: u32 }
+@group(0) @binding(26) var<uniform> ep: EltParams;
+@group(0) @binding(27) var<storage, read_write> edst: array<f32>;
+@group(0) @binding(28) var<storage, read> esrc: array<f32>;
+
+@compute @workgroup_size(256, 1, 1)
+fn add_ip(@builtin(workgroup_id) wg: vec3<u32>,
+          @builtin(num_workgroups) nwg: vec3<u32>,
+          @builtin(local_invocation_id) lid: vec3<u32>) {
+    let idx = (wg.y * nwg.x + wg.x) * 256u + lid.x;
+    if (idx < ep.count) {
+        edst[idx] = edst[idx] + esrc[idx % ep.srcCount];
+    }
+}
+
+@compute @workgroup_size(256, 1, 1)
+fn silu_mul_ip(@builtin(workgroup_id) wg: vec3<u32>,
+               @builtin(num_workgroups) nwg: vec3<u32>,
+               @builtin(local_invocation_id) lid: vec3<u32>) {
+    let idx = (wg.y * nwg.x + wg.x) * 256u + lid.x;
+    if (idx < ep.count) {
+        let g = edst[idx];
+        edst[idx] = g / (1.0 + exp(-g)) * esrc[idx % ep.srcCount];
+    }
+}
 `
 
 // gpuPipelines holds one compute pipeline (and its auto bind-group layout)
@@ -515,8 +606,10 @@ fn qmatmul(@builtin(workgroup_id) wid: vec3<u32>,
 type gpuPipelines struct {
 	matmul, matmulT, matmulS, matmulTS             uintptr
 	scale, softmax, attn, qmatmul                  uintptr
+	rmsnorm, rope, addIP, siluMulIP                uintptr
 	layMatmul, layMatmulT, layMatmulS, layMatmulTS uintptr
 	layScale, laySoftmax, layAttn, layQmatmul      uintptr
+	layRmsnorm, layRope, layAddIP, laySiluMulIP    uintptr
 }
 
 // initPipelines compiles every kernel from g.module; the caller holds
@@ -534,6 +627,10 @@ func (g *GPU) initPipelines() error {
 		{&g.pipes.softmax, &g.pipes.laySoftmax, "softmax_last"},
 		{&g.pipes.attn, &g.pipes.layAttn, "attn_causal"},
 		{&g.pipes.qmatmul, &g.pipes.layQmatmul, "qmatmul"},
+		{&g.pipes.rmsnorm, &g.pipes.layRmsnorm, "rmsnorm_row"},
+		{&g.pipes.rope, &g.pipes.layRope, "rope_rows"},
+		{&g.pipes.addIP, &g.pipes.layAddIP, "add_ip"},
+		{&g.pipes.siluMulIP, &g.pipes.laySiluMulIP, "silu_mul_ip"},
 	} {
 		*x.pipe = g.makePipeline(x.entry)
 		if *x.pipe == 0 || uncapturedCB != "" {
@@ -550,7 +647,8 @@ func (g *GPU) releasePipelines() {
 	for _, h := range []uintptr{
 		g.pipes.layMatmul, g.pipes.layMatmulT, g.pipes.layMatmulS,
 		g.pipes.layMatmulTS, g.pipes.layScale, g.pipes.laySoftmax, g.pipes.layAttn,
-		g.pipes.layQmatmul,
+		g.pipes.layQmatmul, g.pipes.layRmsnorm, g.pipes.layRope,
+		g.pipes.layAddIP, g.pipes.laySiluMulIP,
 	} {
 		if h != 0 {
 			fnLayoutRelease(h)
@@ -559,7 +657,8 @@ func (g *GPU) releasePipelines() {
 	for _, h := range []uintptr{
 		g.pipes.matmul, g.pipes.matmulT, g.pipes.matmulS,
 		g.pipes.matmulTS, g.pipes.scale, g.pipes.softmax, g.pipes.attn,
-		g.pipes.qmatmul,
+		g.pipes.qmatmul, g.pipes.rmsnorm, g.pipes.rope,
+		g.pipes.addIP, g.pipes.siluMulIP,
 	} {
 		if h != 0 {
 			fnPipelineRelease(h)
@@ -568,15 +667,25 @@ func (g *GPU) releasePipelines() {
 }
 
 // dispatch runs one compute pass and pumps the error callback once; the
-// caller holds wgpuMu.
+// caller holds wgpuMu. Inside a batch (see BeginBatch) the pass is only
+// recorded — submission waits for Flush.
 func (g *GPU) dispatch(pipe, bindGroup uintptr, x, y, z uint32) error {
-	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
+	encoder := g.batchEnc
+	if encoder == 0 {
+		encoder = fnDeviceCreateCmdEncoder(g.device, nil)
+	}
 	pass := fnEncoderBeginComputePass(encoder, nil)
 	fnPassSetPipeline(pass, pipe)
 	fnPassSetBindGroup(pass, 0, bindGroup, 0, nil)
 	fnPassDispatch(pass, x, y, z)
 	fnPassEnd(pass)
 	fnPassRelease(pass)
+	if g.batchEnc != 0 {
+		if uncapturedCB != "" {
+			return fmt.Errorf("tensai: gpu dispatch failed: %s", uncapturedCB)
+		}
+		return nil
+	}
 	cmd := fnEncoderFinish(encoder, nil)
 	fnCmdEncoderRelease(encoder)
 	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
@@ -586,6 +695,143 @@ func (g *GPU) dispatch(pipe, bindGroup uintptr, x, y, z uint32) error {
 		return fmt.Errorf("tensai: gpu dispatch failed: %s", uncapturedCB)
 	}
 	return nil
+}
+
+// BeginBatch opens a command encoder that collects every subsequent
+// operation on this GPU — compute dispatches and buffer copies — into one
+// submission, which Flush sends. One submission instead of hundreds is
+// the difference between a usable and an unusable decode step on drivers
+// with per-submit overhead. Operations inside a batch report validation
+// errors at Flush; Download flushes an open batch implicitly.
+func (g *GPU) BeginBatch() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return errors.New("tensai: gpu is closed")
+	}
+	if g.batchEnc != 0 {
+		return errors.New("tensai: gpu batch already open")
+	}
+	uncapturedCB = ""
+	g.batchEnc = fnDeviceCreateCmdEncoder(g.device, nil)
+	return nil
+}
+
+// Flush submits the batch opened by BeginBatch. Safe to call with no batch
+// open.
+func (g *GPU) Flush() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	return g.flushLocked()
+}
+
+// flushLocked submits and closes an open batch encoder; the caller holds
+// g.mu and wgpuMu.
+func (g *GPU) flushLocked() error {
+	if g.batchEnc == 0 {
+		return nil
+	}
+	encoder := g.batchEnc
+	g.batchEnc = 0
+	cmd := fnEncoderFinish(encoder, nil)
+	fnCmdEncoderRelease(encoder)
+	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
+	fnCmdBufferRelease(cmd)
+	fnDevicePoll(g.device, 0, nil)
+	g.drainPending()
+	if uncapturedCB != "" {
+		return fmt.Errorf("tensai: gpu batch failed: %s", uncapturedCB)
+	}
+	return nil
+}
+
+// gpuBufferPool recycles transient buffers — op parameter uniforms and
+// intermediate tensors — keyed by exact (usage, size). A decode step
+// allocates the same shapes every token, so after the first token every
+// request hits. While a batch is open, returned buffers wait in pending:
+// reuse writes go through fnQueueWriteBuffer, which jumps ahead of the
+// still-unsubmitted encoder, so a buffer must not be handed out again
+// until the batch that references it is flushed.
+type gpuBufferPool struct {
+	free    map[[2]uint64][]uintptr
+	pending []pooledBuf
+	bytes   uint64
+}
+
+type pooledBuf struct {
+	usage, size uint64
+	buf         uintptr
+}
+
+// gpuPoolMaxBytes caps the pooled total; beyond it buffers just release.
+const gpuPoolMaxBytes = 512 << 20
+
+// takeBuffer returns a pooled buffer of exactly this usage and size, or a
+// fresh one. The caller holds g.mu and wgpuMu.
+func (g *GPU) takeBuffer(usage, size uint64) uintptr {
+	key := [2]uint64{usage, size}
+	if l := g.pool.free[key]; len(l) > 0 {
+		buf := l[len(l)-1]
+		g.pool.free[key] = l[:len(l)-1]
+		g.pool.bytes -= size
+		return buf
+	}
+	return g.newBuffer(usage, size)
+}
+
+// putBuffer returns a buffer to the pool (or releases it past the cap).
+// The caller holds wgpuMu.
+func (g *GPU) putBuffer(usage, size uint64, buf uintptr) {
+	if g.closed || g.pool.bytes+size > gpuPoolMaxBytes {
+		fnBufferRelease(buf)
+		return
+	}
+	if g.batchEnc != 0 {
+		g.pool.pending = append(g.pool.pending, pooledBuf{usage, size, buf})
+		return
+	}
+	if g.pool.free == nil {
+		g.pool.free = make(map[[2]uint64][]uintptr)
+	}
+	key := [2]uint64{usage, size}
+	g.pool.free[key] = append(g.pool.free[key], buf)
+	g.pool.bytes += size
+}
+
+// drainPending moves batch-held buffers into the free lists once their
+// batch has been submitted. The caller holds wgpuMu.
+func (g *GPU) drainPending() {
+	for _, p := range g.pool.pending {
+		if g.pool.bytes+p.size > gpuPoolMaxBytes {
+			fnBufferRelease(p.buf)
+			continue
+		}
+		if g.pool.free == nil {
+			g.pool.free = make(map[[2]uint64][]uintptr)
+		}
+		key := [2]uint64{p.usage, p.size}
+		g.pool.free[key] = append(g.pool.free[key], p.buf)
+		g.pool.bytes += p.size
+	}
+	g.pool.pending = g.pool.pending[:0]
+}
+
+// releasePool drops every pooled buffer during Close. The caller holds
+// wgpuMu.
+func (g *GPU) releasePool() {
+	for _, l := range g.pool.free {
+		for _, buf := range l {
+			fnBufferRelease(buf)
+		}
+	}
+	for _, p := range g.pool.pending {
+		fnBufferRelease(p.buf)
+	}
+	g.pool = gpuBufferPool{}
 }
 
 // GPUTensor is a tensor whose data lives in GPU memory. Create one with
@@ -680,7 +926,7 @@ func (g *GPU) Upload(t *Tensor) (*GPUTensor, error) {
 	if err := g.checkSize(uint64(len(t.Data)) * 4); err != nil {
 		return nil, err
 	}
-	buf := g.newBuffer(gpuTensorUsage, uint64(len(t.Data))*4)
+	buf := g.takeBuffer(gpuTensorUsage, uint64(len(t.Data))*4)
 	if buf == 0 {
 		return nil, errors.New("tensai: gpu buffer allocation failed")
 	}
@@ -701,6 +947,9 @@ func (t *GPUTensor) Download() (*Tensor, error) {
 	defer wgpuMu.Unlock()
 	if g.closed {
 		return nil, errors.New("tensai: gpu is closed")
+	}
+	if err := g.flushLocked(); err != nil {
+		return nil, err
 	}
 	out := NewTensor(t.shape...)
 	bytes := uint64(len(out.Data)) * 4
@@ -734,8 +983,9 @@ func (t *GPUTensor) Download() (*Tensor, error) {
 	return out, nil
 }
 
-// Free releases the GPU buffer. The tensor must not be used afterwards;
-// calling Free again is a no-op.
+// Free releases the GPU buffer (into the transient pool, from which the
+// next same-sized tensor will reuse it). The tensor must not be used
+// afterwards; calling Free again is a no-op.
 func (t *GPUTensor) Free() {
 	wgpuMu.Lock()
 	defer wgpuMu.Unlock()
@@ -743,7 +993,7 @@ func (t *GPUTensor) Free() {
 		return
 	}
 	t.freed = true
-	fnBufferRelease(t.buf)
+	t.g.putBuffer(gpuTensorUsage, uint64(t.Size())*4, t.buf)
 }
 
 // MatMul multiplies two GPU-resident tensors with the same shape and
@@ -844,11 +1094,11 @@ func (g *GPU) stridedMatMul(a, b *GPUTensor, outShape []int, transB bool, m, k, 
 	if err := g.checkSize(outBytes); err != nil {
 		return nil, err
 	}
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
-	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
-	bufOut := g.newBuffer(gpuTensorUsage, outBytes)
-	defer fnBufferRelease(bufParams)
-	defer fnBufferRelease(bufOffs)
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
+	bufOffs := g.takeBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
+	bufOut := g.takeBuffer(gpuTensorUsage, outBytes)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32, bufParams)
+	defer g.putBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4, bufOffs)
 
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 32)
 	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
@@ -918,8 +1168,8 @@ func (t *GPUTensor) Scale(s Float) error {
 	uncapturedCB = ""
 
 	params := [4]uint32{uint32(count), math.Float32bits(float32(s))}
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
-	defer fnBufferRelease(bufParams)
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
 
 	entries := [2]wgpuBindGroupEntry{
@@ -964,9 +1214,9 @@ func (t *GPUTensor) softmax(qmod, off int) (*GPUTensor, error) {
 
 	bytes := uint64(t.Size()) * 4
 	params := [4]uint32{uint32(rows), uint32(cols), uint32(qmod), uint32(off)}
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
-	bufOut := g.newBuffer(gpuTensorUsage, bytes)
-	defer fnBufferRelease(bufParams)
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	bufOut := g.takeBuffer(gpuTensorUsage, bytes)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
 
 	entries := [3]wgpuBindGroupEntry{
@@ -1143,7 +1393,7 @@ func (q *GPUTensor) fusedCausalMHA(k, v *GPUTensor, heads, batch, seq, seqKV, d,
 	rows := bh * seq
 	params := [8]uint32{
 		uint32(seq), uint32(seqKV), uint32(dh), uint32(d),
-		uint32(rows), uint32(seqKV - seq), 0, 0,
+		uint32(rows), uint32(seqKV - seq), uint32(d), 0,
 	}
 	outShape := append(append([]int(nil), q.shape[:len(q.shape)-2]...), seq, d)
 
@@ -1161,11 +1411,11 @@ func (q *GPUTensor) fusedCausalMHA(k, v *GPUTensor, heads, batch, seq, seqKV, d,
 	if err := g.checkSize(outBytes); err != nil {
 		return nil, err
 	}
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
-	bufOffs := g.newBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
-	bufOut := g.newBuffer(gpuTensorUsage, outBytes)
-	defer fnBufferRelease(bufParams)
-	defer fnBufferRelease(bufOffs)
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
+	bufOffs := g.takeBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
+	bufOut := g.takeBuffer(gpuTensorUsage, outBytes)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32, bufParams)
+	defer g.putBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4, bufOffs)
 
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 32)
 	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
@@ -1327,9 +1577,9 @@ func (q *GPUQMatrix) MatMul(x *GPUTensor) (*GPUTensor, error) {
 		return nil, err
 	}
 	params := [4]uint32{uint32(q.rows), uint32(q.cols), uint32(q.words), uint32(m)}
-	bufParams := g.newBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
-	bufOut := g.newBuffer(gpuTensorUsage, outBytes)
-	defer fnBufferRelease(bufParams)
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	bufOut := g.takeBuffer(gpuTensorUsage, outBytes)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
 
 	entries := [5]wgpuBindGroupEntry{
@@ -1350,4 +1600,280 @@ func (q *GPUQMatrix) MatMul(x *GPUTensor) (*GPUTensor, error) {
 		return nil, err
 	}
 	return &GPUTensor{g: g, buf: bufOut, shape: outShape}, nil
+}
+
+// RMSNorm normalizes each row of the last axis by its root mean square and
+// multiplies by the weight vector w (length = last axis), the pre-norm of
+// Llama-family transformer blocks. Returns a new GPU-resident tensor.
+func (t *GPUTensor) RMSNorm(w *GPUTensor, eps float64) (*GPUTensor, error) {
+	if t.freed || w.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	nd := len(t.shape)
+	if nd == 0 {
+		return nil, errors.New("tensai: rmsnorm needs at least 1 axis")
+	}
+	n := t.shape[nd-1]
+	if w.Size() != n {
+		return nil, fmt.Errorf("tensai: rmsnorm weight length %d != last axis %d", w.Size(), n)
+	}
+	rows := t.Size() / n
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	params := [4]uint32{uint32(rows), uint32(n), math.Float32bits(float32(eps)), 0}
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	bufOut := g.takeBuffer(gpuTensorUsage, uint64(t.Size())*4)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+
+	entries := [4]wgpuBindGroupEntry{
+		{binding: 20, buffer: bufParams, size: 16},
+		{binding: 21, buffer: t.buf, size: uint64(t.Size()) * 4},
+		{binding: 22, buffer: w.buf, size: uint64(w.Size()) * 4},
+		{binding: 23, buffer: bufOut, size: uint64(t.Size()) * 4},
+	}
+	bindGroup := g.makeBindGroup(g.pipes.layRmsnorm, entries[:])
+	runtime.KeepAlive(&entries)
+	defer fnBindGroupRelease(bindGroup)
+
+	x, y := split2D(rows)
+	if err := g.dispatch(g.pipes.rmsnorm, bindGroup, x, y, 1); err != nil {
+		fnBufferRelease(bufOut)
+		return nil, err
+	}
+	return &GPUTensor{g: g, buf: bufOut, shape: append([]int(nil), t.shape...)}, nil
+}
+
+// RoPE applies rotary position embeddings in place, half-split style: the
+// last axis divides into heads of headSz, and element pair (c, c+headSz/2)
+// of each head in row r rotates by (pos0+r) * theta^(-2c/headSz).
+func (t *GPUTensor) RoPE(headSz, pos0 int, theta float64) error {
+	if t.freed {
+		return errors.New("tensai: gpu tensor already freed")
+	}
+	nd := len(t.shape)
+	if nd == 0 {
+		return errors.New("tensai: rope needs at least 1 axis")
+	}
+	d := t.shape[nd-1]
+	if headSz <= 0 || headSz%2 != 0 || d%headSz != 0 {
+		return fmt.Errorf("tensai: rope head size %d does not divide axis %d", headSz, d)
+	}
+	rows := t.Size() / d
+	if rows > 65535 {
+		return fmt.Errorf("tensai: rope batch of %d rows exceeds 65535", rows)
+	}
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	params := [8]uint32{
+		uint32(rows), uint32(d), uint32(headSz), uint32(pos0),
+		math.Float32bits(float32(theta)), 0, 0, 0,
+	}
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32, bufParams)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 32)
+
+	entries := [2]wgpuBindGroupEntry{
+		{binding: 24, buffer: bufParams, size: 32},
+		{binding: 25, buffer: t.buf, size: uint64(t.Size()) * 4},
+	}
+	bindGroup := g.makeBindGroup(g.pipes.layRope, entries[:])
+	runtime.KeepAlive(&entries)
+	defer fnBindGroupRelease(bindGroup)
+
+	pairs := (d / headSz) * (headSz / 2)
+	return g.dispatch(g.pipes.rope, bindGroup, uint32((pairs+63)/64), uint32(rows), 1)
+}
+
+// eltwiseIP dispatches one of the two in-place elementwise kernels with o
+// as the second operand, repeating o when it is shorter (a row bias
+// against a batch of rows).
+func (t *GPUTensor) eltwiseIP(pipe, lay uintptr, o *GPUTensor) error {
+	if t.freed || o.freed {
+		return errors.New("tensai: gpu tensor already freed")
+	}
+	if t.g != o.g {
+		return errors.New("tensai: gpu tensors belong to different GPUs")
+	}
+	if o.Size() == 0 || t.Size()%o.Size() != 0 {
+		return fmt.Errorf("tensai: elementwise size mismatch: %d vs %d", t.Size(), o.Size())
+	}
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	params := [4]uint32{uint32(t.Size()), uint32(o.Size()), 0, 0}
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+
+	entries := [3]wgpuBindGroupEntry{
+		{binding: 26, buffer: bufParams, size: 16},
+		{binding: 27, buffer: t.buf, size: uint64(t.Size()) * 4},
+		{binding: 28, buffer: o.buf, size: uint64(o.Size()) * 4},
+	}
+	bindGroup := g.makeBindGroup(lay, entries[:])
+	runtime.KeepAlive(&entries)
+	defer fnBindGroupRelease(bindGroup)
+
+	x, y := split2D((t.Size() + gpuKernelWG - 1) / gpuKernelWG)
+	return g.dispatch(pipe, bindGroup, x, y, 1)
+}
+
+// Add computes t += o elementwise in place. o may be shorter as long as
+// its size divides t's: it repeats, which applies a row bias to every row.
+func (t *GPUTensor) Add(o *GPUTensor) error {
+	return t.eltwiseIP(t.g.pipes.addIP, t.g.pipes.layAddIP, o)
+}
+
+// SiluMul computes t = silu(t) * o elementwise in place — the SwiGLU
+// joint, with t the gate projection and o the up projection.
+func (t *GPUTensor) SiluMul(o *GPUTensor) error {
+	return t.eltwiseIP(t.g.pipes.siluMulIP, t.g.pipes.laySiluMulIP, o)
+}
+
+// CopyRowsInto copies t's whole buffer into dst starting at element offset
+// off — appending freshly projected k/v rows to a preallocated cache
+// without leaving the device.
+func (t *GPUTensor) CopyRowsInto(dst *GPUTensor, off int) error {
+	if t.freed || dst.freed {
+		return errors.New("tensai: gpu tensor already freed")
+	}
+	if t.g != dst.g {
+		return errors.New("tensai: gpu tensors belong to different GPUs")
+	}
+	if off < 0 || off+t.Size() > dst.Size() {
+		return fmt.Errorf("tensai: copy of %d elements at %d overflows %d", t.Size(), off, dst.Size())
+	}
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+	if g.batchEnc != 0 {
+		fnEncoderCopyBuffer(g.batchEnc, t.buf, 0, dst.buf, uint64(off)*4, uint64(t.Size())*4)
+		return nil
+	}
+	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
+	fnEncoderCopyBuffer(encoder, t.buf, 0, dst.buf, uint64(off)*4, uint64(t.Size())*4)
+	cmd := fnEncoderFinish(encoder, nil)
+	fnCmdEncoderRelease(encoder)
+	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
+	fnCmdBufferRelease(cmd)
+	if uncapturedCB != "" {
+		return fmt.Errorf("tensai: gpu copy failed: %s", uncapturedCB)
+	}
+	return nil
+}
+
+// GroupedCausalAttention is causal multi-head attention against a
+// KV cache that may pack fewer heads than the queries (grouped-query
+// attention) and hold more positions than are valid: q is (seq, heads*dh),
+// k and v hold at least seqKV rows of kvHeads*dh (extra cache capacity
+// beyond seqKV is ignored), and query i attends to positions
+// 0..i+(seqKV-seq). Head h reads kv head h/(heads/kvHeads). One fused
+// dispatch, dh at most 128.
+func (q *GPUTensor) GroupedCausalAttention(k, v *GPUTensor, heads, kvHeads, seqKV int) (*GPUTensor, error) {
+	if q.freed || k.freed || v.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if q.g != k.g || q.g != v.g {
+		return nil, errors.New("tensai: gpu tensors belong to different GPUs")
+	}
+	nd := len(q.shape)
+	if nd == 0 {
+		return nil, errors.New("tensai: attention needs at least 1 axis")
+	}
+	d := q.shape[nd-1]
+	if heads <= 0 || kvHeads <= 0 || d%heads != 0 || heads%kvHeads != 0 {
+		return nil, fmt.Errorf("tensai: %d query heads / %d kv heads do not divide dimension %d", heads, kvHeads, d)
+	}
+	dh := d / heads
+	if dh > 128 {
+		return nil, fmt.Errorf("tensai: grouped attention head dimension %d exceeds 128", dh)
+	}
+	seq := q.Size() / d
+	kvDim := kvHeads * dh
+	if seqKV < seq {
+		return nil, fmt.Errorf("tensai: grouped attention needs seqKV >= seq, got %d < %d", seqKV, seq)
+	}
+	if k.Size() < seqKV*kvDim || v.Size() < seqKV*kvDim {
+		return nil, fmt.Errorf("tensai: kv cache of %d/%d elements is smaller than %d x %d", k.Size(), v.Size(), seqKV, kvDim)
+	}
+	group := heads / kvHeads
+	offs := make([]uint32, 4*heads)
+	for h := 0; h < heads; h++ {
+		offs[4*h] = uint32(h * dh)
+		offs[4*h+1] = uint32((h / group) * dh)
+		offs[4*h+2] = uint32(h * dh)
+	}
+	rows := heads * seq
+	params := [8]uint32{
+		uint32(seq), uint32(seqKV), uint32(dh), uint32(d),
+		uint32(rows), uint32(seqKV - seq), uint32(kvDim), 0,
+	}
+
+	g := q.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	outBytes := uint64(q.Size()) * 4
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
+	bufOffs := g.takeBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4)
+	bufOut := g.takeBuffer(gpuTensorUsage, outBytes)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32, bufParams)
+	defer g.putBuffer(wgpuBufferUsageStorage|wgpuBufferUsageCopyDst, uint64(len(offs))*4, bufOffs)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 32)
+	fnQueueWriteBuffer(g.queue, bufOffs, 0, unsafe.Pointer(&offs[0]), uintptr(len(offs))*4)
+
+	entries := [6]wgpuBindGroupEntry{
+		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
+		{binding: 10, buffer: bufParams, size: 32},
+		{binding: 11, buffer: q.buf, size: uint64(q.Size()) * 4},
+		{binding: 12, buffer: k.buf, size: uint64(k.Size()) * 4},
+		{binding: 13, buffer: v.buf, size: uint64(v.Size()) * 4},
+		{binding: 14, buffer: bufOut, size: outBytes},
+	}
+	bindGroup := g.makeBindGroup(g.pipes.layAttn, entries[:])
+	runtime.KeepAlive(&entries)
+	defer fnBindGroupRelease(bindGroup)
+
+	x, y := split2D(rows)
+	if err := g.dispatch(g.pipes.attn, bindGroup, x, y, 1); err != nil {
+		fnBufferRelease(bufOut)
+		return nil, err
+	}
+	return &GPUTensor{g: g, buf: bufOut, shape: append([]int(nil), q.shape...)}, nil
 }


### PR DESCRIPTION
Lands the remaining decode ops on the device: RMSNorm, in-place RoPE, Add with row-bias broadcast, SiluMul, CopyRowsInto for appending k/v rows to a resident cache, and GroupedCausalAttention — the fused causal kernel gains a separate kv row stride so the cache packs fewer heads than the queries (GQA) and reads only its valid prefix. BeginBatch/Flush record a whole token's dispatches into one queue submission, and freed transients recycle through an exact-size buffer pool, held back while a batch is open because queue writes jump unsubmitted encoders.

_example/qwen -q8 -gpu uploads every block's int8 weights once, prefills the prompt on the CPU, syncs the KV cache up, and then decodes with a single hidden-state download per token; the final norm, lm_head, and sampling stay on the CPU. Verified on lavapipe (wgpu v22) and a Ryzen iGPU via dozen (wgpu24 v29); 0.5B answers match the CPU path's quality.

Decode step on the iGPU through dozen, same session:

| stage | naive | batched + pooled |
|---|---|---|
| record | 60ms | 7ms |
| exec + readback | 170ms | 45ms |
| tok/s steady state | 1.2 | ~17 |