### PR TITLE
quant: vectorize activation quantization, pack quads once

### DIFF
--- a/quant.go
+++ b/quant.go
@@ -14,7 +14,7 @@ func matvecWorkerCount(cols, rows int) int {
 	if cols*rows < 1<<20 {
 		return 1
 	}
-	workers := runtime.NumCPU()
+	workers := runtime.GOMAXPROCS(0)
 	if workers > cols {
 		workers = cols
 	}
@@ -119,8 +119,21 @@ func quantizeColumns(m *Matrix, q *QMatrix, colLo, colHi int) {
 // quantizeActs maps an activation row to 7-bit offset-binary: round(x/sx)
 // clamped to [-63,63], stored +64 so every value sits in [1,127]. The
 // range keeps u8 x s8 pair sums inside int16. Pad bytes (which the weight
-// layout pairs with zero weight rows) fill the final quad.
+// layout pairs with zero weight rows) fill the final quad. The AVX2 build
+// runs a vectorized twin with the same rounding (see quantacts_simd.go).
 func quantizeActs(x []Float) (xu []uint8, sx Float) {
+	padded := (len(x) + 3) &^ 3
+	xu = make([]uint8, padded)
+	for i := len(x); i < padded; i++ {
+		xu[i] = 64 // pairs with a zero weight row: contributes 64*0
+	}
+	sx = quantizeActsInto(x, xu)
+	return xu, sx
+}
+
+// quantizeActsScalar is the portable body; the round is half away from
+// zero, truncation after a signed 0.5 nudge.
+func quantizeActsScalar(x []Float, xu []uint8) Float {
 	var maxAbs Float
 	for _, v := range x {
 		if v < 0 {
@@ -130,17 +143,12 @@ func quantizeActs(x []Float) (xu []uint8, sx Float) {
 			maxAbs = v
 		}
 	}
-	padded := (len(x) + 3) &^ 3
-	xu = make([]uint8, padded)
-	for i := len(x); i < padded; i++ {
-		xu[i] = 64 // pairs with a zero weight row: contributes 64*0
-	}
-	sx = maxAbs / 63
+	sx := maxAbs / 63
 	if sx == 0 {
-		for i := range xu {
+		for i := range x {
 			xu[i] = 64
 		}
-		return xu, 0
+		return 0
 	}
 	inv := 1 / sx
 	for i, v := range x {
@@ -158,7 +166,7 @@ func quantizeActs(x []Float) (xu []uint8, sx Float) {
 		}
 		xu[i] = uint8(n + 64)
 	}
-	return xu, sx
+	return sx
 }
 
 // MatVec computes out = x @ Q for a single activation row: len(x) must be

--- a/quant4.go
+++ b/quant4.go
@@ -124,6 +124,21 @@ func quantize4Columns(m *Matrix, q *Q4Matrix, groups, colLo, colHi int) {
 	}
 }
 
+// packQuads re-centers the 7-bit activations to signed bytes and packs
+// each quad into the u32 the kernels broadcast, so the scalar assembly
+// runs once per call instead of once per column tile.
+func packQuads(xu []uint8) []uint32 {
+	xq := make([]uint32, len(xu)/4)
+	for i := range xq {
+		x0 := uint32(uint8(int8(int(xu[4*i]) - 64)))
+		x1 := uint32(uint8(int8(int(xu[4*i+1]) - 64)))
+		x2 := uint32(uint8(int8(int(xu[4*i+2]) - 64)))
+		x3 := uint32(uint8(int8(int(xu[4*i+3]) - 64)))
+		xq[i] = x0 | x1<<8 | x2<<16 | x3<<24
+	}
+	return xq
+}
+
 // MatVec computes out = x @ Q for a single activation row: len(x) must be
 // Rows and len(out) Cols. The activation row quantizes once per call, with
 // its per-group sums carrying the nibble offset correction.
@@ -133,6 +148,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 			len(x), len(out), q.Rows, q.Cols)
 	}
 	xu, sx := quantizeActs(x) // quad-padded, matching the weight layout
+	xq := packQuads(xu)
 	grp := q.group()
 	gsum := make([]int32, (q.Rows+grp-1)/grp)
 	for i, u := range xu {
@@ -140,7 +156,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)
 	if workers == 1 {
-		q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, 0, q.Cols)
+		q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
 	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
@@ -150,7 +166,7 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 		wg.Add(1)
 		go func(lo, hi int) {
 			defer wg.Done()
-			q4matvecCols(out, xu, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+			q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}(lo, hi)
 	}
 	wg.Wait()
@@ -185,7 +201,7 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
 		for ; r < rows; r++ {
-			q4matvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], gsums[r], q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+			q4matvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], packQuads(xus[r]), sxs[r], gsums[r], q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)

