### PR TITLE
quant4: tile the nibble layout 32 columns wide

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -174,8 +174,8 @@ func repackQ4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap func
 				q := blk[2+l]
 				iLo := b*32 + l
 				iHi := b*32 + l + 16
-				dst.Q[(iLo/4)*2*dst.Cols+2*j+(iLo%4)/2] |= (q & 0x0F) << (4 * (iLo % 2))
-				dst.Q[(iHi/4)*2*dst.Cols+2*j+(iHi%4)/2] |= (q >> 4) << (4 * (iHi % 2))
+				dst.Q[dst.Index(iLo, j)] |= (q & 0x0F) << (4 * (iLo % 2))
+				dst.Q[dst.Index(iHi, j)] |= (q >> 4) << (4 * (iHi % 2))
 			}
 		}
 	}
@@ -250,8 +250,8 @@ func repackQ4K(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fun
 					q := qs[32*c+l]
 					iLo := b*256 + 64*c + l
 					iHi := iLo + 32
-					dst.Q[(iLo/4)*2*dst.Cols+2*j+(iLo%4)/2] |= (q & 0x0F) << (4 * (iLo % 2))
-					dst.Q[(iHi/4)*2*dst.Cols+2*j+(iHi%4)/2] |= (q >> 4) << (4 * (iHi % 2))
+					dst.Q[dst.Index(iLo, j)] |= (q & 0x0F) << (4 * (iLo % 2))
+					dst.Q[dst.Index(iHi, j)] |= (q >> 4) << (4 * (iHi % 2))
 				}
 			}
 		}
@@ -364,7 +364,7 @@ func repackQ6K4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fu
 						n = 15
 					}
 					gi := b*256 + p*32 + k
-					dst.Q[(gi/4)*2*dst.Cols+2*j+(gi%4)/2] |= uint8(n) << (4 * (gi % 2))
+					dst.Q[dst.Index(gi, j)] |= uint8(n) << (4 * (gi % 2))
 				}
 			}
 		}
@@ -560,7 +560,7 @@ func repackQ5K4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fu
 				for k, w := range grp {
 					nib := (sgn*(int(w)-int(qref))*30 + span) / (2 * span)
 					gi := b*256 + is*32 + k
-					dst.Q[(gi/4)*2*dst.Cols+2*j+(gi%4)/2] |= uint8(nib) << (4 * (gi % 2))
+					dst.Q[dst.Index(gi, j)] |= uint8(nib) << (4 * (gi % 2))
 				}
 			}
 		}
@@ -763,15 +763,7 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 			}
 			return &qmat{cols: dst.Cols, f: dst.MatVec, mm: dst.MatMul}
 		}
-		quads := (in + 3) / 4
-		groups := (in + 31) / 32
-		dst := &tensai.Q4Matrix{
-			Rows:     in,
-			Cols:     total,
-			Q:        make([]uint8, quads*2*total+32),
-			ScaleMin: make([]uint32, groups*total),
-			Group:    32,
-		}
+		dst := tensai.NewQ4Matrix(in, total, 32, true)
 		colOff := 0
 		for i, name := range names {
 			_, raw, err := g.RawTensor(name)
@@ -825,15 +817,7 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 			}
 			return &qmat{cols: dst.Cols, f: dst.MatVec, mm: dst.MatMul}
 		}
-		quads := (in + 3) / 4
-		groups := (in + 31) / 32
-		dst := &tensai.Q4Matrix{
-			Rows:     in,
-			Cols:     total,
-			Q:        make([]uint8, quads*2*total+32),
-			ScaleMin: make([]uint32, groups*total),
-			Group:    32,
-		}
+		dst := tensai.NewQ4Matrix(in, total, 32, true)
 		colOff := 0
 		for i, name := range names {
 			_, raw, err := g.RawTensor(name)
@@ -872,15 +856,7 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 			}
 			return &qmat{cols: dst.Cols, f: dst.MatVec, mm: dst.MatMul}
 		}
