### PR TITLE
SentencePiece tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **safetensors** - `encoding/safetensors` reads the checkpoint format most published model weights ship in — lazily, one tensor at a time, with F16/BF16/F64 converted to float32 — and writes F32 checkpoints; interoperability is verified against the reference implementation in both directions. Also dependency-free
 - **GGUF** - `encoding/gguf` reads llama.cpp's model container — typed metadata plus lazily-loaded tensors, with F16/BF16, the block-quantized Q8_0/Q4_0/Q4_1/Q5_0/Q5_1, the K-quants Q2_K through Q6_K, and IQ4_NL dequantized to float32 — verified block-exact against real llama.cpp conversions. Dependency-free as well
 - **ONNX export** - `encoding/onnx` marshals Sequential models into ONNX (opset 13, FP32) with a hand-written protobuf encoder; onnxruntime reproduces `Predict` to ~1e-7 relative error. ONNX convolutions are NCHW, which is tensai's own row layout, so nothing is reordered
-- **Tokenizers** - the `tokenizer` package loads Hugging Face `tokenizer.json` files and implements the byte-level BPE family (GPT-2, Llama 3, Qwen, ...), including the split patterns Go's regexp cannot express, as hand-written scanners; encodings and decodings match the reference `tokenizers` library exactly on both split families
+- **Tokenizers** - the `tokenizer` package loads Hugging Face `tokenizer.json` files and implements the byte-level BPE family (GPT-2, Llama 3, Qwen, ...), including the split patterns Go's regexp cannot express, as hand-written scanners, plus SentencePiece (Gemma, the Llama-2 era) built from GGUF vocabularies via `NewSPM`; encodings match the reference `tokenizers` library on the BPE families and `llama-tokenize` exactly on SentencePiece
 
 ## Layout
 

--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -26,8 +26,12 @@ import (
 // ggufTokenizer rebuilds a tokenizer.json from the metadata llama.cpp
 // embeds and hands it to the tokenizer package's parser.
 func ggufTokenizer(g *gguf.File) (*tokenizer.Tokenizer, error) {
-	if model, _ := g.String("tokenizer.ggml.model"); model != "gpt2" {
-		return nil, fmt.Errorf("unsupported tokenizer model %q (byte-level BPE only)", model)
+	switch model, _ := g.String("tokenizer.ggml.model"); model {
+	case "gpt2":
+	case "llama": // SentencePiece: Gemma and the Llama-2 family
+		return ggufSPMTokenizer(g)
+	default:
+		return nil, fmt.Errorf("unsupported tokenizer model %q", model)
 	}
 	toksAny, ok := g.KV("tokenizer.ggml.tokens")
 	if !ok {
@@ -174,6 +178,36 @@ func repackQ4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap func
 			}
 		}
 	}
+}
+
+// ggufSPMTokenizer builds a SentencePiece tokenizer from the embedded
+// vocabulary, scores, and token types.
+func ggufSPMTokenizer(g *gguf.File) (*tokenizer.Tokenizer, error) {
+	toksAny, ok := g.KV("tokenizer.ggml.tokens")
+	if !ok {
+		return nil, fmt.Errorf("gguf has no embedded tokenizer")
+	}
+	scoresAny, ok := g.KV("tokenizer.ggml.scores")
+	if !ok {
+		return nil, fmt.Errorf("gguf spm tokenizer has no scores")
+	}
+	typesAny, _ := g.KV("tokenizer.ggml.token_type")
+	ta := toksAny.([]any)
+	sa := scoresAny.([]any)
+	ya := typesAny.([]any)
+	tokens := make([]string, len(ta))
+	scores := make([]float32, len(ta))
+	types := make([]int32, len(ta))
+	for i := range ta {
+		tokens[i], _ = ta[i].(string)
+		scores[i], _ = sa[i].(float32)
+		types[i], _ = ya[i].(int32)
+	}
+	pre := false
+	if v, ok := g.KV("tokenizer.ggml.add_space_prefix"); ok {
+		pre, _ = v.(bool)
+	}
+	return tokenizer.NewSPM(tokens, scores, types, pre)
 }
 
 // unpermuteMap returns the llama rope unpermutation as a row index map,

