### PR TITLE
quant: one fan-out helper, the caller streaming a chunk

### DIFF
--- a/quant.go
+++ b/quant.go
@@ -21,6 +21,25 @@ func matvecWorkerCount(cols, rows int) int {
 	return workers
 }
 
+// parallelChunks splits [0, n) into align-rounded chunks across the
+// workers, the calling goroutine taking the first chunk itself: a
+// matvec fan-out spawns workers-1 goroutines and the caller streams
+// instead of idling on the join.
+func parallelChunks(n, workers, align int, body func(lo, hi int)) {
+	chunk := ((n+workers-1)/workers + align - 1) &^ (align - 1)
+	var wg sync.WaitGroup
+	for lo := chunk; lo < n; lo += chunk {
+		hi := min(lo+chunk, n)
+		wg.Add(1)
+		go func(lo, hi int) {
+			defer wg.Done()
+			body(lo, hi)
+		}(lo, hi)
+	}
+	body(0, min(chunk, n))
+	wg.Wait()
+}
+
 // QMatrix is a weight matrix quantized to int8 with one scale per output
 // column: W[i][j] ~= Float(q_ij) * Scale[j]. Rows are stored in
 // interleaved quads — Q[(i/4)*4*Cols + 4*j + i%4] holds rows i..i+3 of
@@ -184,17 +203,9 @@ func (q *QMatrix) MatVec(x, out []Float) error {
 		return nil
 	}
 	// Chunks stay multiples of 8 so only the last one has a scalar tail.
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			qmatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+		qmatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+	})
 	return nil
 }
 
@@ -228,17 +239,9 @@ func (q *QMatrix) MatMul(x, out *Matrix) error {
 		run(0, q.Cols)
 		return nil
 	}
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			run(lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+		run(lo, hi)
+	})
 	return nil
 }
 

--- a/quant4.go
+++ b/quant4.go
@@ -3,7 +3,6 @@ package tensai
 import (
 	"fmt"
 	"math"
-	"sync"
 )
 
 // q4Group is the number of input rows sharing one scale. 64 keeps
@@ -193,17 +192,9 @@ func (q *Q4Matrix) MatVec(x, out []Float) error {
 	}
 	// Tile-aligned chunks keep every worker's vector span inside whole
 	// layout tiles, and its memory walk sequential.
-	chunk := ((q.Cols+workers-1)/workers + q4Tile - 1) &^ (q4Tile - 1)
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+		q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+	})
 	return nil
 }
 
@@ -245,17 +236,9 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 	}
 	// Tile-aligned, so the row-tail matvec's vector span starts on a
 	// layout tile like the batch kernel's 8-column steps do.
-	chunk := ((q.Cols+workers-1)/workers + q4Tile - 1) &^ (q4Tile - 1)
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			run(lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+		run(lo, hi)
+	})
 	return nil
 }
 

--- a/quant8g.go
+++ b/quant8g.go
@@ -2,7 +2,6 @@ package tensai
 
 import (
 	"fmt"
-	"sync"
 )
 
 // q8Group is the number of input rows sharing one scale in a Q8GMatrix —
@@ -65,17 +64,9 @@ func (q *Q8GMatrix) MatVec(x, out []Float) error {
 		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
+	})
 	return nil
 }
 
@@ -107,17 +98,9 @@ func (q *Q8GMatrix) MatMul(x, out *Matrix) error {
 		run(0, q.Cols)
 		return nil
 	}
-	chunk := ((q.Cols+workers-1)/workers + 7) &^ 7
-	var wg sync.WaitGroup
-	for lo := 0; lo < q.Cols; lo += chunk {
-		hi := min(lo+chunk, q.Cols)
-		wg.Add(1)
-		go func(lo, hi int) {
-			defer wg.Done()
-			run(lo, hi)
-		}(lo, hi)
-	}
-	wg.Wait()
+	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+		run(lo, hi)
+	})
 	return nil
 }
 


### PR DESCRIPTION
Collapses the six copies of the column fan-out loop into parallelChunks, which hands the first chunk to the calling goroutine instead of parking it on the join. Measured neutral on decode — spawn cost was already noise against the streams — so the value is one place to align chunks per layout and no idle caller.

Instrumentation along the way put the 1.5B Q4_K_M decode budget at 44ms of layer matvecs (18 GB/s effective vs the kernel's 22.5 — small projections never reach peak stream rate), a 6ms lm head at full kernel speed, 5ms attention, and 3.5ms scalar silu. The remaining structural lever is interleaving the scale tables into the weight tiles so each worker reads one stream instead of two, the way llama.cpp's superblocks do.