-		quads := (in + 3) / 4
-		groups := (in + 31) / 32
-		dst := &tensai.Q4Matrix{
-			Rows:     in,
-			Cols:     total,
-			Q:        make([]uint8, quads*2*total+32),
-			ScaleMin: make([]uint32, groups*total),
-			Group:    32,
-		}
+		dst := tensai.NewQ4Matrix(in, total, 32, true)
 		colOff := 0
 		for i, name := range names {
 			_, raw, err := g.RawTensor(name)
@@ -905,15 +881,7 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 		for _, o := range outs {
 			total += o
 		}
-		quads := (in + 3) / 4
-		groups := (in + 31) / 32
-		dst := &tensai.Q4Matrix{
-			Rows:  in,
-			Cols:  total,
-			Q:     make([]uint8, quads*2*total+32),
-			Scale: make([]float32, groups*total),
-			Group: 32,
-		}
+		dst := tensai.NewQ4Matrix(in, total, 32, false)
 		colOff := 0
 		for i, name := range names {
 			_, raw, err := g.RawTensor(name)

--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -43,19 +43,25 @@ type gpuQwen struct {
 }
 
 // sliceQ4 copies a column range out of a fused 4-bit quantized matrix;
-// scales are per (group, column), so the slice is exact.
+// scales are per (group, column), so the slice is exact. Tile-aligned
+// ranges (every fused projection boundary in practice) copy whole
+// contiguous tile blocks; anything else moves nibble by nibble.
 func sliceQ4(q *tensai.Q4Matrix, lo, hi int) *tensai.Q4Matrix {
 	quads := (q.Rows + 3) / 4
 	groups := len(q.Scale) / q.Cols
 	cols := hi - lo
-	out := &tensai.Q4Matrix{
-		Rows:  q.Rows,
-		Cols:  cols,
-		Q:     make([]uint8, quads*2*cols+32),
-		Scale: make([]float32, groups*cols),
-	}
-	for i4 := 0; i4 < quads; i4++ {
-		copy(out.Q[i4*2*cols:i4*2*cols+2*cols], q.Q[i4*2*q.Cols+2*lo:i4*2*q.Cols+2*hi])
+	out := tensai.NewQ4Matrix(q.Rows, cols, q.Group, false)
+	if lo%32 == 0 && cols%32 == 0 {
+		block := quads * 64
+		copy(out.Q[:(cols/32)*block], q.Q[(lo/32)*block:(hi/32)*block])
+	} else {
+		for j := 0; j < cols; j++ {
+			for i := 0; i < 4*quads; i += 2 {
+				b := q.Q[q.Index(i, lo+j)]
+				out.Q[out.Index(i, j)] |= b & 0x0F << (4 * uint(i%2))
+				out.Q[out.Index(i+1, j)] |= b >> 4 << (4 * uint((i+1)%2))
+			}
+		}
 	}
 	for g := 0; g < groups; g++ {
 		copy(out.Scale[g*cols:(g+1)*cols], q.Scale[g*q.Cols+lo:g*q.Cols+hi])

--- a/quant4.go
+++ b/quant4.go
@@ -13,14 +13,17 @@ const q4Group = 64
 
 // Q4Matrix is a weight matrix quantized to 4 bits with one scale per
 // (64-row group, output column). Rows are stored in interleaved quads of
-// two bytes per column: byte (i/4)*2*Cols + 2*j + (i%4)/2 holds rows
-// i..i+3 of column j as four nibbles (each byte low nibble first),
-// offset-binary (0..15 encodes -8..7), zero rows padding the final quad.
-// The 256-bit kernel's nibble unpack turns those two bytes into four
-// consecutive u8 lanes — exactly QMatrix's quad layout — so the same
-// two-instruction multiply-add chain takes a column four rows deep, with
-// activations re-centered to signed bytes and the nibble offset folded
-// out through per-group activation sums.
+// two bytes per column, tiled 32 columns at a time: tile j/32 packs its
+// row quads back to back (64 bytes apiece, see Index), so a kernel
+// worker sweeping a tile range streams strictly sequential memory
+// instead of striding across the full row width. Each byte holds two
+// rows' nibbles (low nibble first), offset-binary (0..15 encodes -8..7),
+// zero rows padding the final quad. The 256-bit kernel's nibble unpack
+// turns those two bytes into four consecutive u8 lanes — exactly
+// QMatrix's quad layout — so the same two-instruction multiply-add chain
+// takes a column four rows deep, with activations re-centered to signed
+// bytes and the nibble offset folded out through per-group activation
+// sums.
 type Q4Matrix struct {
 	Rows, Cols int
 	Q          []uint8 // row quads x 2*Cols, padded for 32-byte loads
@@ -53,6 +56,41 @@ func bf16(f Float) uint16 {
 	return uint16((b + 0x7fff + (b >> 16 & 1)) >> 16)
 }
 
+// q4Tile is the column-tile width of the nibble layout.
+const q4Tile = 32
+
+// Index returns the position in Q of the byte carrying column j of rows
+// i and i+1 (the low and the high nibble; shift by 4*(i%2)).
+func (q *Q4Matrix) Index(i, j int) int {
+	quads := (q.Rows + 3) / 4
+	return (j/q4Tile)*quads*2*q4Tile + (i/4)*2*q4Tile + (j%q4Tile)*2 + (i%4)/2
+}
+
+// NewQ4Matrix allocates the layout for rows x cols with `group` input
+// rows per scale (0 for the default 64); minForm picks the packed
+// asymmetric scale/min table over the symmetric Scale. The caller fills
+// Q via Index and the table it asked for.
+func NewQ4Matrix(rows, cols, group int, minForm bool) *Q4Matrix {
+	if group == 0 {
+		group = q4Group
+	}
+	quads := (rows + 3) / 4
+	groups := (rows + group - 1) / group
+	tiles := (cols + q4Tile - 1) / q4Tile
+	q := &Q4Matrix{
+		Rows:  rows,
+		Cols:  cols,
+		Q:     make([]uint8, tiles*quads*2*q4Tile+32),
+		Group: group,
+	}
+	if minForm {
+		q.ScaleMin = make([]uint32, groups*cols)
+	} else {
+		q.Scale = make([]Float, groups*cols)
+	}
+	return q
+}
+
 // group returns the effective scale-group length.
 func (q *Q4Matrix) group() int {
 	if q.Group != 0 {
@@ -64,14 +102,8 @@ func (q *Q4Matrix) group() int {
 // QuantizeMatrix4 quantizes group-wise, symmetric with round-to-nearest.
 // Columns split across CPUs for large matrices, like QuantizeMatrix.
 func QuantizeMatrix4(m *Matrix) (*Q4Matrix, error) {
-	quads := (m.Rows + 3) / 4
 	groups := (m.Rows + q4Group - 1) / q4Group
-	q := &Q4Matrix{
-		Rows:  m.Rows,
-		Cols:  m.Cols,
-		Q:     make([]uint8, quads*2*m.Cols+32),
-		Scale: make([]Float, groups*m.Cols),
-	}
+	q := NewQ4Matrix(m.Rows, m.Cols, 0, false)
 	parallelCols(m.Rows, m.Cols, func(lo, hi int) {
 		quantize4Columns(m, q, groups, lo, hi)
 	})
@@ -115,11 +147,11 @@ func quantize4Columns(m *Matrix, q *Q4Matrix, groups, colLo, colHi int) {
 						n = 7
 					}
 				}
-				q.Q[(i/4)*2*m.Cols+2*j+(i%4)/2] |= uint8(n+8) << (4 * (i % 2))
+				q.Q[q.Index(i, j)] |= uint8(n+8) << (4 * (i % 2))
 			}
 		}
 		for i := m.Rows; i < 4*((m.Rows+3)/4); i++ {
-			q.Q[(i/4)*2*m.Cols+2*j+(i%4)/2] |= 8 << (4 * (i % 2)) // zero pad rows
+			q.Q[q.Index(i, j)] |= 8 << (4 * (i % 2)) // zero pad rows
 		}
 	}
 }
@@ -159,7 +191,9 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 		q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
+	// Tile-aligned chunks keep every worker's vector span inside whole
+	// layout tiles, and its memory walk sequential.
+	chunk := ((q.Cols+workers-1)/workers + q4Tile - 1) &^ (q4Tile - 1)
 	var wg sync.WaitGroup
 	for lo := 0; lo < q.Cols; lo += chunk {
 		hi := min(lo+chunk, q.Cols)
@@ -209,7 +243,9 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 		run(0, q.Cols)
 		return nil
 	}
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
+	// Tile-aligned, so the row-tail matvec's vector span starts on a
+	// layout tile like the batch kernel's 8-column steps do.
+	chunk := ((q.Cols+workers-1)/workers + q4Tile - 1) &^ (q4Tile - 1)
 	var wg sync.WaitGroup
 	for lo := 0; lo < q.Cols; lo += chunk {
 		hi := min(lo+chunk, q.Cols)
@@ -241,7 +277,7 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 			clear(acc[r])
 		}
 		for i4 := ib; i4 < ie; i4++ {
-			row := qw[i4*2*cols:]
+			row := qw[i4*2*q4Tile:]
 			for r := 0; r < 4; r++ {
 				x0 := int32(xus[r][4*i4]) - 64
 				x1 := int32(xus[r][4*i4+1]) - 64
@@ -249,7 +285,8 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 				x3 := int32(xus[r][4*i4+3]) - 64
 				a := acc[r]
 				for j := lo; j < hi; j++ {
-					b0, b1 := row[2*j], row[2*j+1]
+					o := (j/q4Tile)*quads*2*q4Tile + (j%q4Tile)*2
+					b0, b1 := row[o], row[o+1]
 					a[j-lo] += int32(b0&0x0F)*x0 + int32(b0>>4)*x1 +
 						int32(b1&0x0F)*x2 + int32(b1>>4)*x3
 				}
@@ -301,9 +338,10 @@ func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []u
 			x1 := int32(xu[4*i4+1]) - 64
 			x2 := int32(xu[4*i4+2]) - 64
 			x3 := int32(xu[4*i4+3]) - 64
-			row := qw[i4*2*cols:]
+			row := qw[i4*2*q4Tile:]
 			for j := lo; j < hi; j++ {
-				b0, b1 := row[2*j], row[2*j+1]
+				o := (j/q4Tile)*quads*2*q4Tile + (j%q4Tile)*2
+				b0, b1 := row[o], row[o+1]
 				acc[j-lo] += int32(b0&0x0F)*x0 + int32(b0>>4)*x1 +
 					int32(b1&0x0F)*x2 + int32(b1>>4)*x3
 			}

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -45,10 +45,11 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 				gsf := archsimd.BroadcastFloat32x8(Float(gsum[g]))
 				smrow := sm[g*cols:]
 				for jt := lo; jt < vecEnd; jt += 32 {
+					tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
-						row := qw[i4*2*cols+2*jt:]
+						row := tile[i4*2*q4Tile:]
 						v := loadU8x16(row).ExtendToUint16()
 						a0 = a0.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 						v = loadU8x16(row[16:]).ExtendToUint16()
@@ -79,10 +80,11 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 				corr := archsimd.BroadcastInt32x8(8 * gsum[g])
 				srow := scale[g*cols:]
 				for jt := lo; jt < vecEnd; jt += 32 {
+					tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
-						row := qw[i4*2*cols+2*jt:]
+						row := tile[i4*2*q4Tile:]
 						v := loadU8x16(row).ExtendToUint16()
 						a0 = a0.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 						v = loadU8x16(row[16:]).ExtendToUint16()
@@ -148,9 +150,10 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 				gsf2 := archsimd.BroadcastFloat32x8(Float(gsums[2][g]))
 				gsf3 := archsimd.BroadcastFloat32x8(Float(gsums[3][g]))
 				for jt := lo; jt < vecEnd; jt += 8 {
+					tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
-						v := loadU8x16(qw[i4*2*cols+2*jt:]).ExtendToUint16()
+						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
 						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
 						xf := xq[i4*4 : i4*4+4]
 						a0 = a0.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[0]).AsInt8x32()).DotProductPairs(ones))
@@ -177,9 +180,10 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 				corr2 := archsimd.BroadcastInt32x8(8 * gsums[2][g])
 				corr3 := archsimd.BroadcastInt32x8(8 * gsums[3][g])
 				for jt := lo; jt < vecEnd; jt += 8 {
+					tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
-						v := loadU8x16(qw[i4*2*cols+2*jt:]).ExtendToUint16()
+						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
 						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
 						xf := xq[i4*4 : i4*4+4]
 						a0 = a0.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[0]).AsInt8x32()).DotProductPairs(ones))

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -38,7 +38,7 @@ func TestQuantize4MatVec(t *testing.T) {
 				rlo, rhi := g*q4Group, min((g+1)*q4Group, c.rows)
 				var acc, gs int64
 				for i := rlo; i < rhi; i++ {
-					nib := int64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
+					nib := int64(q.Q[q.Index(i, j)]>>(4*(i%2))) & 0x0F
 					xs := int64(xu[i]) - 64
 					acc += nib * xs
 					gs += xs
@@ -92,15 +92,8 @@ func TestQuantize4Group32(t *testing.T) {
 		m := RandomMatrix(c.rows, c.cols, rng)
 		// Build a Group-32 matrix by quantizing per 32-row group, the way
 		// a GGUF Q4_0 repack does.
-		quads := (c.rows + 3) / 4
 		groups := (c.rows + 31) / 32
-		q := &Q4Matrix{
-			Rows:  c.rows,
-			Cols:  c.cols,
-			Q:     make([]uint8, quads*2*c.cols+32),
-			Scale: make([]Float, groups*c.cols),
-			Group: 32,
-		}
+		q := NewQ4Matrix(c.rows, c.cols, 32, false)
 		for j := 0; j < c.cols; j++ {
 			for g := 0; g < groups; g++ {
 				rlo, rhi := g*32, min((g+1)*32, c.rows)
@@ -132,11 +125,11 @@ func TestQuantize4Group32(t *testing.T) {
 							n = 7
 						}
 					}
-					q.Q[(i/4)*2*c.cols+2*j+(i%4)/2] |= uint8(n+8) << (4 * (i % 2))
+					q.Q[q.Index(i, j)] |= uint8(n+8) << (4 * (i % 2))
 				}
 			}
-			for i := c.rows; i < 4*quads; i++ {
-				q.Q[(i/4)*2*c.cols+2*j+(i%4)/2] |= 8 << (4 * (i % 2))
+			for i := c.rows; i < 4*((c.rows+3)/4); i++ {
+				q.Q[q.Index(i, j)] |= 8 << (4 * (i % 2))
 			}
 		}
 
@@ -155,7 +148,7 @@ func TestQuantize4Group32(t *testing.T) {
 				rlo, rhi := g*32, min((g+1)*32, c.rows)
 				var acc, gs int64
 				for i := rlo; i < rhi; i++ {
-					nib := int64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
+					nib := int64(q.Q[q.Index(i, j)]>>(4*(i%2))) & 0x0F
 					xs := int64(xu[i]) - 64
 					acc += nib * xs
 					gs += xs
@@ -197,15 +190,8 @@ func TestQuantize4MinForm(t *testing.T) {
 		m := RandomMatrix(c.rows, c.cols, rng)
 		// Asymmetric group quantization: value = scale*q - min, q in 0..15
 		// — the form GGUF's Q4_K sub-blocks carry.
-		quads := (c.rows + 3) / 4
 		groups := (c.rows + 31) / 32
-		q := &Q4Matrix{
-			Rows:     c.rows,
-			Cols:     c.cols,
-			Q:        make([]uint8, quads*2*c.cols+32),
-			ScaleMin: make([]uint32, groups*c.cols),
-			Group:    32,
-		}
+		q := NewQ4Matrix(c.rows, c.cols, 32, true)
 		for j := 0; j < c.cols; j++ {
 			for g := 0; g < groups; g++ {
 				rlo, rhi := g*32, min((g+1)*32, c.rows)
@@ -233,7 +219,7 @@ func TestQuantize4MinForm(t *testing.T) {
 							n = 15
 						}
 					}
-					q.Q[(i/4)*2*c.cols+2*j+(i%4)/2] |= uint8(n) << (4 * (i % 2))
+					q.Q[q.Index(i, j)] |= uint8(n) << (4 * (i % 2))
 				}
 			}
 			// Pad rows encode q=0; their min contribution must vanish, so
@@ -254,7 +240,7 @@ func TestQuantize4MinForm(t *testing.T) {
 				rlo, rhi := g*32, min((g+1)*32, c.rows)
 				var acc, gs int64
 				for i := rlo; i < rhi; i++ {
-					qv := int64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
+					qv := int64(q.Q[q.Index(i, j)]>>(4*(i%2))) & 0x0F
 					xs := int64(xu[i]) - 64
 					acc += qv * xs
 					gs += xs

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -1152,7 +1152,7 @@ func TestGPUQ4MatMul(t *testing.T) {
 			for j := 0; j < c.cols; j++ {
 				var want float64
 				for i := 0; i < c.rows; i++ {
-					nib := float64(q.Q[(i/4)*2*c.cols+2*j+(i%4)/2]>>(4*(i%2))&0x0F) - 8
+					nib := float64(q.Q[q.Index(i, j)]>>(4*(i%2))&0x0F) - 8
 					sc := float64(q.Scale[(i/64)*c.cols+j])
 					want += float64(x.Data[r*c.rows+i]) * nib * sc
 				}

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -2182,7 +2182,7 @@ func (g *GPU) UploadQ4(q *Q4Matrix) (*GPUQ4Matrix, error) {
 		if i >= q.Rows {
 			return 8 // zero pad row
 		}
-		return uint32(q.Q[(i/4)*2*q.Cols+2*j+(i%4)/2]>>(4*(i%2))) & 0x0F
+		return uint32(q.Q[q.Index(i, j)]>>(4*(i%2))) & 0x0F
 	}
 	packed := make([]uint32, pairs*words)
 	for i2 := 0; i2 < pairs; i2++ {


### PR DESCRIPTION
The quad layout stored each row quad across the full column width, so a matvec worker owning a column stripe touched a short run of every 32KB-strided row — and adding workers shortened the runs further, to the point that a four-worker decode beat sixteen by ten percent. Tiles of 32 columns now pack their row quads back to back (64 bytes per quad; Q4Matrix.Index gives the byte address), turning each worker's walk into one sequential stream.

Worker scaling comes back (sixteen beats four again), the symmetric matvec picks up another ~1 GB/s (28 GB/s nibble-rate), and a 1.5B Q4_K_M decodes at ~16 tok/s against 14 before today's series. Writers go through the new exported NewQ4Matrix and Index — the quantizer, the example's four GGUF repackers, the GPU upload, and the GPU column slicer, which copies whole contiguous tile blocks for the aligned ranges fused projections produce. Column chunks align to tiles in both the matvec and batch splits, so a vector span never straddles a tile; the batch-equals-matvec test caught exactly that misalignment during development.