--- a/tokenizer/spm.go
+++ b/tokenizer/spm.go
@@ -1,0 +1,196 @@
+package tokenizer
+
+import (
+	"container/heap"
+	"fmt"
+	"strings"
+)
+
+// SentencePiece support: the tokenizer family Gemma and Llama-2-era
+// models ship (GGUF calls it "llama"). Instead of byte-level BPE ranks,
+// the vocabulary carries a score per piece; encoding greedily merges the
+// adjacent pair whose concatenation has the highest score, spaces are
+// rewritten to the visible U+2581, and anything that ends up outside the
+// vocabulary falls back to per-byte <0xXX> tokens.
+
+// spmToken classifies GGUF token types.
+const (
+	spmNormal  = 1
+	spmUnknown = 2
+	spmControl = 3
+	spmUserDef = 4
+	spmByte    = 6
+)
+
+// NewSPM builds a SentencePiece tokenizer from parallel vocabulary
+// arrays — tokens, their scores, and their GGUF token types. Control and
+// user-defined tokens match verbatim in the input like the BPE
+// tokenizers' added tokens; addSpacePrefix prepends a space before
+// encoding, the way most Llama-2-family models expect (Gemma does not).
+func NewSPM(tokens []string, scores []float32, types []int32, addSpacePrefix bool) (*Tokenizer, error) {
+	if len(tokens) != len(scores) || len(tokens) != len(types) {
+		return nil, fmt.Errorf("tokenizer: spm arrays disagree: %d tokens, %d scores, %d types",
+			len(tokens), len(scores), len(types))
+	}
+	t := &Tokenizer{
+		vocab:       make(map[string]int, len(tokens)),
+		inverse:     make(map[int]string, len(tokens)),
+		byID:        map[int]string{},
+		ranks:       map[[2]string]int{},
+		byteDec:     map[rune]byte{},
+		cache:       map[string][]int{},
+		spm:         true,
+		scores:      scores,
+		spacePrefix: addSpacePrefix,
+		unkID:       -1,
+	}
+	for i := range t.byteID {
+		t.byteID[i] = -1
+	}
+	for id, tok := range tokens {
+		switch types[id] {
+		case spmControl, spmUserDef:
+			t.specials = append(t.specials, special{content: tok, id: id})
+			t.byID[id] = tok
+		case spmUnknown:
+			t.unkID = id
+			t.inverse[id] = tok
+		case spmByte:
+			var b byte
+			if _, err := fmt.Sscanf(tok, "<0x%02X>", &b); err == nil {
+				t.byteID[b] = id
+			}
+			t.inverse[id] = tok
+		default:
+			t.vocab[tok] = id
+			t.inverse[id] = tok
+		}
+	}
+	sortSpecials(t)
+	return t, nil
+}
+
+// spmSymbol is one live segment during merging; merged-away segments get
+// size 0 and stay linked out.
+type spmSymbol struct {
+	text       string
+	prev, next int
+}
+
+// spmBigram is a candidate merge in the priority queue.
+type spmBigram struct {
+	left, right int
+	score       float32
+	size        int // combined byte length when queued, to detect staleness
+}
+
+type spmQueue []spmBigram
+
+func (q spmQueue) Len() int { return len(q) }
+func (q spmQueue) Less(i, j int) bool {
+	if q[i].score != q[j].score {
+		return q[i].score > q[j].score
+	}
+	return q[i].left < q[j].left // ties resolve left-most, like the reference
+}
+func (q spmQueue) Swap(i, j int) { q[i], q[j] = q[j], q[i] }
+func (q *spmQueue) Push(x any)   { *q = append(*q, x.(spmBigram)) }
+func (q *spmQueue) Pop() any     { old := *q; n := len(old); v := old[n-1]; *q = old[:n-1]; return v }
+
+// spmEncode tokenizes one special-free fragment.
+func (t *Tokenizer) spmEncode(s string) []int {
+	if s == "" {
+		return nil
+	}
+	if t.spacePrefix {
+		s = " " + s
+	}
+	s = strings.ReplaceAll(s, " ", "▁")
+
+	// One symbol per UTF-8 character to start.
+	var syms []spmSymbol
+	for i, r := range s {
+		_ = r
+		if len(syms) > 0 {
+			syms[len(syms)-1].next = len(syms)
+		}
+		end := i + len(string(r))
+		syms = append(syms, spmSymbol{text: s[i:end], prev: len(syms) - 1, next: -1})
+	}
+
+	q := &spmQueue{}
+	tryAdd := func(l, r int) {
+		if l < 0 || r < 0 {
+			return
+		}
+		cat := syms[l].text + syms[r].text
+		if id, ok := t.vocab[cat]; ok {
+			heap.Push(q, spmBigram{left: l, right: r, score: t.scores[id], size: len(cat)})
+		}
+	}
+	for i := 0; i+1 < len(syms); i++ {
+		tryAdd(i, i+1)
+	}
+	for q.Len() > 0 {
+		bg := heap.Pop(q).(spmBigram)
+		l, r := bg.left, bg.right
+		if syms[l].text == "" || syms[r].text == "" || len(syms[l].text)+len(syms[r].text) != bg.size {
+			continue // one side was merged away since this was queued
+		}
+		syms[l].text += syms[r].text
+		syms[r].text = ""
+		syms[l].next = syms[r].next
+		if syms[r].next >= 0 {
+			syms[syms[r].next].prev = l
+		}
+		tryAdd(syms[l].prev, l)
+		tryAdd(l, syms[l].next)
+	}
+
+	var ids []int
+	for i := 0; i >= 0 && i < len(syms); i = syms[i].next {
+		if syms[i].text == "" {
+			continue
+		}
+		if id, ok := t.vocab[syms[i].text]; ok {
+			ids = append(ids, id)
+			continue
+		}
+		// Byte fallback for pieces outside the vocabulary.
+		ok := true
+		for _, b := range []byte(syms[i].text) {
+			if t.byteID[b] < 0 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			for _, b := range []byte(syms[i].text) {
+				ids = append(ids, t.byteID[b])
+			}
+		} else if t.unkID >= 0 {
+			ids = append(ids, t.unkID)
+		}
+	}
+	return ids
+}
+
+// spmDecode renders ids back to text: U+2581 becomes a space, byte
+// tokens their byte, specials their literal content.
+func (t *Tokenizer) spmDecode(ids []int) string {
+	var sb strings.Builder
+	for _, id := range ids {
+		if sp, ok := t.byID[id]; ok {
+			sb.WriteString(sp)
+			continue
+		}
+		piece := t.inverse[id]
+		var b byte
+		if _, err := fmt.Sscanf(piece, "<0x%02X>", &b); err == nil && t.byteID[b] == id {
+			sb.WriteByte(b)
+			continue
+		}
+		sb.WriteString(strings.ReplaceAll(piece, "▁", " "))
+	}
+	return sb.String()
+}

