### PR TITLE
Top-p sampling for the gpt2 example

### DIFF
--- a/_example/gpt2/main.go
+++ b/_example/gpt2/main.go
@@ -64,9 +64,13 @@ func fetch(dir, name string) (string, error) {
 	return path, os.Rename(tmp, path)
 }
 
-// sample picks the next token: argmax at temperature 0, otherwise a draw
-// from the tempered distribution.
-func sample(logits []float32, temp float64, rng *rand.Rand) int {
+// sample picks the next token: argmax at temperature 0, otherwise a
+// tempered draw restricted to the nucleus — the smallest
+// probability-sorted prefix holding topP of the mass, found through a
+// histogram over probability exponents so only that prefix ever gets
+// sorted (the same scheme as the qwen example). topP >= 1 keeps the
+// whole distribution with a plain CDF walk.
+func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 	if temp <= 0 {
 		best := 0
 		for i, v := range logits {
@@ -76,25 +80,79 @@ func sample(logits []float32, temp float64, rng *rand.Rand) int {
 		}
 		return best
 	}
-	type cand struct {
-		id int
-		p  float64
-	}
-	cands := make([]cand, len(logits))
 	var maxl float32 = logits[0]
 	for _, v := range logits {
 		if v > maxl {
 			maxl = v
 		}
 	}
+	ps := make([]float64, len(logits))
 	var sum float64
 	for i, v := range logits {
 		p := math.Exp(float64(v-maxl) / temp)
-		cands[i] = cand{i, p}
+		ps[i] = p
 		sum += p
 	}
+
+	if topP >= 1 {
+		r := rng.Float64() * sum
+		for i, p := range ps {
+			r -= p
+			if r <= 0 {
+				return i
+			}
+		}
+		return len(ps) - 1
+	}
+
+	const nb = 1100
+	var bsum [nb]float64
+	bucket := func(p float64) int {
+		b := -math.Ilogb(p)
+		if b < 0 {
+			b = 0
+		} else if b >= nb {
+			b = nb - 1
+		}
+		return b
+	}
+	for _, p := range ps {
+		if p > 0 {
+			bsum[bucket(p)] += p
+		}
+	}
+	target := topP * sum
+	var mass float64
+	cut := nb - 1
+	for b := 0; b < nb; b++ {
+		mass += bsum[b]
+		if mass >= target {
+			cut = b
+			break
+		}
+	}
+	type cand struct {
+		id int
+		p  float64
+	}
+	var cands []cand
+	for i, p := range ps {
+		if p > 0 && bucket(p) <= cut {
+			cands = append(cands, cand{i, p})
+		}
+	}
 	sort.Slice(cands, func(a, b int) bool { return cands[a].p > cands[b].p })
-	r := rng.Float64() * sum
+	mass = 0
+	n := len(cands)
+	for i, c := range cands {
+		mass += c.p
+		if mass >= target {
+			n = i + 1
+			break
+		}
+	}
+	cands = cands[:n]
+	r := rng.Float64() * mass
 	for _, c := range cands {
 		r -= c.p
 		if r <= 0 {
@@ -109,6 +167,7 @@ func main() {
 	prompt := flag.String("prompt", "Hello, I'm a language model,", "prompt text")
 	n := flag.Int("n", 40, "tokens to generate")
 	temp := flag.Float64("temp", 0, "sampling temperature; 0 = greedy")
+	topP := flag.Float64("topp", 0.9, "nucleus sampling: keep the smallest set of tokens with this much probability mass (1 disables)")
 	seed := flag.Int64("seed", 1, "sampling seed for -temp > 0")
 	useGPU := flag.Bool("gpu", false, "run prompt-prefill attention on the GPU (build with -tags wgpu or wgpu24)")
 	q8 := flag.Bool("q8", false, "decode against int8-quantized weights (weight-only, per-column scales)")
@@ -168,7 +227,7 @@ func main() {
 	fmt.Fprintf(os.Stderr, "prefill: %d tokens in %v\n", len(ids), time.Since(start).Round(time.Millisecond))
 	steps := len(ids)
 	for i := 0; i < *n && steps < nCtx; i++ {
-		next := sample(logits, *temp, rng)
+		next := sample(logits, *temp, *topP, rng)
 		fmt.Print(tok.Decode([]int{next}))
 		logits = model.step(next, steps)
 		steps++


### PR DESCRIPTION
Ports the qwen example's nucleus sampler: positive-temperature draws restrict to the smallest probability-sorted prefix holding -topp of the mass (default 0.9, 1 disables), found through the exponent-histogram scheme so only that prefix is ever sorted. Greedy decoding, which doubles as the reference-output check, is untouched.