### PR TITLE
quant4: bfloat16-packed min-form tables

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -223,8 +223,8 @@ func kScaleMin(is int, q []byte) (sc, mn uint8) {
 // repackQ4K copies a Q4_K tensor's super-blocks — [out, in] with eight
 // 32-value sub-groups per 256, each carrying a 6-bit scale and min
 // against two f16 super-factors — into columns of a transposed Group-32
-// min-form Q4Matrix. Nibbles copy raw; only the per-group scale and min
-// tables touch floats.
+// min-form Q4Matrix. Nibbles copy raw; the per-group scale and min pairs
+// round to packed bfloat16, the only lossy step (~0.2% on the tables).
 func repackQ4K(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap func(int) int) {
 	nb := in / 256
 	for r := 0; r < out; r++ {
@@ -241,8 +241,7 @@ func repackQ4K(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fun
 			for is := 0; is < 8; is++ {
 				sc, mn := kScaleMin(is, scales)
 				g := b*8 + is
-				dst.Scale[g*dst.Cols+j] = d * float32(sc)
-				dst.Min[g*dst.Cols+j] = dmin * float32(mn)
+				dst.ScaleMin[g*dst.Cols+j] = tensai.PackScaleMin(d*float32(sc), dmin*float32(mn))
 			}
 			for c := 0; c < 4; c++ {
 				for l := 0; l < 32; l++ {
@@ -345,17 +344,25 @@ func repackQ6K4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fu
 					vmin, vmax = min(vmin, w), max(vmax, w)
 				}
 				g := b*8 + p
-				scale := (vmax - vmin) / 15
-				dst.Scale[g*dst.Cols+j] = scale
-				dst.Min[g*dst.Cols+j] = -vmin
+				// Quantize against the bfloat16-rounded pair the kernel
+				// will unpack, so the rounding lands on the nibble choice
+				// rather than stacking onto the reconstruction.
+				packed := tensai.PackScaleMin((vmax-vmin)/15, -vmin)
+				dst.ScaleMin[g*dst.Cols+j] = packed
+				scale, mn := tensai.UnpackScaleMin(packed)
 				if scale == 0 {
 					continue
 				}
 				inv := 1 / scale
 				for k, w := range v {
-					nib := uint8((w-vmin)*inv + 0.5)
+					n := (w+mn)*inv + 0.5
+					if n < 0 {
+						n = 0
+					} else if n > 15 {
+						n = 15
+					}
 					gi := b*256 + p*32 + k
-					dst.Q[(gi/4)*2*dst.Cols+2*j+(gi%4)/2] |= nib << (4 * (gi % 2))
+					dst.Q[(gi/4)*2*dst.Cols+2*j+(gi%4)/2] |= uint8(n) << (4 * (gi % 2))
 				}
 			}
 		}
@@ -544,12 +551,11 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 		quads := (in + 3) / 4
 		groups := (in + 31) / 32
 		dst := &tensai.Q4Matrix{
-			Rows:  in,
-			Cols:  total,
-			Q:     make([]uint8, quads*2*total+32),
-			Scale: make([]float32, groups*total),
-			Min:   make([]float32, groups*total),
-			Group: 32,
+			Rows:     in,
+			Cols:     total,
+			Q:        make([]uint8, quads*2*total+32),
+			ScaleMin: make([]uint32, groups*total),
+			Group:    32,
 		}
 		colOff := 0
 		for i, name := range names {
@@ -578,12 +584,11 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 		quads := (in + 3) / 4
 		groups := (in + 31) / 32
 		dst := &tensai.Q4Matrix{
-			Rows:  in,
-			Cols:  total,
-			Q:     make([]uint8, quads*2*total+32),
-			Scale: make([]float32, groups*total),
-			Min:   make([]float32, groups*total),
-			Group: 32,
+			Rows:     in,
+			Cols:     total,
+			Q:        make([]uint8, quads*2*total+32),
+			ScaleMin: make([]uint32, groups*total),
+			Group:    32,
 		}
 		colOff := 0
 		for i, name := range names {

--- a/quant4.go
+++ b/quant4.go
@@ -2,6 +2,7 @@ package tensai
 
 import (
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -24,12 +25,32 @@ type Q4Matrix struct {
 	Rows, Cols int
 	Q          []uint8 // row quads x 2*Cols, padded for 32-byte loads
 	Scale      []Float
-	// Min, when non-nil, switches the per-(group, column) dequantization
-	// from the symmetric offset-binary form scale*(nibble-8) to the
-	// asymmetric scale*nibble - min — the form GGUF's Q4_K sub-blocks
-	// carry. Nil keeps the symmetric form.
-	Min   []Float
-	Group int // input rows per scale; 0 means the default q4Group (64)
+	// ScaleMin, when non-nil, switches the per-(group, column)
+	// dequantization from the symmetric offset-binary form
+	// scale*(nibble-8) to the asymmetric scale*nibble - min — the form
+	// GGUF's Q4_K sub-blocks carry — with Scale unused. Each entry packs
+	// the pair as bfloat16 (PackScaleMin), halving what the kernels
+	// stream per group next to two float32 tables. Nil keeps the
+	// symmetric form.
+	ScaleMin []uint32
+	Group    int // input rows per scale; 0 means the default q4Group (64)
+}
+
+// PackScaleMin rounds a min-form group's scale and min to bfloat16 and
+// packs them into one ScaleMin entry (scale low, min high).
+func PackScaleMin(scale, min Float) uint32 {
+	return uint32(bf16(scale)) | uint32(bf16(min))<<16
+}
+
+// UnpackScaleMin is the inverse of PackScaleMin.
+func UnpackScaleMin(u uint32) (scale, min Float) {
+	return math.Float32frombits(u << 16), math.Float32frombits(u & 0xffff0000)
+}
+
+// bf16 rounds a float32 to nearest-even bfloat16, returning the top bits.
+func bf16(f Float) uint16 {
+	b := math.Float32bits(f)
+	return uint16((b + 0x7fff + (b >> 16 & 1)) >> 16)
 }
 
 // group returns the effective scale-group length.
@@ -119,7 +140,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)
 	if workers == 1 {
-		q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.Min, grp, q.Cols, 0, q.Cols)
+		q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
 	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
@@ -129,7 +150,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 		wg.Add(1)
 		go func(lo, hi int) {
 			defer wg.Done()
-			q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.Min, grp, q.Cols, lo, hi)
+			q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}(lo, hi)
 	}
 	wg.Wait()
@@ -161,10 +182,10 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 	run := func(lo, hi int) {
 		var r int
 		for ; r+4 <= rows; r += 4 {
-			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.Min, grp, q.Cols, lo, hi)
+			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
 		for ; r < rows; r++ {
-			q4matvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], gsums[r], q.Q, q.Scale, q.Min, grp, q.Cols, lo, hi)
+			q4matvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], gsums[r], q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)
@@ -188,7 +209,7 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 
 // q4matmulCols4Generic is the four-row batched body: each nibble byte read
 // once feeds four output rows.
-func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
+func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	for r := 0; r < 4; r++ {
 		clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+hi])
 	}
