### PR TITLE
Register-resident kernel accumulators

### DIFF
--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -43,19 +43,22 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 			corr := archsimd.BroadcastInt32x8(8 * gsum[g])
 			srow := scale[g*cols:]
 			for jt := lo; jt < vecEnd; jt += 32 {
-				var a [4]archsimd.Int32x8
+				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
 					xp := archsimd.BroadcastUint32x8(q4xQuad(xu, i4)).AsInt8x32()
 					row := qw[i4*2*cols+2*jt:]
-					for k := 0; k < 4; k++ {
-						v := loadU8x16(row[16*k:]).ExtendToUint16()
-						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
-						a[k] = a[k].Add(pair.DotProductPairsSaturated(xp).DotProductPairs(ones))
-					}
+					v := loadU8x16(row).ExtendToUint16()
+					a0 = a0.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
+					v = loadU8x16(row[16:]).ExtendToUint16()
+					a1 = a1.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
+					v = loadU8x16(row[32:]).ExtendToUint16()
+					a2 = a2.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
+					v = loadU8x16(row[48:]).ExtendToUint16()
+					a3 = a3.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 				}
-				for k := 0; k < 4; k++ {
+				for k, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 					j := jt + 8*k
-					f := a[k].Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
+					f := a.Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
 					storeF32x8(loadF32x8(out[j:]).Add(f), out[j:])
 				}
 			}
@@ -80,11 +83,10 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 		return
 	}
 	quads := len(xus[0]) / 4
-	var xq [4][]uint32
+	xq := make([]uint32, 4*quads)
 	for r := 0; r < 4; r++ {
-		xq[r] = make([]uint32, quads)
 		for i4 := 0; i4 < quads; i4++ {
-			xq[r][i4] = q4xQuad(xus[r], i4)
+			xq[i4*4+r] = q4xQuad(xus[r], i4)
 		}
 	}
 	vecEnd := lo + ((hi - lo) &^ 7)
@@ -100,20 +102,21 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 			ie := min(ib+group/4, quads)
 			srow := scale[g*cols:]
 			for jt := lo; jt < vecEnd; jt += 8 {
-				var a [4]archsimd.Int32x8
+				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
 					v := loadU8x16(qw[i4*2*cols+2*jt:]).ExtendToUint16()
 					pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
-					for r := 0; r < 4; r++ {
-						xp := archsimd.BroadcastUint32x8(xq[r][i4]).AsInt8x32()
-						a[r] = a[r].Add(pair.DotProductPairsSaturated(xp).DotProductPairs(ones))
-					}
+					xf := xq[i4*4 : i4*4+4]
+					a0 = a0.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[0]).AsInt8x32()).DotProductPairs(ones))
+					a1 = a1.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[1]).AsInt8x32()).DotProductPairs(ones))
+					a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
+					a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
 				}
 				sc := loadF32x8(srow[jt:])
-				for r := 0; r < 4; r++ {
+				for r, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 					corr := archsimd.BroadcastInt32x8(8 * gsums[r][g])
 					o := out.Data[(r0+r)*cols:]
-					f := a[r].Sub(corr).ConvertToFloat32().Mul(sc)
+					f := a.Sub(corr).ConvertToFloat32().Mul(sc)
 					storeF32x8(loadF32x8(o[jt:]).Add(f), o[jt:])
 				}
 			}

