### PR TITLE
Fused qkv and gate/up projections

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -175,7 +175,7 @@ func loadGGUF(path string, bits int) (*qwen, *tokenizer.Tokenizer, error) {
 	}
 	// Projection weights arrive [out, in] like HF's; transpose for the
 	// matvec and quantize immediately so the float32 copy dies here.
-	lin := func(name string, unpermute int) (*tensai.Matrix, *qmat) {
+	trans := func(name string, unpermute int) *tensai.Matrix {
 		m, err := tensor(name).Matrix()
 		if err != nil {
 			panic(err)
@@ -183,11 +183,16 @@ func loadGGUF(path string, bits int) (*qwen, *tokenizer.Tokenizer, error) {
 		if unpermute > 0 {
 			unpermuteRows(m, unpermute)
 		}
-		w := m.T()
+		return m.T()
+	}
+	quant := func(w *tensai.Matrix) (*tensai.Matrix, *qmat) {
 		if bits == 0 {
 			return w, nil
 		}
 		return nil, quantizeMat(w, bits)
+	}
+	lin := func(name string, unpermute int) (*tensai.Matrix, *qmat) {
+		return quant(trans(name, unpermute))
 	}
 
 	// Only the llama architecture's q/k rows are stored permuted.
@@ -218,15 +223,20 @@ func loadGGUF(path string, bits int) (*qwen, *tokenizer.Tokenizer, error) {
 		p := fmt.Sprintf("blk.%d.", i)
 		b.ln1 = tensor(p + "attn_norm.weight").Data
 		b.ln2 = tensor(p + "ffn_norm.weight").Data
-		b.wq, b.qq = lin(p+"attn_q.weight", qPerm)
-		b.bq = unpermuteVec(vecOpt(p+"attn_q.bias"), qPerm)
-		b.wk, b.qk = lin(p+"attn_k.weight", kPerm)
-		b.bk = unpermuteVec(vecOpt(p+"attn_k.bias"), kPerm)
-		b.wv, b.qv = lin(p+"attn_v.weight", 0)
-		b.bv = vecOpt(p + "attn_v.bias")
+		b.wQKV, b.qQKV = quant(hcat([]*tensai.Matrix{
+			trans(p+"attn_q.weight", qPerm),
+			trans(p+"attn_k.weight", kPerm),
+			trans(p+"attn_v.weight", 0),
+		}))
+		b.bQKV = catVec(
+			unpermuteVec(vecOpt(p+"attn_q.bias"), qPerm),
+			unpermuteVec(vecOpt(p+"attn_k.bias"), kPerm),
+			vecOpt(p+"attn_v.bias"))
 		b.wo, b.qo = lin(p+"attn_output.weight", 0)
-		b.wGate, b.qGate = lin(p+"ffn_gate.weight", 0)
-		b.wUp, b.qUp = lin(p+"ffn_up.weight", 0)
+		b.wGU, b.qGU = quant(hcat([]*tensai.Matrix{
+			trans(p+"ffn_gate.weight", 0),
+			trans(p+"ffn_up.weight", 0),
+		}))
 		b.wDown, b.qDown = lin(p+"ffn_down.weight", 0)
 	}
 	return m, tok, nil

--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -29,6 +29,35 @@ type gpuQwen struct {
 	gpuLen int // cache positions currently valid on the GPU
 }
 
+// sliceQ copies a column range out of a fused quantized matrix: the GPU
+// path keeps q, k, v (and gate, up) as separate resident weights, and
+// per-column quantization makes the slice exact.
+func sliceQ(q *tensai.QMatrix, lo, hi int) *tensai.QMatrix {
+	pairs := (q.Rows + 1) / 2
+	cols := hi - lo
+	out := &tensai.QMatrix{
+		Rows:     q.Rows,
+		Cols:     cols,
+		Q:        make([]int8, pairs*2*cols+16),
+		Scale:    make([]float32, cols),
+		ColSum64: make([]int32, cols+8),
+	}
+	copy(out.Scale, q.Scale[lo:hi])
+	copy(out.ColSum64, q.ColSum64[lo:hi])
+	for i2 := 0; i2 < pairs; i2++ {
+		copy(out.Q[i2*2*cols:i2*2*cols+2*cols], q.Q[i2*2*q.Cols+2*lo:i2*2*q.Cols+2*hi])
+	}
+	return out
+}
+
+// vecRange slices a fused bias, staying nil for biasless models.
+func vecRange(v []float32, lo, hi int) []float32 {
+	if v == nil {
+		return nil
+	}
+	return v[lo:hi]
+}
+
 func must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)
@@ -47,21 +76,25 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 		}
 		return must(g.Upload(&tensai.Tensor{Shape: []int{len(v)}, Data: v}))
 	}