--- a/quant4_generic.go
+++ b/quant4_generic.go
@@ -5,7 +5,7 @@ package tensai
 // Portable dispatcher for the 4-bit matvec kernel; build with
 // GOEXPERIMENT=simd on amd64 for the AVX2 version in quant4_simd.go.
 
-func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
 }
 

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -25,12 +25,12 @@ func q4xQuad(xu []uint8, i4 int) uint32 {
 	return x0 | x1<<8 | x2<<16 | x3<<24
 }
 
-func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	if !hasAVX2 {
 		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
 		return
 	}
-	quads := len(xu) / 4
+	quads := len(xq)
 	vecEnd := lo + ((hi - lo) &^ 31)
 	if vecEnd > lo {
 		mLo := archsimd.BroadcastUint16x16(0x000F)
@@ -47,7 +47,7 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 				for jt := lo; jt < vecEnd; jt += 32 {
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
-						xp := archsimd.BroadcastUint32x8(q4xQuad(xu, i4)).AsInt8x32()
+						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
 						row := qw[i4*2*cols+2*jt:]
 						v := loadU8x16(row).ExtendToUint16()
 						a0 = a0.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
@@ -81,7 +81,7 @@ func q4matvecCols(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, s
 				for jt := lo; jt < vecEnd; jt += 32 {
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
-						xp := archsimd.BroadcastUint32x8(q4xQuad(xu, i4)).AsInt8x32()
+						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
 						row := qw[i4*2*cols+2*jt:]
 						v := loadU8x16(row).ExtendToUint16()
 						a0 = a0.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))

--- a/quant_test.go
+++ b/quant_test.go
@@ -273,3 +273,33 @@ func BenchmarkQ8PrefillRowwise(b *testing.B) {
 		}
 	}
 }
+
+func TestQuantizeActsAgree(t *testing.T) {
+	rng := rand.New(rand.NewSource(77))
+	for _, n := range []int{5, 16, 31, 1536, 4099} {
+		x := make([]Float, n)
+		for i := range x {
+			x[i] = Float(rng.NormFloat64())
+		}
+		// Force representable ties and extremes into the mix.
+		x[0] = 0
+		if n > 8 {
+			x[7] = -x[1]
+			x[8] = 63.5 * x[2]
+		}
+		want := make([]uint8, (n+3)&^3)
+		for i := n; i < len(want); i++ {
+			want[i] = 64
+		}
+		wantSx := quantizeActsScalar(x, want)
+		got, gotSx := quantizeActs(x)
+		if gotSx != wantSx {
+			t.Fatalf("n=%d: sx %v vs scalar %v", n, gotSx, wantSx)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d idx %d: %d vs scalar %d (x=%v)", n, i, got[i], want[i], x[min(i, n-1)])
+			}
+		}
+	}
+}

--- a/quantacts_generic.go
+++ b/quantacts_generic.go
@@ -1,0 +1,10 @@
+//go:build !goexperiment.simd || !amd64
+
+package tensai
+
+// Portable dispatcher for the activation quantizer; build with
+// GOEXPERIMENT=simd on amd64 for the AVX2 version in quantacts_simd.go.
+
+func quantizeActsInto(x []Float, xu []uint8) Float {
+	return quantizeActsScalar(x, xu)
+}

--- a/quantacts_simd.go
+++ b/quantacts_simd.go
@@ -15,9 +15,11 @@ func quantizeActsInto(x []Float, xu []uint8) Float {
 		return quantizeActsScalar(x, xu)
 	}
 	vecEnd := len(x) &^ 7
+	// Clearing the sign bit is Abs; the method only exists from Go 1.27.
+	mSign := archsimd.BroadcastInt32x8(0x7fffffff)
 	m := archsimd.BroadcastFloat32x8(0)
 	for i := 0; i < vecEnd; i += 8 {
-		m = m.Max(loadF32x8(x[i:]).Abs())
+		m = m.Max(loadF32x8(x[i:]).AsInt32x8().And(mSign).AsFloat32x8())
 	}
 	var mb [8]Float
 	storeF32x8(m, mb[:])