--- a/quant8g_simd.go
+++ b/quant8g_simd.go
@@ -28,18 +28,18 @@ func q8gMatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, 
 			srow := scale[g*cols:]
 			csrow := colSum64[g*cols:]
 			for jt := lo; jt < vecEnd; jt += 32 {
-				var a [4]archsimd.Int32x8
+				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
 					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsUint8x32()
 					row := qw[i4*4*cols+4*jt:]
-					a[0] = a[0].Add(xp.DotProductPairsSaturated(loadI8x32(row)).DotProductPairs(ones))
-					a[1] = a[1].Add(xp.DotProductPairsSaturated(loadI8x32(row[32:])).DotProductPairs(ones))
-					a[2] = a[2].Add(xp.DotProductPairsSaturated(loadI8x32(row[64:])).DotProductPairs(ones))
-					a[3] = a[3].Add(xp.DotProductPairsSaturated(loadI8x32(row[96:])).DotProductPairs(ones))
+					a0 = a0.Add(xp.DotProductPairsSaturated(loadI8x32(row)).DotProductPairs(ones))
+					a1 = a1.Add(xp.DotProductPairsSaturated(loadI8x32(row[32:])).DotProductPairs(ones))
+					a2 = a2.Add(xp.DotProductPairsSaturated(loadI8x32(row[64:])).DotProductPairs(ones))
+					a3 = a3.Add(xp.DotProductPairsSaturated(loadI8x32(row[96:])).DotProductPairs(ones))
 				}
-				for k := 0; k < 4; k++ {
+				for k, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 					j := jt + 8*k
-					f := a[k].Sub(loadI32x8(csrow[j:])).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
+					f := a.Sub(loadI32x8(csrow[j:])).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
 					storeF32x8(loadF32x8(out[j:]).Add(f), out[j:])
 				}
 			}
@@ -64,11 +64,10 @@ func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, 
 	}
 	quads := len(xus[0]) / 4
 	groups := (len(xus[0]) + q8Group - 1) / q8Group
-	var xq [8][]uint32
+	xq := make([]uint32, 8*quads)
 	for r := 0; r < 8; r++ {
-		xq[r] = make([]uint32, quads)
 		for i4 := 0; i4 < quads; i4++ {
-			xq[r][i4] = qxQuad(xus[r], i4)
+			xq[i4*8+r] = qxQuad(xus[r], i4)
 		}
 	}
 	ones := archsimd.BroadcastInt16x16(1)