+	hs := m.cfg.HiddenSize
+	inter := m.cfg.Intermediate
 	gq := &gpuQwen{m: m, g: g, nCtx: nCtx, layers: make([]gpuLayer, len(m.blocks))}
 	for i := range m.blocks {
 		b := &m.blocks[i]
-		if b.qq == nil || b.qq.q8 == nil {
+		if b.qQKV == nil || b.qQKV.q8 == nil {
 			return nil, fmt.Errorf("gpu decode needs int8 weights (run with -q8)")
 		}
 		l := &gq.layers[i]
 		l.ln1, l.ln2 = vec(b.ln1), vec(b.ln2)
-		l.bq, l.bk, l.bv = vec(b.bq), vec(b.bk), vec(b.bv)
-		l.qq = must(g.UploadQ8(b.qq.q8))
-		l.qk = must(g.UploadQ8(b.qk.q8))
-		l.qv = must(g.UploadQ8(b.qv.q8))
+		l.bq = vec(vecRange(b.bQKV, 0, hs))
+		l.bk = vec(vecRange(b.bQKV, hs, hs+kvDim))
+		l.bv = vec(vecRange(b.bQKV, hs+kvDim, hs+2*kvDim))
+		l.qq = must(g.UploadQ8(sliceQ(b.qQKV.q8, 0, hs)))
+		l.qk = must(g.UploadQ8(sliceQ(b.qQKV.q8, hs, hs+kvDim)))
+		l.qv = must(g.UploadQ8(sliceQ(b.qQKV.q8, hs+kvDim, hs+2*kvDim)))
 		l.qo = must(g.UploadQ8(b.qo.q8))
-		l.qGate = must(g.UploadQ8(b.qGate.q8))
-		l.qUp = must(g.UploadQ8(b.qUp.q8))
+		l.qGate = must(g.UploadQ8(sliceQ(b.qGU.q8, 0, inter)))
+		l.qUp = must(g.UploadQ8(sliceQ(b.qGU.q8, inter, 2*inter)))
 		l.qDown = must(g.UploadQ8(b.qDown.q8))
 		l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
 		l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))

--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -61,14 +61,18 @@ func quantizeMat(m *tensai.Matrix, bits int) *qmat {
 	panic("unsupported quantization width")
 }
 
+// qblock holds one layer's weights. The q, k, and v projections fuse
+// into one matrix (columns [q | k | v]) and gate/up into another, so a
+// decode step streams four weight matrices instead of seven — quantization
+// is per column, so the fused results are bit-identical to separate calls.
 type qblock struct {
-	ln1, ln2          []float32
-	wq, wk, wv, wo    *tensai.Matrix // [in, out] after transposing HF's [out, in]
-	bq, bk, bv        []float32
-	wGate, wUp, wDown *tensai.Matrix
-	qq, qk, qv, qo    *qmat
-	qGate, qUp, qDown *qmat
-	kc, vc            [][]float32 // KV cache, kvHeads*headDim per position
+	ln1, ln2   []float32
+	wQKV, wo   *tensai.Matrix // [in, out] after transposing HF's [out, in]
+	bQKV       []float32
+	wGU, wDown *tensai.Matrix
+	qQKV, qo   *qmat
+	qGU, qDown *qmat
+	kc, vc     [][]float32 // KV cache, kvHeads*headDim per position
 }
 
 type qwen struct {
@@ -156,6 +160,27 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 		}
 		return nil, quantizeMat(w, bits)
 	}
+	// linqFused transposes and column-concatenates several [out, in]
+	// weights into one [in, sum(out)] matrix before quantizing.
+	linqFused := func(names ...string) (*tensai.Matrix, *qmat) {
+		var parts []*tensai.Matrix
+		for _, name := range names {
+			t, err := f.Tensor(name)
+			if err != nil {
+				panic(err)
+			}
+			m, err := t.Matrix()
+			if err != nil {
+				panic(err)
+			}
+			parts = append(parts, m.T())
+		}
+		w := hcat(parts)
+		if bits == 0 {
+			return w, nil
+		}
+		return nil, quantizeMat(w, bits)
+	}
 
 	m := &qwen{cfg: cfg, headSz: cfg.HiddenSize / cfg.Heads}
 	m.embed, err = f.Tensor("model.embed_tokens.weight")
