### PR TITLE
Server: GPU backing and disconnect cancellation

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -343,14 +343,6 @@ func main() {
 		nCtx = 4096
 	}
 
-	if *serveAddr != "" {
-		if err := serve(*serveAddr, model, tok, *system, nCtx, *temp, *topP, imEnd, eot); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		return
-	}
-
 	// With -gpu the transformer blocks decode on the device; the prompt
 	// still prefills on the CPU, and syncCache carries it over below.
 	var gq *gpuQwen
@@ -391,14 +383,43 @@ func main() {
 	// feed pushes tokens through the model, extending the KV cache;
 	// generate then samples until an end token, which is also fed so the
 	// cache stays aligned with the template for the next turn.
-	steps := 0
-	var logits []float32
+	// Qwen3's template disables its thinking mode by opening the assistant
+	// turn with an empty think block; -think leaves the block open so the
+	// model reasons first. Other models just open the turn.
+	asst := "<|im_start|>assistant\n"
+	if model.cfg.ModelType == "qwen3" && !*think {
+		asst += "<think>\n\n</think>\n\n"
+	}
+
 	stepFn := model.step
 	prefillFn := model.prefill
+	reset := func() {
+		model.reset()
+	}
 	if gq != nil {
 		stepFn = gq.step
 		prefillFn = gq.prefill
+		reset = func() {
+			model.reset()
+			gq.gpuLen = 0
+		}
 	}
+
+	if *serveAddr != "" {
+		s := &server{
+			model: model, tok: tok, system: *system, nCtx: nCtx,
+			temp: *temp, topP: *topP, imEnd: imEnd, eot: eot,
+			asst: asst, prefill: prefillFn, step: stepFn, reset: reset,
+		}
+		if err := s.listen(*serveAddr); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	steps := 0
+	var logits []float32
 	feed := func(ids []int) {
 		if len(ids) > 1 {
 			if draftM != nil {
@@ -488,14 +509,6 @@ func main() {
 		fmt.Println()
 		fmt.Fprintf(os.Stderr, "(%d tokens, %.1f tok/s)\n",
 			gen, float64(gen)/time.Since(start).Seconds())
-	}
-
-	// Qwen3's template disables its thinking mode by opening the assistant
-	// turn with an empty think block; -think leaves the block open so the
-	// model reasons first. Other models just open the turn.
-	asst := "<|im_start|>assistant\n"
-	if model.cfg.ModelType == "qwen3" && !*think {
-		asst += "<think>\n\n</think>\n\n"
 	}
 
 	if *chat {

--- a/_example/qwen/serve.go
+++ b/_example/qwen/serve.go
@@ -61,15 +61,19 @@ func chatML(msgs []chatMessage, defaultSystem, asst string) string {
 }
 
 type server struct {
-	mu     sync.Mutex // one request drives the model at a time
-	model  *qwen
-	tok    tokenizerIface
-	system string
-	nCtx   int
-	temp   float64
-	topP   float64
-	imEnd  int
-	eot    int
+	mu      sync.Mutex // one request drives the model at a time
+	model   *qwen
+	tok     tokenizerIface
+	system  string
+	nCtx    int
+	temp    float64
+	topP    float64
+	imEnd   int
+	eot     int
+	asst    string // assistant-turn opening (Qwen3: may close thinking)
+	prefill func([]int, int) []float32
+	step    func(int, int) []float32
+	reset   func()
 }
 
 // tokenizerIface is the slice of the tokenizer the server needs.
@@ -78,9 +82,7 @@ type tokenizerIface interface {
 	Decode([]int) string
 }
 
-func serve(addr string, model *qwen, tok tokenizerIface, system string, nCtx int, temp, topP float64, imEnd, eot int) error {
-	s := &server{model: model, tok: tok, system: system, nCtx: nCtx,
-		temp: temp, topP: topP, imEnd: imEnd, eot: eot}
+func (s *server) listen(addr string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/chat/completions", s.chatCompletions)
 	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
@@ -140,11 +142,7 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	rng := rand.New(rand.NewSource(seed))
 
-	asst := "<|im_start|>assistant\n"
-	if s.model.cfg.ModelType == "qwen3" {
-		asst += "<think>\n\n</think>\n\n"
-	}
-	ids := s.tok.Encode(chatML(req.Messages, s.system, asst))
+	ids := s.tok.Encode(chatML(req.Messages, s.system, s.asst))
 	if len(ids) >= s.nCtx-1 {
 		httpError(w, http.StatusBadRequest, fmt.Sprintf("prompt of %d tokens exceeds the %d-token context", len(ids), s.nCtx))
 		return
@@ -152,7 +150,7 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.model.reset()
+	s.reset()
 
 	id := fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano())
 	created := time.Now().Unix()
@@ -178,11 +176,21 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logits := s.model.prefill(ids, 0)
+	logits := s.prefill(ids, 0)
 	steps := len(ids)
 	var out []int
 	finish := "length"
+	ctx := r.Context()
 	for len(out) < limit && steps < s.nCtx-1 {
+		// A disconnected client stops the generation instead of holding
+		// the model for tokens nobody will read.
+		select {
+		case <-ctx.Done():
+			finish = "abort"
+			steps = s.nCtx // fall out below
+			continue
+		default:
+		}
 		next := sample(logits, temp, topP, rng)
 		if next == s.imEnd || next == s.eot {
 			finish = "stop"
@@ -192,8 +200,11 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		if flush != nil {
 			flush(s.tok.Decode([]int{next}))
 		}
-		logits = s.model.step(next, steps)
+		logits = s.step(next, steps)
 		steps++
+	}
+	if finish == "abort" {
+		return
 	}
 
 	if req.Stream {


### PR DESCRIPTION
The server now runs through the same prefill/step indirection as the CLI, so -serve -q8 -gpu answers over the resident GPU model — the per-request reset rewinds the GPU cache alongside the CPU one — and the assistant-turn opening (including Qwen3's think handling and -think) is decided once and shared between the CLI and the server.

A disconnected client cancels its generation through the request context instead of holding the model mutex for tokens nobody will read: killing a 400-token stream previously blocked the next request for the whole remaining generation; now the follow-up answers in about a second. Verified with curl against the CPU and GPU (dozen) backends.