@@ -83,19 +82,24 @@ func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, 
 			srow := scale[g*cols:]
 			csrow := colSum64[g*cols:]
 			for jt := lo; jt < vecEnd; jt += 8 {
-				var a [8]archsimd.Int32x8
+				var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
 					w := loadI8x32(qw[i4*4*cols+4*jt:])
-					for r := 0; r < 8; r++ {
-						xp := archsimd.BroadcastUint32x8(xq[r][i4]).AsUint8x32()
-						a[r] = a[r].Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
-					}
+					xf := xq[i4*8 : i4*8+8]
+					a0 = a0.Add(archsimd.BroadcastUint32x8(xf[0]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a1 = a1.Add(archsimd.BroadcastUint32x8(xf[1]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a2 = a2.Add(archsimd.BroadcastUint32x8(xf[2]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a3 = a3.Add(archsimd.BroadcastUint32x8(xf[3]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a4 = a4.Add(archsimd.BroadcastUint32x8(xf[4]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a5 = a5.Add(archsimd.BroadcastUint32x8(xf[5]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a6 = a6.Add(archsimd.BroadcastUint32x8(xf[6]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a7 = a7.Add(archsimd.BroadcastUint32x8(xf[7]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 				}
 				cs := loadI32x8(csrow[jt:])
 				sc := loadF32x8(srow[jt:])
-				for r := 0; r < 8; r++ {
+				for r, a := range [8]archsimd.Int32x8{a0, a1, a2, a3, a4, a5, a6, a7} {
 					o := out.Data[(r0+r)*cols:]
-					f := a[r].Sub(cs).ConvertToFloat32().Mul(sc)
+					f := a.Sub(cs).ConvertToFloat32().Mul(sc)
 					storeF32x8(loadF32x8(o[jt:]).Add(f), o[jt:])
 				}
 			}

--- a/quant_simd.go
+++ b/quant_simd.go
@@ -64,29 +64,36 @@ func qmatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, sc
 		return
 	}
 	quads := len(xus[0]) / 4
-	// The packed activation quads per row, hoisted out of the tile loop.
-	var xq [8][]uint32
+	// The packed activation quads, interleaved per quad row so the inner
+	// loop walks one contiguous stream. Accumulators are eight named
+	// variables: an array of SIMD values would live on the stack and turn
+	// every multiply-add into a load-op-store round trip.
+	xq := make([]uint32, 8*quads)
 	for r := 0; r < 8; r++ {
-		xq[r] = make([]uint32, quads)
 		for i4 := 0; i4 < quads; i4++ {
-			xq[r][i4] = qxQuad(xus[r], i4)
+			xq[i4*8+r] = qxQuad(xus[r], i4)
 		}
 	}
 	ones := archsimd.BroadcastInt16x16(1)
 	vecEnd := lo + ((hi - lo) &^ 7)
 	for jt := lo; jt < vecEnd; jt += 8 {
-		var a [8]archsimd.Int32x8
+		var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
 		for i4 := 0; i4 < quads; i4++ {
 			w := loadI8x32(qw[i4*4*cols+4*jt:])
-			for r := 0; r < 8; r++ {
-				xp := archsimd.BroadcastUint32x8(xq[r][i4]).AsUint8x32()
-				a[r] = a[r].Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
-			}
+			xf := xq[i4*8 : i4*8+8]
+			a0 = a0.Add(archsimd.BroadcastUint32x8(xf[0]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a1 = a1.Add(archsimd.BroadcastUint32x8(xf[1]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a2 = a2.Add(archsimd.BroadcastUint32x8(xf[2]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a3 = a3.Add(archsimd.BroadcastUint32x8(xf[3]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a4 = a4.Add(archsimd.BroadcastUint32x8(xf[4]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a5 = a5.Add(archsimd.BroadcastUint32x8(xf[5]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a6 = a6.Add(archsimd.BroadcastUint32x8(xf[6]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+			a7 = a7.Add(archsimd.BroadcastUint32x8(xf[7]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 		}
 		cs := loadI32x8(colSum64[jt:])
 		sc := loadF32x8(scale[jt:])
-		for r := 0; r < 8; r++ {
-			f := a[r].Sub(cs).ConvertToFloat32().Mul(sc).Mul(archsimd.BroadcastFloat32x8(sxs[r]))
+		for r, a := range [8]archsimd.Int32x8{a0, a1, a2, a3, a4, a5, a6, a7} {
+			f := a.Sub(cs).ConvertToFloat32().Mul(sc).Mul(archsimd.BroadcastFloat32x8(sxs[r]))
 			storeF32x8(f, out.Data[(r0+r)*cols+jt:])
 		}
 	}


### PR DESCRIPTION
The batched kernels held their accumulators in arrays of SIMD values and looped over batch rows. The compiler places arrays of archsimd values on the stack, so every multiply-add compiled to a load-op-store round trip — the disassembly showed a single VPMADDUBSW reused inside a loop against 133 stack references. The accumulators are now individually named variables with the row loops manually unrolled, and the packed activation quads interleave into one contiguous per-quad stream instead of eight parallel slices.

Outputs are bit-identical (accumulation order per accumulator is unchanged). Interleaved same-session benchmarks:

| kernel | before | after |
|---|---|---|
| Q8 batched prefill 64x1536 @ 1536x8960 | 8.7ms | 5.7ms (1.5x) |
| Q4 batched prefill | 12.6ms | 7.7ms (1.6x) |
| Q4 matvec 4096x16384 | 1.9ms | 1.5ms (1.3x) |
| Q8 matvec | unchanged (DRAM-bound) | |

End to end: 0.5B -q4 decode 21.3 -> 25.6 tok/s, 96-token -q8 prefill 879 -> 703ms (137 tok/s). The grouped-int8 GGUF kernels get the same treatment.