### PR TITLE
Memory-mapped checkpoint reading

### DIFF
--- a/encoding/gguf/gguf.go
+++ b/encoding/gguf/gguf.go
@@ -23,6 +23,7 @@
 package gguf
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -31,6 +32,7 @@ import (
 	"sort"
 
 	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/mmapfile"
 )
 
 // Tensor encodings from the GGML type enum; only the ones this package
@@ -92,6 +94,8 @@ type tensorInfo struct {
 type File struct {
 	r        io.ReaderAt
 	closer   io.Closer
+	data     []byte // the whole file when memory-mapped; nil otherwise
+	unmap    func() error
 	kv       map[string]any
 	tensors  map[string]tensorInfo
 	names    []string
@@ -99,10 +103,25 @@ type File struct {
 }
 
 // Open opens a GGUF file and parses its metadata and tensor directory.
+// The file is memory-mapped where the platform allows, so tensor blocks
+// dequantize straight out of the page cache; otherwise reads go through
+// ReadAt.
 func Open(path string) (*File, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
+	}
+	if data, unmap, err := mmapfile.Map(f); err == nil {
+		g, err := NewFile(bytes.NewReader(data))
+		if err != nil {
+			unmap()
+			f.Close()
+			return nil, err
+		}
+		g.data = data
+		g.unmap = unmap
+		g.closer = f
+		return g, nil
 	}
 	g, err := NewFile(f)
 	if err != nil {
@@ -177,12 +196,21 @@ func NewFile(r io.ReaderAt) (*File, error) {
 	return g, nil
 }
 
-// Close closes the underlying file when the File was created by Open.
+// Close unmaps and closes the underlying file when the File was created
+// by Open.
 func (f *File) Close() error {
-	if f.closer != nil {
-		return f.closer.Close()
+	var err error
+	if f.unmap != nil {
+		err = f.unmap()
+		f.unmap = nil
+		f.data = nil
 	}
-	return nil
+	if f.closer != nil {
+		if cerr := f.closer.Close(); err == nil {
+			err = cerr
+		}
+	}
+	return err
 }
 
 // Names returns the tensor names in sorted order.
@@ -293,9 +321,19 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 	if n%spec.values != 0 {
 		return nil, fmt.Errorf("gguf: tensor %q: %d values not a whole number of blocks", name, n)
 	}
-	raw := make([]byte, n/spec.values*spec.bytes)
-	if _, err := f.r.ReadAt(raw, f.dataBase+t.offset); err != nil {
-		return nil, fmt.Errorf("gguf: tensor %q: %w", name, err)
+	var raw []byte
+	nbytes := n / spec.values * spec.bytes
+	if f.data != nil {
+		lo := f.dataBase + t.offset
+		if lo < 0 || lo+nbytes > int64(len(f.data)) {
+			return nil, fmt.Errorf("gguf: tensor %q extends past the file", name)
+		}
+		raw = f.data[lo : lo+nbytes]
+	} else {
+		raw = make([]byte, nbytes)
+		if _, err := f.r.ReadAt(raw, f.dataBase+t.offset); err != nil {
+			return nil, fmt.Errorf("gguf: tensor %q: %w", name, err)
+		}
 	}
 	out := tensai.NewTensor(t.shape...)
 	dst := out.Data

--- a/encoding/safetensors/safetensors.go
+++ b/encoding/safetensors/safetensors.go
@@ -13,6 +13,7 @@
 package safetensors
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"sort"
 
 	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/mmapfile"
 )
 
 // maxHeaderSize bounds the JSON header; the reference implementation
@@ -40,18 +42,34 @@ type entry struct {
 type File struct {
 	r       io.ReaderAt
 	closer  io.Closer
+	data    []byte // the whole file when memory-mapped; nil otherwise
+	unmap   func() error
 	entries map[string]entry
 	names   []string
 	meta    map[string]string
 	dataOff int64 // where the byte buffer starts
 }
 
-// Open opens a safetensors file, parsing its header. Close the returned
-// File when done.
+// Open opens a safetensors file, parsing its header. The file is
+// memory-mapped where the platform allows, so tensor bytes slice straight
+// out of the page cache; otherwise reads go through ReadAt. Close the
+// returned File when done.
 func Open(path string) (*File, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
+	}
+	if data, unmap, err := mmapfile.Map(f); err == nil {
+		sf, err := NewFile(bytes.NewReader(data))
+		if err != nil {
+			unmap()
+			f.Close()
+			return nil, err
+		}
+		sf.data = data
+		sf.unmap = unmap
+		sf.closer = f
+		return sf, nil
 	}
 	sf, err := NewFile(f)
 	if err != nil {
@@ -122,10 +140,18 @@ func NewFile(r io.ReaderAt) (*File, error) {
 // Close closes the underlying file when the File came from Open; it is a
 // no-op otherwise.
 func (f *File) Close() error {
-	if f.closer != nil {
-		return f.closer.Close()
+	var err error
+	if f.unmap != nil {
+		err = f.unmap()
+		f.unmap = nil
+		f.data = nil
 	}
-	return nil
+	if f.closer != nil {
+		if cerr := f.closer.Close(); err == nil {
+			err = cerr
+		}
+	}
+	return err
 }
 
 // Names lists the tensor names, sorted.
@@ -166,9 +192,18 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 	if _, err := dtypeSize(e.Dtype); err != nil {
 		return nil, fmt.Errorf("%w (tensor %q)", err, name)
 	}
-	buf := make([]byte, e.DataOffsets[1]-e.DataOffsets[0])
-	if _, err := f.r.ReadAt(buf, f.dataOff+e.DataOffsets[0]); err != nil {
-		return nil, fmt.Errorf("safetensors: reading tensor %q: %w", name, err)
+	var buf []byte
+	if f.data != nil {
+		lo, hi := f.dataOff+e.DataOffsets[0], f.dataOff+e.DataOffsets[1]
+		if hi > int64(len(f.data)) || lo < 0 || lo > hi {
+			return nil, fmt.Errorf("safetensors: tensor %q extends past the file", name)
+		}
+		buf = f.data[lo:hi]
+	} else {
+		buf = make([]byte, e.DataOffsets[1]-e.DataOffsets[0])
+		if _, err := f.r.ReadAt(buf, f.dataOff+e.DataOffsets[0]); err != nil {
+			return nil, fmt.Errorf("safetensors: reading tensor %q: %w", name, err)
+		}
 	}
 	shape := e.Shape
 	if len(shape) == 0 {

--- a/internal/mmapfile/mmapfile_other.go
+++ b/internal/mmapfile/mmapfile_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package mmapfile
+
+import (
+	"errors"
+	"os"
+)
+
+// Map is unsupported on this platform; callers fall back to ReadAt.
+func Map(f *os.File) ([]byte, func() error, error) {
+	return nil, nil, errors.New("mmap unsupported")
+}

--- a/internal/mmapfile/mmapfile_unix.go
+++ b/internal/mmapfile/mmapfile_unix.go
@@ -1,0 +1,30 @@
+//go:build linux || darwin
+
+// Package mmapfile memory-maps files read-only, so checkpoint readers can
+// slice tensor bytes straight out of the page cache instead of copying
+// them through read buffers.
+package mmapfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// Map maps the whole file read-only. The returned close function unmaps;
+// the byte slice must not be used after it. Returns an error on empty
+// files or platforms without support, in which case callers fall back to
+// ReadAt.
+func Map(f *os.File) ([]byte, func() error, error) {
+	st, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if st.Size() == 0 {
+		return nil, nil, syscall.EINVAL
+	}
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(st.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, func() error { return syscall.Munmap(data) }, nil
+}

--- a/internal/mmapfile/mmapfile_windows.go
+++ b/internal/mmapfile/mmapfile_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package mmapfile
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Map maps the whole file read-only via CreateFileMapping/MapViewOfFile.
+func Map(f *os.File) ([]byte, func() error, error) {
+	st, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	size := st.Size()
+	if size == 0 {
+		return nil, nil, syscall.EINVAL
+	}
+	h, err := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY,
+		uint32(size>>32), uint32(size), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	addr, err := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		syscall.CloseHandle(h)
+		return nil, nil, err
+	}
+	data := unsafe.Slice((*byte)(unsafe.Pointer(addr)), size)
+	closeFn := func() error {
+		err := syscall.UnmapViewOfFile(addr)
+		if cerr := syscall.CloseHandle(h); err == nil {
+			err = cerr
+		}
+		return err
+	}
+	return data, closeFn, nil
+}


### PR DESCRIPTION
Open in both the safetensors and GGUF readers now memory-maps the file where the platform allows — linux, darwin, and windows through a small internal/mmapfile helper, with ReadAt as the fallback elsewhere and on map failure — and Tensor slices raw bytes straight out of the mapping instead of staging them through allocated read buffers. For a bf16 1.5B load that removes about 3GB of transient allocations; warm-cache load times are unchanged since quantization compute dominates, and the mapping is the groundwork for the next PR, which will use quantized GGUF blocks in place without any copy at all.

Close unmaps, and returned tensors are always fresh float32 copies, so they outlive the mapping safely. Cross-compiles checked for windows, darwin, and freebsd (fallback); all suites pass and both loaders answer correctly.