### PR TITLE
GPU decode in chat mode

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -26,6 +26,7 @@ type gpuQwen struct {
 	g      *tensai.GPU
 	layers []gpuLayer
 	nCtx   int
+	gpuLen int // cache positions currently valid on the GPU
 }
 
 func must[T any](v T, err error) T {
@@ -68,35 +69,66 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 	return gq, nil
 }
 
-// syncCache copies the CPU-side KV cache — the prompt prefill — into the
-// GPU caches, one upload per layer.
-func (gq *gpuQwen) syncCache() error {
+// syncUp copies CPU-side cache rows the GPU has not seen yet — a fresh
+// prompt prefill, or a chat turn's new tokens — into the GPU caches.
+func (gq *gpuQwen) syncUp() error {
 	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
+	cpuLen := len(gq.m.blocks[0].kc)
+	if cpuLen > gq.nCtx {
+		return fmt.Errorf("prefill of %d tokens exceeds gpu cache of %d", cpuLen, gq.nCtx)
+	}
+	lo := gq.gpuLen
+	if cpuLen <= lo {
+		return nil
+	}
 	for i := range gq.layers {
 		cb := &gq.m.blocks[i]
-		if len(cb.kc) > gq.nCtx {
-			return fmt.Errorf("prefill of %d tokens exceeds gpu cache of %d", len(cb.kc), gq.nCtx)
-		}
 		for _, pair := range [2]struct {
 			rows [][]float32
 			dst  *tensai.GPUTensor
 		}{{cb.kc, gq.layers[i].kc}, {cb.vc, gq.layers[i].vc}} {
-			if len(pair.rows) == 0 {
-				continue
-			}
-			flat := &tensai.Tensor{Shape: []int{len(pair.rows), kvDim}, Data: make([]float32, len(pair.rows)*kvDim)}
-			for t, row := range pair.rows {
+			flat := &tensai.Tensor{Shape: []int{cpuLen - lo, kvDim}, Data: make([]float32, (cpuLen-lo)*kvDim)}
+			for t, row := range pair.rows[lo:] {
 				copy(flat.Data[t*kvDim:], row)
 			}
 			tmp, err := gq.g.Upload(flat)
 			if err != nil {
 				return err
 			}
-			err = tmp.CopyRowsInto(pair.dst, 0)
+			err = tmp.CopyRowsInto(pair.dst, lo*kvDim)
 			tmp.Free()
 			if err != nil {
 				return err
 			}
+		}
+	}
+	gq.gpuLen = cpuLen
+	return nil
+}
+
+// syncBack appends the rows GPU decoding produced since the CPU cache
+// last saw them, so the next turn's CPU prefill attends over the whole
+// conversation — the piece that lets -gpu and -chat compose.
+func (gq *gpuQwen) syncBack() error {
+	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
+	cpuLen := len(gq.m.blocks[0].kc)
+	if gq.gpuLen <= cpuLen {
+		return nil
+	}
+	n := gq.gpuLen - cpuLen
+	for i := range gq.layers {
+		cb := &gq.m.blocks[i]
+		kt, err := gq.layers[i].kc.DownloadRange(cpuLen*kvDim, n*kvDim)
+		if err != nil {
+			return err
+		}
+		vt, err := gq.layers[i].vc.DownloadRange(cpuLen*kvDim, n*kvDim)
+		if err != nil {
+			return err
+		}
+		for t := 0; t < n; t++ {
+			cb.kc = append(cb.kc, kt.Data[t*kvDim:(t+1)*kvDim])
+			cb.vc = append(cb.vc, vt.Data[t*kvDim:(t+1)*kvDim])
 		}
 	}
 	return nil
@@ -150,6 +182,9 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 		}
 		k.Free()
 		v.Free()
+		if pos+1 > gq.gpuLen {
+			gq.gpuLen = pos + 1
+		}
 		attn := must(q.GroupedCausalAttention(l.kc, l.vc, cfg.Heads, cfg.KVHeads, pos+1))
 		q.Free()
 		proj := must(l.qo.MatMul(attn))

--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -265,10 +265,6 @@ func main() {
 	// still prefills on the CPU, and syncCache carries it over below.
 	var gq *gpuQwen
 	if *gpu {
-		if *chat {
-			fmt.Fprintln(os.Stderr, "-gpu does not support -chat yet (the CPU and GPU caches would diverge)")
-			os.Exit(1)
-		}
 		if bits != 8 {
 			fmt.Fprintln(os.Stderr, "-gpu requires -q8")
 			os.Exit(1)
@@ -330,9 +326,25 @@ func main() {
 			if !sc.Scan() || strings.TrimSpace(sc.Text()) == "" {
 				break
 			}
+			// Each turn's prompt prefills on the CPU; with -gpu the new
+			// cache rows sync up, the turn decodes on the device, and the
+			// rows it appended sync back for the next turn's prefill.
 			feed(tok.Encode("<|im_start|>user\n" + sc.Text() + "<|im_end|>\n<|im_start|>assistant\n"))
+			if gq != nil {
+				if err := gq.syncUp(); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				stepFn = gq.step
+			}
 			generate(*n)
 			feed(tok.Encode("\n"))
+			if gq != nil {
+				if err := gq.syncBack(); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+			}
 			if steps >= nCtx-64 {
 				fmt.Fprintln(os.Stderr, "context window exhausted")
 				break
@@ -353,7 +365,7 @@ func main() {
 	feed(ids)
 	fmt.Fprintf(os.Stderr, "prefill: %v\n", time.Since(start).Round(time.Millisecond))
 	if gq != nil {
-		if err := gq.syncCache(); err != nil {
+		if err := gq.syncUp(); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -124,3 +124,6 @@ func (g *GPU) BeginBatch() error { return errNoWGPU }
 
 // Flush is a no-op in builds without the wgpu tag.
 func (g *GPU) Flush() error { return nil }
+
+// DownloadRange always fails in builds without the wgpu tag.
+func (t *GPUTensor) DownloadRange(off, n int) (*Tensor, error) { return nil, errNoWGPU }

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -983,6 +983,58 @@ func (t *GPUTensor) Download() (*Tensor, error) {
 	return out, nil
 }
 
+// DownloadRange copies elements [off, off+n) back into host memory as a
+// flat tensor — reading freshly appended rows out of a resident cache
+// without moving the whole buffer. Like Download it flushes an open
+// batch first.
+func (t *GPUTensor) DownloadRange(off, n int) (*Tensor, error) {
+	if t.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if off < 0 || n <= 0 || off+n > t.Size() {
+		return nil, fmt.Errorf("tensai: download of %d elements at %d overflows %d", n, off, t.Size())
+	}
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	if err := g.flushLocked(); err != nil {
+		return nil, err
+	}
+	out := NewTensor(n)
+	bytes := uint64(n) * 4
+	staging, stagingSize := g.takeReadback(bytes)
+	if staging == 0 {
+		return nil, errors.New("tensai: gpu readback buffer allocation failed")
+	}
+	reuse := false
+	defer func() {
+		if reuse {
+			g.putReadback(staging, stagingSize)
+		} else {
+			fnBufferRelease(staging)
+		}
+	}()
+	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
+	fnEncoderCopyBuffer(encoder, t.buf, uint64(off)*4, staging, 0, bytes)
+	cmd := fnEncoderFinish(encoder, nil)
+	fnCmdEncoderRelease(encoder)
+	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
+	fnCmdBufferRelease(cmd)
+	src, err := g.mapRead(staging, bytes)
+	if err != nil {
+		return nil, err
+	}
+	copy(out.Data, unsafe.Slice((*Float)(src), n))
+	fnBufferUnmap(staging)
+	reuse = true
+	return out, nil
+}
+
 // Free releases the GPU buffer (into the transient pool, from which the
 // next same-sized tensor will reuse it). The tensor must not be used
 // afterwards; calling Free again is a no-op.


### PR DESCRIPTION
DownloadRange reads a slice of a resident GPU buffer back to the host, which closes the cache-divergence gap that kept -gpu out of chat mode. Each turn's prompt still prefills on the CPU; syncUp copies only the rows the GPU has not seen, the turn decodes on the device, and syncBack appends the freshly generated k/v rows to the CPU cache, so the next turn's prefill attends over the whole conversation.

Verified on a real iGPU via dozen: memory carries across turns (the name-recall test), and the CPU-only chat path behaves as before.