--- a/tokenizer/spm_test.go
+++ b/tokenizer/spm_test.go
@@ -1,0 +1,64 @@
+package tokenizer
+
+import "testing"
+
+// A tiny hand-built SentencePiece vocabulary: scores steer the merges.
+func testSPM(t *testing.T, pre bool) *Tokenizer {
+	t.Helper()
+	tokens := []string{"<unk>", "<s>", "</s>", "▁", "a", "b", "c", "ab", "abc", "▁ab", "▁abc", "<0x41>", "<0x42>", "<0xE3>", "<0x81>", "<0x82>"}
+	scores := []float32{0, 0, 0, -3, -1, -1, -1, -2, -1.5, -2.5, -1.2, 0, 0, 0, 0, 0}
+	types := []int32{2, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 6, 6, 6, 6, 6}
+	tok, err := NewSPM(tokens, scores, types, pre)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+func TestSPMEncode(t *testing.T) {
+	tok := testSPM(t, false)
+
+	// "abc" merges all the way: ab (score -2) then abc (-1.5), because the
+	// best-scoring bigram wins each round.
+	if got := tok.Encode("abc"); len(got) != 1 || got[0] != 8 {
+		t.Fatalf("abc: %v", got)
+	}
+	// " abc" becomes ▁abc via the ▁ab / ▁abc chain.
+	if got := tok.Encode(" abc"); len(got) != 1 || got[0] != 10 {
+		t.Fatalf(" abc: %v", got)
+	}
+	// Specials match verbatim and split the text around them.
+	if got := tok.Encode("<s>abc</s>"); len(got) != 3 || got[0] != 1 || got[1] != 8 || got[2] != 2 {
+		t.Fatalf("specials: %v", got)
+	}
+	// Out-of-vocabulary characters fall back to bytes: "A" -> <0x41>,
+	// and あ (E3 81 82) -> three byte tokens.
+	if got := tok.Encode("A"); len(got) != 1 || got[0] != 11 {
+		t.Fatalf("byte fallback: %v", got)
+	}
+	if got := tok.Encode("あ"); len(got) != 3 || got[0] != 13 || got[1] != 14 || got[2] != 15 {
+		t.Fatalf("multibyte fallback: %v", got)
+	}
+
+	// Decode round-trips text, spaces and byte tokens included.
+	for _, s := range []string{"abc", " abc", "A", "あ", "<s>ab c</s>"} {
+		if got := tok.Decode(tok.Encode(s)); got != s {
+			t.Fatalf("roundtrip %q: got %q", s, got)
+		}
+	}
+}
+
+func TestSPMSpacePrefix(t *testing.T) {
+	tok := testSPM(t, true)
+	// With add_space_prefix the fragment gains a leading space, so "abc"
+	// encodes like " abc".
+	if got := tok.Encode("abc"); len(got) != 1 || got[0] != 10 {
+		t.Fatalf("prefixed abc: %v", got)
+	}
+}
+
+func TestSPMArrayMismatch(t *testing.T) {
+	if _, err := NewSPM([]string{"a"}, nil, nil, false); err == nil {
+		t.Fatal("expected error for mismatched arrays")
+	}
+}

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -26,15 +26,20 @@ type special struct {
 
 // Tokenizer encodes text to token ids and back.
 type Tokenizer struct {
-	vocab    map[string]int
-	inverse  map[int]string
-	specials []special // sorted longest-first
-	byID     map[int]string
-	ranks    map[[2]string]int
-	cfg      splitConfig
-	byteEnc  [256]rune
-	byteDec  map[rune]byte
-	cache    map[string][]int
+	vocab       map[string]int
+	inverse     map[int]string
+	specials    []special // sorted longest-first
+	byID        map[int]string
+	ranks       map[[2]string]int
+	cfg         splitConfig
+	spm         bool
+	scores      []float32
+	byteID      [256]int
+	unkID       int
+	spacePrefix bool
+	byteEnc     [256]rune
+	byteDec     map[rune]byte
+	cache       map[string][]int
 }
 
 // splitConfig selects between the two pre-tokenization scanners.
@@ -139,9 +144,7 @@ func Parse(raw []byte) (*Tokenizer, error) {
 		t.specials = append(t.specials, special{content: at.Content, id: at.ID})
 		t.byID[at.ID] = at.Content
 	}
-	sort.Slice(t.specials, func(i, j int) bool {
-		return len(t.specials[i].content) > len(t.specials[j].content)
-	})
+	sortSpecials(t)
 
 	// bytes_to_unicode: printable bytes map to themselves, the rest to
 	// 256 and up, so every byte has a visible stand-in character.
@@ -284,6 +287,9 @@ func (t *Tokenizer) Encode(s string) []int {
 }
 
 func (t *Tokenizer) encodeText(s string) []int {
+	if t.spm {
+		return t.spmEncode(s)
+	}
 	var ids []int
 	for _, word := range t.split(s) {
 		var sb strings.Builder
@@ -297,6 +303,9 @@ func (t *Tokenizer) encodeText(s string) []int {
 
 // Decode turns token ids back into text.
 func (t *Tokenizer) Decode(ids []int) string {
+	if t.spm {
+		return t.spmDecode(ids)
+	}
 	var bs []byte
 	for _, id := range ids {
 		if sp, ok := t.byID[id]; ok {
@@ -487,4 +496,12 @@ func matchContraction(rs []rune, ci bool) int {
 
 func isPunct(r rune) bool {
 	return !unicode.IsSpace(r) && !unicode.IsLetter(r) && !unicode.IsNumber(r)
+}
+
+// sortSpecials orders special tokens longest-first so overlapping matches
+// resolve to the longest.
+func sortSpecials(t *Tokenizer) {
+	sort.Slice(t.specials, func(i, j int) bool {
+		return len(t.specials[i].content) > len(t.specials[j].content)
+	})
 }


### PR DESCRIPTION
NewSPM builds a tokenizer from parallel vocabulary arrays — pieces, scores, and GGUF token types — the shape Gemma and the Llama-2 family embed in their checkpoints. Encoding is the reference greedy merge: spaces rewrite to U+2581, symbols start as single characters, and the adjacent pair whose concatenation scores highest merges first (a priority queue with stale-entry invalidation, left-most on ties); anything left outside the vocabulary falls back to per-byte <0xXX> tokens, then the unknown token. Control and user-defined tokens ride the existing verbatim-special machinery, add_space_prefix is honored, and decode reverses the whole thing.

Verified token-exact against llama.cpp's llama-tokenize on the Gemma 3 vocabulary: 78 corpus lines covering multilingual text, control bytes, specials appearing mid-text, whitespace runs, and random fuzz — zero mismatches. Unit tests cover the merge order, byte fallback, specials, space-prefix mode, and round-trips on a hand-built vocabulary. The example's GGUF tokenizer now accepts tokenizer.ggml.model "llama" through it; Gemma 3 architecture support comes next on top of this.