@@ -218,16 +239,20 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 				}
 			}
 		}
-		srow := scale[g*cols:]
-		for r := 0; r < 4; r++ {
-			o := out.Data[(r0+r)*cols:]
-			if mins != nil {
-				mrow := mins[g*cols:]
+		if sm != nil {
+			smrow := sm[g*cols:]
+			for r := 0; r < 4; r++ {
+				o := out.Data[(r0+r)*cols:]
 				gs := Float(gsums[r][g])
 				for j := lo; j < hi; j++ {
-					o[j] += Float(acc[r][j-lo])*srow[j] - gs*mrow[j]
+					s, m := UnpackScaleMin(smrow[j])
+					o[j] += Float(acc[r][j-lo])*s - gs*m
 				}
-			} else {
+			}
+		} else {
+			srow := scale[g*cols:]
+			for r := 0; r < 4; r++ {
+				o := out.Data[(r0+r)*cols:]
 				corr := 8 * gsums[r][g]
 				for j := lo; j < hi; j++ {
 					o[j] += Float(acc[r][j-lo]-corr) * srow[j]
@@ -247,7 +272,7 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 // 7-bit activations as the AVX2 kernel, so both builds agree exactly.
 // q4matvecCols (see quant4_simd.go and quant4_generic.go) dispatches to
 // the AVX2 kernel when available.
-func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
+func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	clear(out[lo:hi])
 	quads := len(xu) / 4
 	acc := make([]int32, hi-lo)
@@ -267,14 +292,15 @@ func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []u
 					int32(b1&0x0F)*x2 + int32(b1>>4)*x3
 			}
 		}
-		srow := scale[g*cols:]
-		if mins != nil {
-			mrow := mins[g*cols:]
+		if sm != nil {
+			smrow := sm[g*cols:]
 			gs := Float(gsum[g])
 			for j := lo; j < hi; j++ {
-				out[j] += Float(acc[j-lo])*srow[j] - gs*mrow[j]
+				s, m := UnpackScaleMin(smrow[j])
+				out[j] += Float(acc[j-lo])*s - gs*m
 			}
 		} else {
+			srow := scale[g*cols:]
 			corr := 8 * gsum[g]
 			for j := lo; j < hi; j++ {
 				out[j] += Float(acc[j-lo]-corr) * srow[j]

--- a/quant4_generic.go
+++ b/quant4_generic.go
@@ -5,10 +5,10 @@ package tensai
 // Portable dispatcher for the 4-bit matvec kernel; build with
 // GOEXPERIMENT=simd on amd64 for the AVX2 version in quant4_simd.go.
 
-func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
-	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, mins, group, cols, lo, hi)
+func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
 }
 
-func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
-	q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, mins, group, cols, lo, hi)
+func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+	q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, lo, hi)
 }

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -25,9 +25,9 @@ func q4xQuad(xu []uint8, i4 int) uint32 {
 	return x0 | x1<<8 | x2<<16 | x3<<24
 }
 
-func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
+func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	if !hasAVX2 {
-		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, mins, group, cols, lo, hi)
+		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
 		return
 	}
 	quads := len(xu) / 4