@@ -183,18 +208,45 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 		p := fmt.Sprintf("model.layers.%d.", i)
 		b.ln1 = vec(p + "input_layernorm.weight")
 		b.ln2 = vec(p + "post_attention_layernorm.weight")
-		b.wq, b.qq = linq(p + "self_attn.q_proj.weight")
-		b.bq = vecOpt(p + "self_attn.q_proj.bias")
-		b.wk, b.qk = linq(p + "self_attn.k_proj.weight")
-		b.bk = vecOpt(p + "self_attn.k_proj.bias")
-		b.wv, b.qv = linq(p + "self_attn.v_proj.weight")
-		b.bv = vecOpt(p + "self_attn.v_proj.bias")
+		b.wQKV, b.qQKV = linqFused(p+"self_attn.q_proj.weight", p+"self_attn.k_proj.weight", p+"self_attn.v_proj.weight")
+		b.bQKV = catVec(vecOpt(p+"self_attn.q_proj.bias"), vecOpt(p+"self_attn.k_proj.bias"), vecOpt(p+"self_attn.v_proj.bias"))
 		b.wo, b.qo = linq(p + "self_attn.o_proj.weight")
-		b.wGate, b.qGate = linq(p + "mlp.gate_proj.weight")
-		b.wUp, b.qUp = linq(p + "mlp.up_proj.weight")
+		b.wGU, b.qGU = linqFused(p+"mlp.gate_proj.weight", p+"mlp.up_proj.weight")
 		b.wDown, b.qDown = linq(p + "mlp.down_proj.weight")
 	}
 	return m, nil
+}
+
+// hcat concatenates matrices with equal rows along the columns.
+func hcat(parts []*tensai.Matrix) *tensai.Matrix {
+	rows := parts[0].Rows
+	cols := 0
+	for _, p := range parts {
+		cols += p.Cols
+	}
+	out := tensai.NewMatrix(rows, cols)
+	off := 0
+	for _, p := range parts {
+		for r := 0; r < rows; r++ {
+			copy(out.Data[r*cols+off:], p.Data[r*p.Cols:(r+1)*p.Cols])
+		}
+		off += p.Cols
+	}
+	return out
+}
+
+// catVec concatenates bias vectors; all-nil stays nil (llama).
+func catVec(vs ...[]float32) []float32 {
+	var out []float32
+	any := false
+	for _, v := range vs {
+		any = any || v != nil
+		out = append(out, v...)
+	}
+	if !any {
+		return nil
+	}
+	return out
 }
 
 func rmsnorm(x, w []float32, eps float64) []float32 {
@@ -324,24 +376,25 @@ func (m *qwen) prefill(tokens []int, startPos int) []float32 {
 			copy(a.Data[t*hs:(t+1)*hs], rmsnorm(x.Data[t*hs:(t+1)*hs], w, cfg.RMSEps))
 		}
 	}
