### PR TITLE
256-bit quad-row int4 kernels

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -40,17 +40,17 @@ type gpuQwen struct {
 // sliceQ4 copies a column range out of a fused 4-bit quantized matrix;
 // scales are per (group, column), so the slice is exact.
 func sliceQ4(q *tensai.Q4Matrix, lo, hi int) *tensai.Q4Matrix {
-	pairs := (q.Rows + 1) / 2
+	quads := (q.Rows + 3) / 4
 	groups := len(q.Scale) / q.Cols
 	cols := hi - lo
 	out := &tensai.Q4Matrix{
 		Rows:  q.Rows,
 		Cols:  cols,
-		Q:     make([]uint8, pairs*cols+16),
+		Q:     make([]uint8, quads*2*cols+32),
 		Scale: make([]float32, groups*cols),
 	}
-	for i2 := 0; i2 < pairs; i2++ {
-		copy(out.Q[i2*cols:i2*cols+cols], q.Q[i2*q.Cols+lo:i2*q.Cols+hi])
+	for i4 := 0; i4 < quads; i4++ {
+		copy(out.Q[i4*2*cols:i4*2*cols+2*cols], q.Q[i4*2*q.Cols+2*lo:i4*2*q.Cols+2*hi])
 	}
 	for g := 0; g < groups; g++ {
 		copy(out.Scale[g*cols:(g+1)*cols], q.Scale[g*q.Cols+lo:g*q.Cols+hi])

--- a/quant4.go
+++ b/quant4.go
@@ -11,28 +11,30 @@ import (
 const q4Group = 64
 
 // Q4Matrix is a weight matrix quantized to 4 bits with one scale per
-// (64-row group, output column). The byte at (i/2)*Cols + j holds column j
-// of an interleaved row pair — row i (even) in the low nibble, row i+1 in
-// the high one, offset-binary (0..15 encodes -8..7), with a zero row
-// appended when Rows is odd. That pairing matches the u8 x s8 pairwise
-// multiply-add the AVX2 kernel is built on, the same W-A7 scheme as
-// QMatrix: activations quantize per call to 7 bits, and since nibbles are
-// at most 15 the i16 pair sums sit far inside saturation.
+// (64-row group, output column). Rows are stored in interleaved quads of
+// two bytes per column: byte (i/4)*2*Cols + 2*j + (i%4)/2 holds rows
+// i..i+3 of column j as four nibbles (each byte low nibble first),
+// offset-binary (0..15 encodes -8..7), zero rows padding the final quad.
+// The 256-bit kernel's nibble unpack turns those two bytes into four
+// consecutive u8 lanes — exactly QMatrix's quad layout — so the same
+// two-instruction multiply-add chain takes a column four rows deep, with
+// activations re-centered to signed bytes and the nibble offset folded
+// out through per-group activation sums.
 type Q4Matrix struct {
 	Rows, Cols int
-	Q          []uint8 // row pairs x Cols, padded for 16-byte loads
+	Q          []uint8 // row quads x 2*Cols, padded for 32-byte loads
 	Scale      []Float
 }
 
 // QuantizeMatrix4 quantizes group-wise, symmetric with round-to-nearest.
 // Columns split across CPUs for large matrices, like QuantizeMatrix.
 func QuantizeMatrix4(m *Matrix) (*Q4Matrix, error) {
-	pairs := (m.Rows + 1) / 2
+	quads := (m.Rows + 3) / 4
 	groups := (m.Rows + q4Group - 1) / q4Group
 	q := &Q4Matrix{
 		Rows:  m.Rows,
 		Cols:  m.Cols,
-		Q:     make([]uint8, pairs*m.Cols+16),
+		Q:     make([]uint8, quads*2*m.Cols+32),
 		Scale: make([]Float, groups*m.Cols),
 	}
 	parallelCols(m.Rows, m.Cols, func(lo, hi int) {
@@ -78,11 +80,11 @@ func quantize4Columns(m *Matrix, q *Q4Matrix, groups, colLo, colHi int) {
 						n = 7
 					}
 				}
-				q.Q[(i/2)*m.Cols+j] |= uint8(n+8) << (4 * (i % 2))
+				q.Q[(i/4)*2*m.Cols+2*j+(i%4)/2] |= uint8(n+8) << (4 * (i % 2))
 			}
 		}
-		if m.Rows%2 == 1 {
-			q.Q[(m.Rows/2)*m.Cols+j] |= 8 << 4 // zero weight for the pad row
+		for i := m.Rows; i < 4*((m.Rows+3)/4); i++ {
+			q.Q[(i/4)*2*m.Cols+2*j+(i%4)/2] |= 8 << (4 * (i % 2)) // zero pad rows
 		}
 	}
 }
@@ -95,8 +97,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 		return fmt.Errorf("tensai: q4matvec shape mismatch: x=%d out=%d, want %dx%d",
 			len(x), len(out), q.Rows, q.Cols)
 	}
-	xu, sx := quantizeActs(x)
-	xu = xu[:(q.Rows+1)&^1] // the int4 kernels expect pair padding
+	xu, sx := quantizeActs(x) // quad-padded, matching the weight layout
 	gsum := make([]int32, (q.Rows+q4Group-1)/q4Group)
 	for i, u := range xu {
 		gsum[min(i/q4Group, len(gsum)-1)] += int32(u) - 64
@@ -136,7 +137,6 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 	gsums := make([][]int32, rows)
 	for r := 0; r < rows; r++ {
 		xus[r], sxs[r] = quantizeActs(x.Data[r*x.Cols : (r+1)*x.Cols])
-		xus[r] = xus[r][:(q.Rows+1)&^1] // the int4 kernels expect pair padding
 		gsums[r] = make([]int32, groups)
 		for i, u := range xus[r] {
 			gsums[r][min(i/q4Group, groups-1)] += int32(u) - 64
@@ -176,26 +176,29 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 	for r := 0; r < 4; r++ {
 		clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+hi])
 	}
-	pairs := len(xus[0]) / 2
+	quads := len(xus[0]) / 4
 	var acc [4][]int32
 	for r := range acc {
 		acc[r] = make([]int32, hi-lo)
 	}
 	for g := 0; g < len(gsums[0]); g++ {
-		ib := g * q4Group / 2
-		ie := min(ib+q4Group/2, pairs)
+		ib := g * q4Group / 4
+		ie := min(ib+q4Group/4, quads)
 		for r := range acc {
 			clear(acc[r])
 		}
-		for i2 := ib; i2 < ie; i2++ {
-			row := qw[i2*cols:]
+		for i4 := ib; i4 < ie; i4++ {
+			row := qw[i4*2*cols:]
 			for r := 0; r < 4; r++ {
-				x0 := int32(xus[r][2*i2]) - 64
-				x1 := int32(xus[r][2*i2+1]) - 64
+				x0 := int32(xus[r][4*i4]) - 64
+				x1 := int32(xus[r][4*i4+1]) - 64
+				x2 := int32(xus[r][4*i4+2]) - 64
+				x3 := int32(xus[r][4*i4+3]) - 64
 				a := acc[r]
 				for j := lo; j < hi; j++ {
-					b := row[j]
-					a[j-lo] += int32(b&0x0F)*x0 + int32(b>>4)*x1
+					b0, b1 := row[2*j], row[2*j+1]
+					a[j-lo] += int32(b0&0x0F)*x0 + int32(b0>>4)*x1 +
+						int32(b1&0x0F)*x2 + int32(b1>>4)*x3
 				}
 			}
 		}
@@ -222,19 +225,22 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 // the AVX2 kernel when available.
 func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, cols, lo, hi int) {
 	clear(out[lo:hi])
-	pairs := len(xu) / 2
+	quads := len(xu) / 4
 	acc := make([]int32, hi-lo)
 	for g := 0; g < len(gsum); g++ {
-		ib := g * q4Group / 2
-		ie := min(ib+q4Group/2, pairs)
+		ib := g * q4Group / 4
+		ie := min(ib+q4Group/4, quads)
 		clear(acc)
-		for i2 := ib; i2 < ie; i2++ {
-			x0 := int32(xu[2*i2]) - 64
-			x1 := int32(xu[2*i2+1]) - 64
-			row := qw[i2*cols:]
+		for i4 := ib; i4 < ie; i4++ {
+			x0 := int32(xu[4*i4]) - 64
+			x1 := int32(xu[4*i4+1]) - 64
+			x2 := int32(xu[4*i4+2]) - 64
+			x3 := int32(xu[4*i4+3]) - 64
+			row := qw[i4*2*cols:]
 			for j := lo; j < hi; j++ {
-				b := row[j]
-				acc[j-lo] += int32(b&0x0F)*x0 + int32(b>>4)*x1
+				b0, b1 := row[2*j], row[2*j+1]
+				acc[j-lo] += int32(b0&0x0F)*x0 + int32(b0>>4)*x1 +
+					int32(b1&0x0F)*x2 + int32(b1>>4)*x3
 			}
 		}
 		srow := scale[g*cols:]

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -4,45 +4,56 @@ package tensai
 
 import "simd/archsimd"
 
-// AVX2 kernel for the 4-bit matvec, sharing the u8 x s8 pairwise
-// multiply-add design of the int8 kernel: a load's low 8 bytes zero-extend
-// to u16 lanes, where masks and a shift split each byte's nibbles into the
-// adjacent-byte pair layout the multiply wants; the signed operand is the
-// broadcast 7-bit activation pair. Nibbles are at most 15, so pair sums
-// cannot approach saturation at any activation width. Each group of 32 row
-// pairs is one register-accumulated block: eight i32x8 accumulators cover
-// a 64-column tile (one cache line per pair row), and the group's scales
-// and offset correction fold in vectorized at the block boundary.
+// 256-bit AVX2 kernels for the 4-bit matvec and matmul over the quad-row
+// layout: sixteen loaded bytes hold eight columns four rows deep (two
+// nibble bytes per column), the zero-extend to u16 lanes plus a mask and
+// shift split each byte into adjacent nibble lanes — landing exactly in
+// the int8 kernels' quad layout — and the u8 x s8 pairwise multiply-add
+// against a broadcast of re-centered signed activations, followed by the
+// widening i16 pair-add, takes the column's whole quad in two multiplies.
+// Nibbles are at most 15 and |activations| at most 63, so the i16 pair
+// sums sit far inside saturation. Group scales and the nibble-offset
+// correction (8 times the group's activation sum) fold in per group.
+
+// q4xQuad packs four re-centered activations into the u32 a broadcast
+// turns into the signed multiply operand.
+func q4xQuad(xu []uint8, i4 int) uint32 {
+	x0 := uint32(uint8(int8(int(xu[4*i4]) - 64)))
+	x1 := uint32(uint8(int8(int(xu[4*i4+1]) - 64)))
+	x2 := uint32(uint8(int8(int(xu[4*i4+2]) - 64)))
+	x3 := uint32(uint8(int8(int(xu[4*i4+3]) - 64)))
+	return x0 | x1<<8 | x2<<16 | x3<<24
+}
+
 func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, cols, lo, hi int) {
 	if !hasAVX2 {
 		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, cols, lo, hi)
 		return
 	}
-	pairs := len(xu) / 2
-	vecEnd := lo + ((hi - lo) &^ 63)
+	quads := len(xu) / 4
+	vecEnd := lo + ((hi - lo) &^ 31)
 	if vecEnd > lo {
-		mLo := archsimd.BroadcastUint16x8(0x000F)
-		mHi := archsimd.BroadcastUint16x8(0x0F00)
+		mLo := archsimd.BroadcastUint16x16(0x000F)
+		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		ones := archsimd.BroadcastInt16x16(1)
 		clear(out[lo:vecEnd])
 		for g := 0; g < len(gsum); g++ {
-			ib := g * q4Group / 2
-			ie := min(ib+q4Group/2, pairs)
+			ib := g * q4Group / 4
+			ie := min(ib+q4Group/4, quads)
 			corr := archsimd.BroadcastInt32x8(8 * gsum[g])
 			srow := scale[g*cols:]
-			for jt := lo; jt < vecEnd; jt += 64 {
-				var a [8]archsimd.Int32x8
-				for i2 := ib; i2 < ie; i2++ {
-					x0 := uint8(int8(int(xu[2*i2]) - 64))
-					x1 := uint8(int8(int(xu[2*i2+1]) - 64))
-					xp := archsimd.BroadcastUint16x8(uint16(x0) | uint16(x1)<<8).AsUint8x16().AsInt8x16()
-					row := qw[i2*cols+jt:]
-					for k := 0; k < 8; k++ {
-						v := loadU8x16(row[8*k:]).ExtendLo8ToUint16()
-						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi))
-						a[k] = a[k].Add(pair.AsUint8x16().DotProductPairsSaturated(xp).ExtendToInt32())
+			for jt := lo; jt < vecEnd; jt += 32 {
+				var a [4]archsimd.Int32x8
+				for i4 := ib; i4 < ie; i4++ {
+					xp := archsimd.BroadcastUint32x8(q4xQuad(xu, i4)).AsInt8x32()
+					row := qw[i4*2*cols+2*jt:]
+					for k := 0; k < 4; k++ {
+						v := loadU8x16(row[16*k:]).ExtendToUint16()
+						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
+						a[k] = a[k].Add(pair.DotProductPairsSaturated(xp).DotProductPairs(ones))
 					}
 				}
-				for k := 0; k < 8; k++ {
+				for k := 0; k < 4; k++ {
 					j := jt + 8*k
 					f := a[k].Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
 					storeF32x8(loadF32x8(out[j:]).Add(f), out[j:])
@@ -60,52 +71,50 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 	}
 }
 
-// q4matmulCols4 is the four-row batched form: per 16-column tile each
-// pair-row's nibble load and split happen once and feed four broadcast
-// activation pairs — eight register accumulators, two per row — so the
-// nibble traffic that dominates a single matvec amortizes fourfold. Group
-// scale and offset folding runs per row at each block edge.
+// q4matmulCols4 is the four-row batched form: per eight-column tile each
+// sixteen-byte nibble load unpacks once and feeds four broadcast
+// activation quads, amortizing the nibble traffic fourfold.
 func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, cols, lo, hi int) {
 	if !hasAVX2 {
 		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, cols, lo, hi)
 		return
 	}
-	pairs := len(xus[0]) / 2
-	vecEnd := lo + ((hi - lo) &^ 15)
+	quads := len(xus[0]) / 4
+	var xq [4][]uint32
+	for r := 0; r < 4; r++ {
+		xq[r] = make([]uint32, quads)
+		for i4 := 0; i4 < quads; i4++ {
+			xq[r][i4] = q4xQuad(xus[r], i4)
+		}
+	}
+	vecEnd := lo + ((hi - lo) &^ 7)
 	if vecEnd > lo {
-		mLo := archsimd.BroadcastUint16x8(0x000F)
-		mHi := archsimd.BroadcastUint16x8(0x0F00)
+		mLo := archsimd.BroadcastUint16x16(0x000F)
+		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		ones := archsimd.BroadcastInt16x16(1)
 		for r := 0; r < 4; r++ {
 			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
 		}
 		for g := 0; g < len(gsums[0]); g++ {
-			ib := g * q4Group / 2
-			ie := min(ib+q4Group/2, pairs)
+			ib := g * q4Group / 4
+			ie := min(ib+q4Group/4, quads)
 			srow := scale[g*cols:]
-			for jt := lo; jt < vecEnd; jt += 16 {
-				var a [4][2]archsimd.Int32x8
-				for i2 := ib; i2 < ie; i2++ {
-					row := qw[i2*cols+jt:]
-					v0 := loadU8x16(row).ExtendLo8ToUint16()
-					p0 := v0.And(mLo).Or(v0.ShiftAllLeft(4).And(mHi)).AsUint8x16()
-					v1 := loadU8x16(row[8:]).ExtendLo8ToUint16()
-					p1 := v1.And(mLo).Or(v1.ShiftAllLeft(4).And(mHi)).AsUint8x16()
+			for jt := lo; jt < vecEnd; jt += 8 {
+				var a [4]archsimd.Int32x8
+				for i4 := ib; i4 < ie; i4++ {
+					v := loadU8x16(qw[i4*2*cols+2*jt:]).ExtendToUint16()
+					pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
 					for r := 0; r < 4; r++ {
-						x0 := uint8(int8(int(xus[r][2*i2]) - 64))
-						x1 := uint8(int8(int(xus[r][2*i2+1]) - 64))
-						xp := archsimd.BroadcastUint16x8(uint16(x0) | uint16(x1)<<8).AsUint8x16().AsInt8x16()
-						a[r][0] = a[r][0].Add(p0.DotProductPairsSaturated(xp).ExtendToInt32())
-						a[r][1] = a[r][1].Add(p1.DotProductPairsSaturated(xp).ExtendToInt32())
+						xp := archsimd.BroadcastUint32x8(xq[r][i4]).AsInt8x32()
+						a[r] = a[r].Add(pair.DotProductPairsSaturated(xp).DotProductPairs(ones))
 					}
 				}
+				sc := loadF32x8(srow[jt:])
 				for r := 0; r < 4; r++ {
 					corr := archsimd.BroadcastInt32x8(8 * gsums[r][g])
 					o := out.Data[(r0+r)*cols:]
-					for k := 0; k < 2; k++ {
-						j := jt + 8*k
-						f := a[r][k].Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
-						storeF32x8(loadF32x8(o[j:]).Add(f), o[j:])
-					}
+					f := a[r].Sub(corr).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(o[jt:]).Add(f), o[jt:])
 				}
 			}
 		}

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -38,7 +38,7 @@ func TestQuantize4MatVec(t *testing.T) {
 				rlo, rhi := g*q4Group, min((g+1)*q4Group, c.rows)
 				var acc, gs int64
 				for i := rlo; i < rhi; i++ {
-					nib := int64(q.Q[(i/2)*c.cols+j]>>(4*(i%2))) & 0x0F
+					nib := int64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
 					xs := int64(xu[i]) - 64
 					acc += nib * xs
 					gs += xs

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -1076,7 +1076,7 @@ func TestGPUQ4MatMul(t *testing.T) {
 			for j := 0; j < c.cols; j++ {
 				var want float64
 				for i := 0; i < c.rows; i++ {
-					nib := float64(q.Q[(i/2)*c.cols+j]>>(4*(i%2))&0x0F) - 8
+					nib := float64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))&0x0F) - 8
 					sc := float64(q.Scale[(i/64)*c.cols+j])
 					want += float64(x.Data[r*c.rows+i]) * nib * sc
 				}

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -2124,10 +2124,19 @@ func (g *GPU) UploadQ4(q *Q4Matrix) (*GPUQ4Matrix, error) {
 	}
 	pairs := (q.Rows + 1) / 2
 	words := (q.Cols + 3) / 4
+	// The CPU layout stores row quads (two nibble bytes per column); the
+	// kernel walks row pairs, so repack nibble pairs on the way in.
+	nib := func(i, j int) uint32 {
+		if i >= q.Rows {
+			return 8 // zero pad row
+		}
+		return uint32(q.Q[(i/4)*2*q.Cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
+	}
 	packed := make([]uint32, pairs*words)
 	for i2 := 0; i2 < pairs; i2++ {
 		for j := 0; j < q.Cols; j++ {
-			packed[i2*words+j/4] |= uint32(q.Q[i2*q.Cols+j]) << (8 * (j % 4))
+			b := nib(2*i2, j) | nib(2*i2+1, j)<<4
+			packed[i2*words+j/4] |= b << (8 * (j % 4))
 		}
 	}
 	groups := (q.Rows + 63) / 64 // q4Group


### PR DESCRIPTION
The int4 layout follows the int8 move to row quads: two nibble bytes per column hold four rows, and the 256-bit kernel's zero-extend-mask-shift unpack lands those nibbles exactly in the quad byte layout, so the same VPMADDUBSW-plus-widening-pair-add chain takes a column four rows deep in two multiplies. Activations re-center to signed bytes and the nibble offset still folds out through per-group activation sums, unchanged.

The int4 path was ALU-bound rather than DRAM-bound (~9GB/s physical against the int8 kernel's 31GB/s), so unlike int8 the decode itself speeds up, not just prefill. Outputs are bit-identical end to end. Interleaved same-session:

| benchmark | before | after |
|---|---|---|
| matvec 4096x16384 | 3.2-3.5ms | 2.0-2.2ms (1.6x) |
| batched prefill 64x1536 @ 1536x8960 | 20.5-21.6ms | 11.6-12.4ms (1.75x) |
| qwen 0.5B -q4 decode (128 tok) | 13.3 tok/s | 20.1 tok/s (1.5x) |

With this, int4 finally decodes faster than int8 on small models, as its byte count says it should. The GPU repack converts quads back to the GPU kernel's pair form and the example's fused-weight column slicing follows the new layout; plain, simd, wgpu (lavapipe) and wgpu24 (dozen) suites pass, and -q4 -gpu answers correctly. 7B numbers will follow separately: the parallel loader's staging spike can OOM the whole WSL VM on 7B-class tensors, which the next PR bounds.