@@ -35,14 +35,23 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 	if vecEnd > lo {
 		mLo := archsimd.BroadcastUint16x16(0x000F)
 		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		mMin := archsimd.BroadcastUint32x8(0xFFFF0000)
 		ones := archsimd.BroadcastInt16x16(1)
 		clear(out[lo:vecEnd])
 		for g := 0; g < len(gsum); g++ {
 			ib := g * group / 4
 			ie := min(ib+group/4, quads)
-			corr := archsimd.BroadcastInt32x8(8 * gsum[g])
-			gsf := archsimd.BroadcastFloat32x8(-Float(gsum[g]))
-			srow := scale[g*cols:]
+			var corr archsimd.Int32x8
+			var gsf archsimd.Float32x8
+			var srow []Float
+			var smrow []uint32
+			if sm != nil {
+				gsf = archsimd.BroadcastFloat32x8(-Float(gsum[g]))
+				smrow = sm[g*cols:]
+			} else {
+				corr = archsimd.BroadcastInt32x8(8 * gsum[g])
+				srow = scale[g*cols:]
+			}
 			for jt := lo; jt < vecEnd; jt += 32 {
 				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
@@ -57,12 +66,12 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 					v = loadU8x16(row[48:]).ExtendToUint16()
 					a3 = a3.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 				}
-				if mins != nil {
-					mrow := mins[g*cols:]
+				if sm != nil {
 					for k, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 						j := jt + 8*k
-						o := gsf.MulAdd(loadF32x8(mrow[j:]), loadF32x8(out[j:]))
-						storeF32x8(a.ConvertToFloat32().MulAdd(loadF32x8(srow[j:]), o), out[j:])
+						u := loadU32x8(smrow[j:])
+						o := gsf.MulAdd(u.And(mMin).AsFloat32x8(), loadF32x8(out[j:]))
+						storeF32x8(a.ConvertToFloat32().MulAdd(u.ShiftAllLeft(16).AsFloat32x8(), o), out[j:])
 					}
 				} else {
 					for k, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
@@ -80,16 +89,16 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 	}
 	archsimd.ClearAVXUpperBits()
 	if vecEnd < hi {
-		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, mins, group, cols, vecEnd, hi)
+		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, vecEnd, hi)
 	}
 }
 
 // q4matmulCols4 is the four-row batched form: per eight-column tile each
 // sixteen-byte nibble load unpacks once and feeds four broadcast
 // activation quads, amortizing the nibble traffic fourfold.
