### PR TITLE
tensai: SiluMul through the vector exp

### DIFF
--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -363,10 +363,7 @@ func rmsnorm(x, w []float32, eps float64) []float32 {
 // Gemma's tanh-approximated gelu when geglu is set.
 func activate(gate, up []float32, geglu bool) {
 	if !geglu {
-		for i := range gate {
-			g := float64(gate[i])
-			gate[i] = float32(g/(1+math.Exp(-g))) * up[i]
-		}
+		tensai.SiluMul(gate, up)
 		return
 	}
 	const c = 0.7978845608028654 // sqrt(2/pi)

--- a/kernels.go
+++ b/kernels.go
@@ -50,6 +50,13 @@ func sigmoidFwdGeneric(dst, src []Float) {
 	}
 }
 
+// siluMulGeneric computes gate = silu(gate) * up, the SwiGLU gate.
+func siluMulGeneric(gate, up []Float) {
+	for i, g := range gate {
+		gate[i] = g / (1 + expF(-g)) * up[i]
+	}
+}
+
 // sigmoidBwdGeneric computes dst = grad * y * (1-y) from the forward output y.
 func sigmoidBwdGeneric(dst, grad, y []Float) {
 	for i, g := range grad {

--- a/kernels_test.go
+++ b/kernels_test.go
@@ -157,3 +157,24 @@ func TestLayerNormKernelMatchesGeneric(t *testing.T) {
 		}
 	}
 }
+
+func TestSiluMul(t *testing.T) {
+	rng := rand.New(rand.NewSource(21))
+	for _, n := range []int{1, 7, 8, 33, 1000} {
+		gate := make([]Float, n)
+		up := make([]Float, n)
+		want := make([]Float, n)
+		for i := range gate {
+			gate[i] = Float(rng.NormFloat64() * 4)
+			up[i] = Float(rng.NormFloat64())
+			g := float64(gate[i])
+			want[i] = Float(g/(1+math.Exp(-g))) * up[i]
+		}
+		SiluMul(gate, up)
+		for i := range gate {
+			if diff := math.Abs(float64(gate[i] - want[i])); diff > 2e-6*(1+math.Abs(float64(want[i]))) {
+				t.Fatalf("n=%d idx %d: got %v want %v", n, i, gate[i], want[i])
+			}
+		}
+	}
+}

--- a/mathvec_generic.go
+++ b/mathvec_generic.go
@@ -12,6 +12,7 @@ func leakyBwd(dst, grad, src []Float, alpha Float) {
 	leakyBwdGeneric(dst, grad, src, alpha)
 }
 func sigmoidFwd(dst, src []Float)            { sigmoidFwdGeneric(dst, src) }
+func siluMul(gate, up []Float)               { siluMulGeneric(gate, up) }
 func sigmoidBwd(dst, grad, y []Float)        { sigmoidBwdGeneric(dst, grad, y) }
 func tanhFwd(dst, src []Float)               { tanhFwdGeneric(dst, src) }
 func tanhBwd(dst, grad, y []Float)           { tanhBwdGeneric(dst, grad, y) }

--- a/mathvec_simd.go
+++ b/mathvec_simd.go
@@ -116,6 +116,20 @@ func sigmoidFwd(dst, src []Float) {
 	})
 }
 
+// siluMul computes gate = gate * sigmoid(gate) * up — the SwiGLU gate,
+// a transformer decode's only transcendental hot spot.
+func siluMul(gate, up []Float) {
+	if !hasAVX2 {
+		siluMulGeneric(gate, up)
+		return
+	}
+	one := archsimd.BroadcastFloat32x8(1)
+	zero := archsimd.BroadcastFloat32x8(0)
+	mapSlices2(gate, gate, up, func(g, u archsimd.Float32x8) archsimd.Float32x8 {
+		return g.Div(one.Add(vexpf(zero.Sub(g)))).Mul(u)
+	})
+}
+
 func sigmoidBwd(dst, grad, y []Float) {
 	if !hasAVX2 {
 		sigmoidBwdGeneric(dst, grad, y)

--- a/tensor.go
+++ b/tensor.go
@@ -305,3 +305,15 @@ func Axpy(a Float, x, y []Float) {
 	}
 	axpy(a, x, y)
 }
+
+// SiluMul computes gate[i] = silu(gate[i]) * up[i] in place — the SwiGLU
+// activation between a transformer block's fused gate/up projection and
+// its down projection. The AVX2 build evaluates the sigmoid with the
+// same polynomial exp the training kernels use, so results can differ
+// from the portable build by a few float32 ulps.
+func SiluMul(gate, up []Float) {
+	if len(gate) != len(up) {
+		panic("tensai: SiluMul length mismatch")
+	}
+	siluMul(gate, up)
+}


### PR DESCRIPTION
Decode instrumentation put 3.5ms of a 1.5B's 60ms token on the SwiGLU activation — a scalar loop through float64 math.Exp, a quarter million calls per token. SiluMul runs gate*sigmoid(gate)*up eight lanes at a time through the Cephes exp polynomial the training kernels already use, a few float32 ulps from the float64 reference like the rest of the element-wise family; the portable build keeps the math.Exp form and a test bounds both against the float64 reference. The qwen example's silu path calls it (Gemma's gelu-tanh stays scalar for now). Worth ~5% of decode; qwen and Phi-3 answers unchanged.