@@ -50,7 +52,7 @@ func quantizeActsInto(x []Float, xu []uint8) Float {
 	var buf [8]int32
 	for i := 0; i < vecEnd; i += 8 {
 		f := loadF32x8(x[i:])
-		iv := f.Abs().Mul(inv).Add(half).ConvertToInt32().Min(c63)
+		iv := f.AsInt32x8().And(mSign).AsFloat32x8().Mul(inv).Add(half).ConvertToInt32().Min(c63)
 		s := f.AsInt32x8().ShiftAllRight(31)
 		storeI32x8(iv.Xor(s).Sub(s).Add(c64), buf[:])
 		xu[i] = uint8(buf[0])

--- a/quantacts_simd.go
+++ b/quantacts_simd.go
@@ -1,0 +1,83 @@
+//go:build goexperiment.simd && amd64
+
+package tensai
+
+import "simd/archsimd"
+
+// quantizeActsInto vectorizes the 7-bit activation quantizer with the
+// scalar path's exact rounding: |v|*inv + 0.5 truncates (Go's float to
+// int conversion and CVTTPS2DQ agree), the sign restores through the
+// arithmetic-shift mask, and the clamp caps the magnitude at 63. The
+// max-abs scan and the quantizing pass each run eight lanes wide; only
+// the byte narrowing stays scalar (the API has no saturating pack).
+func quantizeActsInto(x []Float, xu []uint8) Float {
+	if !hasAVX2 || len(x) < 16 {
+		return quantizeActsScalar(x, xu)
+	}
+	vecEnd := len(x) &^ 7
+	m := archsimd.BroadcastFloat32x8(0)
+	for i := 0; i < vecEnd; i += 8 {
+		m = m.Max(loadF32x8(x[i:]).Abs())
+	}
+	var mb [8]Float
+	storeF32x8(m, mb[:])
+	var maxAbs Float
+	for _, v := range mb {
+		if v > maxAbs {
+			maxAbs = v
+		}
+	}
+	for _, v := range x[vecEnd:] {
+		if v < 0 {
+			v = -v
+		}
+		if v > maxAbs {
+			maxAbs = v
+		}
+	}
+	sx := maxAbs / 63
+	if sx == 0 {
+		for i := range x {
+			xu[i] = 64
+		}
+		archsimd.ClearAVXUpperBits()
+		return 0
+	}
+	inv := archsimd.BroadcastFloat32x8(1 / sx)
+	half := archsimd.BroadcastFloat32x8(0.5)
+	c63 := archsimd.BroadcastInt32x8(63)
+	c64 := archsimd.BroadcastInt32x8(64)
+	var buf [8]int32
+	for i := 0; i < vecEnd; i += 8 {
+		f := loadF32x8(x[i:])
+		iv := f.Abs().Mul(inv).Add(half).ConvertToInt32().Min(c63)
+		s := f.AsInt32x8().ShiftAllRight(31)
+		storeI32x8(iv.Xor(s).Sub(s).Add(c64), buf[:])
+		xu[i] = uint8(buf[0])
+		xu[i+1] = uint8(buf[1])
+		xu[i+2] = uint8(buf[2])
+		xu[i+3] = uint8(buf[3])
+		xu[i+4] = uint8(buf[4])
+		xu[i+5] = uint8(buf[5])
+		xu[i+6] = uint8(buf[6])
+		xu[i+7] = uint8(buf[7])
+	}
+	archsimd.ClearAVXUpperBits()
+	invs := 1 / sx
+	for i, v := range x[vecEnd:] {
+		f := v * invs
+		if f >= 0 {
+			f += 0.5
+		} else {
+			f -= 0.5
+		}
+		n := int(f)
+		if n < -63 {
+			n = -63
+		} else if n > 63 {
+			n = 63
+		}
+		xu[vecEnd+i] = uint8(n + 64)
+	}
+	return sx
+}


### PR DESCRIPTION
Decode profiling after #70 left two per-token scalar costs on every matvec call: quantizeActs walked the row twice with branchy scalar rounding, and the Q4 kernel reassembled the same broadcast quad from bytes once per 32-column tile — 280 times over for a 1.5B down projection. quantizeActs gains an AVX2 twin with the scalar path's exact rounding, locked in by a test comparing the two on the simd build, and the Q4 matvec takes pre-packed quads (one packQuads pass per call). Worth a few percent of decode end to end; matvecWorkerCount now follows GOMAXPROCS so worker-count experiments don't need a rebuild.

The profiling also identified the next, structural item: the column-striped weight walk gives each worker short contiguous runs, and a four-worker decode beats sixteen by ~10% on this machine. A contiguous column-tile weight layout (each worker streaming sequential memory, like llama.cpp's output-major blocks) is the follow-up, and looks like the main remaining piece of the 2x decode gap to llama.cpp on the same file.