-func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale, mins []Float, group, cols, lo, hi int) {
+func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	if !hasAVX2 {
-		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, mins, group, cols, lo, hi)
+		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, lo, hi)
 		return
 	}
 	quads := len(xus[0]) / 4
@@ -103,6 +112,7 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 	if vecEnd > lo {
 		mLo := archsimd.BroadcastUint16x16(0x000F)
 		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		mMin := archsimd.BroadcastUint32x8(0xFFFF0000)
 		ones := archsimd.BroadcastInt16x16(1)
 		for r := 0; r < 4; r++ {
 			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
@@ -110,7 +120,13 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 		for g := 0; g < len(gsums[0]); g++ {
 			ib := g * group / 4
 			ie := min(ib+group/4, quads)
-			srow := scale[g*cols:]
+			var srow []Float
+			var smrow []uint32
+			if sm != nil {
+				smrow = sm[g*cols:]
+			} else {
+				srow = scale[g*cols:]
+			}
 			for jt := lo; jt < vecEnd; jt += 8 {
 				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
@@ -122,9 +138,10 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 					a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
 					a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
 				}
-				sc := loadF32x8(srow[jt:])
-				if mins != nil {
-					mn := loadF32x8(mins[g*cols+jt:])
+				if sm != nil {
+					u := loadU32x8(smrow[jt:])
+					sc := u.ShiftAllLeft(16).AsFloat32x8()
+					mn := u.And(mMin).AsFloat32x8()
 					for r, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 						gsf := archsimd.BroadcastFloat32x8(-Float(gsums[r][g]))
 						o := out.Data[(r0+r)*cols:]
@@ -132,6 +149,7 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 						storeF32x8(a.ConvertToFloat32().MulAdd(sc, f), o[jt:])
 					}
 				} else {
+					sc := loadF32x8(srow[jt:])
 					for r, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
 						corr := archsimd.BroadcastInt32x8(8 * gsums[r][g])
 						o := out.Data[(r0+r)*cols:]
@@ -151,6 +169,6 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 	}
 	archsimd.ClearAVXUpperBits()
 	if vecEnd < hi {
-		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, mins, group, cols, vecEnd, hi)
+		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, vecEnd, hi)
 	}
 }

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -200,12 +200,11 @@ func TestQuantize4MinForm(t *testing.T) {
 		quads := (c.rows + 3) / 4
 		groups := (c.rows + 31) / 32
 		q := &Q4Matrix{
-			Rows:  c.rows,
-			Cols:  c.cols,
-			Q:     make([]uint8, quads*2*c.cols+32),
-			Scale: make([]Float, groups*c.cols),
-			Min:   make([]Float, groups*c.cols),
-			Group: 32,
+			Rows:     c.rows,
+			Cols:     c.cols,
+			Q:        make([]uint8, quads*2*c.cols+32),
+			ScaleMin: make([]uint32, groups*c.cols),
+			Group:    32,
 		}
 		for j := 0; j < c.cols; j++ {
 			for g := 0; g < groups; g++ {
@@ -220,9 +219,12 @@ func TestQuantize4MinForm(t *testing.T) {
 						hi = v
 					}
 				}
-				s := (hi - lo) / 15
-				q.Scale[g*c.cols+j] = s
-				q.Min[g*c.cols+j] = -lo // value = s*q + lo = s*q - min
+				// value = s*q + lo = s*q - min; the pack rounds the pair
+				// to bfloat16, so quantize against what the kernel will
+				// actually unpack.
+				q.ScaleMin[g*c.cols+j] = PackScaleMin((hi-lo)/15, -lo)
+				s, mn := UnpackScaleMin(q.ScaleMin[g*c.cols+j])
+				lo = -mn
 				for i := rlo; i < rhi; i++ {
 					n := 0
 					if s != 0 {
@@ -257,7 +259,8 @@ func TestQuantize4MinForm(t *testing.T) {
 					acc += qv * xs
 					gs += xs
 				}
-				want += float64(acc)*float64(q.Scale[g*c.cols+j]) - float64(gs)*float64(q.Min[g*c.cols+j])
+				sc, mn := UnpackScaleMin(q.ScaleMin[g*c.cols+j])
+				want += float64(acc)*float64(sc) - float64(gs)*float64(mn)
 			}
 			want *= float64(sx)
 			if diff := math.Abs(float64(out[j]) - want); diff > 1e-3*(1+math.Abs(want)) {

--- a/simd_compat_go126.go
+++ b/simd_compat_go126.go
@@ -19,6 +19,10 @@ func storeI32x8(v archsimd.Int32x8, s []int32) {
 	v.StoreSlice(s)
 }
 
+func loadU32x8(s []uint32) archsimd.Uint32x8 {
+	return archsimd.LoadUint32x8Slice(s)
+}
+
 func loadU8x16(s []uint8) archsimd.Uint8x16 {
 	return archsimd.LoadUint8x16Slice(s)
 }

--- a/simd_compat_go127.go
+++ b/simd_compat_go127.go
@@ -31,6 +31,10 @@ func storeI32x8(v archsimd.Int32x8, s []int32) {
 	v.Store(s)
 }
 
+func loadU32x8(s []uint32) archsimd.Uint32x8 {
+	return archsimd.LoadUint32x8(s)
+}
+
 func loadU8x16(s []uint8) archsimd.Uint8x16 {
 	return archsimd.LoadUint8x16(s)
 }

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -2171,7 +2171,7 @@ func (g *GPU) UploadQ4(q *Q4Matrix) (*GPUQ4Matrix, error) {
 	if q.Group != 0 && q.Group != 64 {
 		return nil, fmt.Errorf("tensai: gpu int4 kernel folds 64-row groups, not %d", q.Group)
 	}
-	if q.Min != nil {
+	if q.ScaleMin != nil {
 		return nil, fmt.Errorf("tensai: gpu int4 kernel is symmetric; min-form matrices are cpu-only")
 	}
 	pairs := (q.Rows + 1) / 2


### PR DESCRIPTION
Follow-up to #65. The K-quant direct path's decode gap was table bandwidth: two float32 per (32-row group, column) add 0.25 bytes per weight to the 0.5-byte nibbles, a third more traffic than the symmetric 64-row layout streams. Each scale/min pair now rounds to bfloat16 and packs into one uint32, halving the table bytes; the kernels unpack with one shift and one mask ahead of the same two-FMA fold. Rounding costs ~0.2% on the tables — far below the 4-bit step — and the Q6_K narrowing quantizes its nibbles against the rounded pair. ScaleMin replaces Q4Matrix.Min as the min-form representation.

Correctness is covered by the min-form kernel test (exact reference over the packed tables, generic and AVX2 in bit agreement) and end-to-end runs of Q4_K_M, Q4_0, and Q8_0 files, all answering correctly. The machine dropped to battery mid-session and throttled about 8x, so the decode improvement could not be measured meaningfully; that measurement is queued for AC power alongside the other pending numbers.