+	qkvW := hs + 2*kvDim
 	for li := range m.blocks {
 		b := &m.blocks[li]
 		norm(b.ln1)
-		q := mmb(a, b.wq, b.qq, b.bq)
-		k := mmb(a, b.wk, b.qk, b.bk)
-		v := mmb(a, b.wv, b.qv, b.bv)
+		qkv := mmb(a, b.wQKV, b.qQKV, b.bQKV)
 		for t := 0; t < n; t++ {
 			pos := startPos + t
-			qr := q.Data[t*hs:]
+			row := qkv.Data[t*qkvW : (t+1)*qkvW]
+			qr := row[:hs]
 			for h := 0; h < cfg.Heads; h++ {
 				m.rope(qr[h*m.headSz:(h+1)*m.headSz], pos)
 			}
-			kr := k.Data[t*kvDim : (t+1)*kvDim]
+			kr := row[hs : hs+kvDim]
 			for h := 0; h < cfg.KVHeads; h++ {
 				m.rope(kr[h*m.headSz:(h+1)*m.headSz], pos)
 			}
-			b.kc = append(b.kc, kr)
-			b.vc = append(b.vc, v.Data[t*kvDim:(t+1)*kvDim])
+			// Copies detach the cache rows from the wide fused buffer.
+			b.kc = append(b.kc, append(make([]float32, 0, kvDim), kr...))
+			b.vc = append(b.vc, append(make([]float32, 0, kvDim), row[hs+kvDim:]...))
 		}
 
 		// Causal attention: row t sees cache positions [0, startPos+t].
@@ -360,7 +413,7 @@ func (m *qwen) prefill(tokens []int, startPos int) []float32 {
 				scores := make([]float64, startPos+n)
 				for t := range rowCh {
 					steps := startPos + t + 1
-					qr := q.Data[t*hs : (t+1)*hs]
+					qr := qkv.Data[t*qkvW : t*qkvW+hs]
 					ar := attn.Data[t*hs : (t+1)*hs]
 					for h := 0; h < cfg.Heads; h++ {
 						m.attendHead(b, qr, ar, h, group, steps, scores[:steps])
@@ -376,11 +429,15 @@ func (m *qwen) prefill(tokens []int, startPos int) []float32 {
 		}
 
 		norm(b.ln2)
-		gate := mmb(a, b.wGate, b.qGate, nil)
-		up := mmb(a, b.wUp, b.qUp, nil)
-		for i, g0 := range gate.Data {
-			g := float64(g0)
-			gate.Data[i] = float32(g/(1+math.Exp(-g))) * up.Data[i]
+		gu := mmb(a, b.wGU, b.qGU, nil)
+		inter := cfg.Intermediate
+		gate := tensai.NewMatrix(n, inter)
+		for t := 0; t < n; t++ {
+			row := gu.Data[t*2*inter:]
+			for i := 0; i < inter; i++ {
+				g := float64(row[i])
+				gate.Data[t*inter+i] = float32(g/(1+math.Exp(-g))) * row[inter+i]
+			}
 		}
 		down := mmb(gate, b.wDown, b.qDown, nil)
 		for i := range x.Data {
@@ -400,20 +457,24 @@ func (m *qwen) step(token, pos int) []float32 {
 	x := make([]float32, hs)
 	copy(x, m.embed.Data[token*hs:(token+1)*hs])
 
+	kvDim := cfg.KVHeads * m.headSz
 	for li := range m.blocks {
 		b := &m.blocks[li]
 		a := rmsnorm(x, b.ln1, cfg.RMSEps)
-		q := mv(a, b.wq, b.qq, b.bq)
-		k := mv(a, b.wk, b.qk, b.bk)
-		v := mv(a, b.wv, b.qv, b.bv)
+		qkv := mv(a, b.wQKV, b.qQKV, b.bQKV)
+		q := qkv[:hs]
+		k := qkv[hs : hs+kvDim]
+		v := qkv[hs+kvDim:]
 		for h := 0; h < cfg.Heads; h++ {
 			m.rope(q[h*m.headSz:(h+1)*m.headSz], pos)
 		}
 		for h := 0; h < cfg.KVHeads; h++ {
 			m.rope(k[h*m.headSz:(h+1)*m.headSz], pos)
 		}
-		b.kc = append(b.kc, k)
-		b.vc = append(b.vc, v)
+		// Copy k and v out of the fused row so the cache does not retain
+		// the whole qkv buffer per position.
+		b.kc = append(b.kc, append(make([]float32, 0, kvDim), k...))
+		b.vc = append(b.vc, append(make([]float32, 0, kvDim), v...))
 
 		attn := make([]float32, hs)
 		steps := len(b.kc)
@@ -444,8 +505,8 @@ func (m *qwen) step(token, pos int) []float32 {
 		}
 
 		a = rmsnorm(x, b.ln2, cfg.RMSEps)
-		gate := mv(a, b.wGate, b.qGate, nil)
-		up := mv(a, b.wUp, b.qUp, nil)
+		gu := mv(a, b.wGU, b.qGU, nil)
+		gate, up := gu[:cfg.Intermediate], gu[cfg.Intermediate:]
 		for i := range gate {
 			g := float64(gate[i])
 			gate[i] = float32(g/(1+math.Exp(-g))) * up[i] // silu(gate) * up


### PR DESCRIPTION
The q, k, and v projections concatenate into one weight matrix (columns [q | k | v]) and gate/up into another before quantization, so a decode step streams four weight matrices per layer instead of seven — fewer, longer weight streams and 40% fewer worker spawns, which profiling showed as ~10% of a decode under scheduler overhead. Quantization is per column, so outputs are bit-identical to the unfused build (verified on 0.5B and 1.5B). The GPU path slices the fused QMatrix back into exact per-projection uploads, and both loaders — safetensors and GGUF, with the llama q/k unpermutation applied before fusing — produce the same layout.

Same machine, back to back against main (which already carries the SIMD attention):

| model | decode | before | after | speedup |
|---|---|---|---|---|
| 0.5B -q8 | 300 tokens | 15.0 tok/s | 17.9 tok/s | 1.19x |
| 1.5B -q8 | 160 tokens | 8.2 tok/s | 9.0 tok/s | 1.10x |

Combined with the SIMD attention PR, a long-context 0.5B decode has gone 11.4 -> 17.9 tok/s (1.57x) this session.