### PR TITLE
quant4: tile-major tables, tiles outermost, flat fold operands

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -169,7 +169,7 @@ func repackQ4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap func
 		}
 		for b := 0; b < nb; b++ {
 			blk := raw[(r*nb+b)*18:]
-			dst.Scale[b*dst.Cols+j] = gguf.Float16(binary.LittleEndian.Uint16(blk))
+			dst.Scale[dst.TableIndex(b, j)] = gguf.Float16(binary.LittleEndian.Uint16(blk))
 			for l := 0; l < 16; l++ {
 				q := blk[2+l]
 				iLo := b*32 + l
@@ -243,7 +243,7 @@ func repackQ4K(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fun
 			for is := 0; is < 8; is++ {
 				sc, mn := kScaleMin(is, scales)
 				g := b*8 + is
-				dst.ScaleMin[g*dst.Cols+j] = tensai.PackScaleMin(d*float32(sc), dmin*float32(mn))
+				dst.ScaleMin[dst.TableIndex(g, j)] = tensai.PackScaleMin(d*float32(sc), dmin*float32(mn))
 			}
 			for c := 0; c < 4; c++ {
 				for l := 0; l < 32; l++ {
@@ -350,7 +350,7 @@ func repackQ6K4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fu
 				// will unpack, so the rounding lands on the nibble choice
 				// rather than stacking onto the reconstruction.
 				packed := tensai.PackScaleMin((vmax-vmin)/15, -vmin)
-				dst.ScaleMin[g*dst.Cols+j] = packed
+				dst.ScaleMin[dst.TableIndex(g, j)] = packed
 				scale, mn := tensai.UnpackScaleMin(packed)
 				if scale == 0 {
 					continue
@@ -552,7 +552,7 @@ func repackQ5K4(dst *tensai.Q4Matrix, raw []byte, out, in, colOff int, colMap fu
 				}
 				span := int(qhi) - int(qlo)
 				g := b*8 + is
-				dst.ScaleMin[g*dst.Cols+j] = tensai.PackScaleMin(
+				dst.ScaleMin[dst.TableIndex(g, j)] = tensai.PackScaleMin(
 					s*float32(sgn)*float32(span)/15, m-s*float32(qref))
 				if span == 0 {
 					continue

--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -48,7 +48,11 @@ type gpuQwen struct {
 // contiguous tile blocks; anything else moves nibble by nibble.
 func sliceQ4(q *tensai.Q4Matrix, lo, hi int) *tensai.Q4Matrix {
 	quads := (q.Rows + 3) / 4
-	groups := len(q.Scale) / q.Cols
+	gsz := q.Group
+	if gsz == 0 {
+		gsz = 64
+	}
+	groups := (q.Rows + gsz - 1) / gsz
 	cols := hi - lo
 	out := tensai.NewQ4Matrix(q.Rows, cols, q.Group, false)
 	if lo%32 == 0 && cols%32 == 0 {
@@ -64,7 +68,9 @@ func sliceQ4(q *tensai.Q4Matrix, lo, hi int) *tensai.Q4Matrix {
 		}
 	}
 	for g := 0; g < groups; g++ {
-		copy(out.Scale[g*cols:(g+1)*cols], q.Scale[g*q.Cols+lo:g*q.Cols+hi])
+		for j := 0; j < cols; j++ {
+			out.Scale[out.TableIndex(g, j)] = q.Scale[q.TableIndex(g, lo+j)]
+		}
 	}
 	return out
 }

--- a/quant4.go
+++ b/quant4.go
@@ -65,6 +65,14 @@ func (q *Q4Matrix) Index(i, j int) int {
 	return (j/q4Tile)*quads*2*q4Tile + (i/4)*2*q4Tile + (j%q4Tile)*2 + (i%4)/2
 }
 
+// TableIndex returns the position in Scale or ScaleMin of group g,
+// column j. Tables are tile-major like the nibbles — tile, then group,
+// then the 32 columns — so a kernel worker's table walk is sequential.
+func (q *Q4Matrix) TableIndex(g, j int) int {
+	groups := (q.Rows + q.group() - 1) / q.group()
+	return ((j/q4Tile)*groups+g)*q4Tile + j%q4Tile
+}
+
 // NewQ4Matrix allocates the layout for rows x cols with `group` input
 // rows per scale (0 for the default 64); minForm picks the packed
 // asymmetric scale/min table over the symmetric Scale. The caller fills
@@ -83,9 +91,9 @@ func NewQ4Matrix(rows, cols, group int, minForm bool) *Q4Matrix {
 		Group: group,
 	}
 	if minForm {
-		q.ScaleMin = make([]uint32, groups*cols)
+		q.ScaleMin = make([]uint32, tiles*groups*q4Tile)
 	} else {
-		q.Scale = make([]Float, groups*cols)
+		q.Scale = make([]Float, tiles*groups*q4Tile)
 	}
 	return q
 }
@@ -125,7 +133,7 @@ func quantize4Columns(m *Matrix, q *Q4Matrix, groups, colLo, colHi int) {
 				}
 			}
 			s := maxAbs / 7
-			q.Scale[g*m.Cols+j] = s
+			q.Scale[q.TableIndex(g, j)] = s
 			inv := Float(0)
 			if s != 0 {
 				inv = 1 / s
@@ -249,6 +257,7 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 		clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+hi])
 	}
 	quads := len(xus[0]) / 4
+	groups := len(gsums[0])
 	var acc [4][]int32
 	for r := range acc {
 		acc[r] = make([]int32, hi-lo)
@@ -276,22 +285,20 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 			}
 		}
 		if sm != nil {
-			smrow := sm[g*cols:]
 			for r := 0; r < 4; r++ {
 				o := out.Data[(r0+r)*cols:]
 				gs := Float(gsums[r][g])
 				for j := lo; j < hi; j++ {
-					s, m := UnpackScaleMin(smrow[j])
+					s, m := UnpackScaleMin(sm[((j/q4Tile)*groups+g)*q4Tile+j%q4Tile])
 					o[j] += Float(acc[r][j-lo])*s - gs*m
 				}
 			}
 		} else {
-			srow := scale[g*cols:]
 			for r := 0; r < 4; r++ {
 				o := out.Data[(r0+r)*cols:]
 				corr := 8 * gsums[r][g]
 				for j := lo; j < hi; j++ {
-					o[j] += Float(acc[r][j-lo]-corr) * srow[j]
+					o[j] += Float(acc[r][j-lo]-corr) * scale[((j/q4Tile)*groups+g)*q4Tile+j%q4Tile]
 				}
 			}
 		}
@@ -311,6 +318,7 @@ func q4matmulCols4Generic(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int
 func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	clear(out[lo:hi])
 	quads := len(xu) / 4
+	groups := len(gsum)
 	acc := make([]int32, hi-lo)
 	for g := 0; g < len(gsum); g++ {
 		ib := g * group / 4
@@ -330,17 +338,15 @@ func q4matvecColsGeneric(out []Float, xu []uint8, sx Float, gsum []int32, qw []u
 			}
 		}
 		if sm != nil {
-			smrow := sm[g*cols:]
 			gs := Float(gsum[g])
 			for j := lo; j < hi; j++ {
-				s, m := UnpackScaleMin(smrow[j])
+				s, m := UnpackScaleMin(sm[((j/q4Tile)*groups+g)*q4Tile+j%q4Tile])
 				out[j] += Float(acc[j-lo])*s - gs*m
 			}
 		} else {
-			srow := scale[g*cols:]
 			corr := 8 * gsum[g]
 			for j := lo; j < hi; j++ {
-				out[j] += Float(acc[j-lo]-corr) * srow[j]
+				out[j] += Float(acc[j-lo]-corr) * scale[((j/q4Tile)*groups+g)*q4Tile+j%q4Tile]
 			}
 		}
 	}

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -31,21 +31,34 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 		return
 	}
 	quads := len(xq)
+	groups := len(gsum)
 	vecEnd := lo + ((hi - lo) &^ 31)
 	if vecEnd > lo {
+		gsumF := make([]Float, groups)
+		gsum8 := make([]int32, groups)
+		for i, v := range gsum {
+			gsumF[i] = Float(v)
+			gsum8[i] = 8 * v
+		}
 		mLo := archsimd.BroadcastUint16x16(0x000F)
 		mHi := archsimd.BroadcastUint16x16(0x0F00)
 		mMin := archsimd.BroadcastUint32x8(0xFFFF0000)
 		ones := archsimd.BroadcastInt16x16(1)
 		clear(out[lo:vecEnd])
-		if sm != nil {
-			for g := 0; g < len(gsum); g++ {
-				ib := g * group / 4
-				ie := min(ib+group/4, quads)
-				gsf := archsimd.BroadcastFloat32x8(Float(gsum[g]))
-				smrow := sm[g*cols:]
-				for jt := lo; jt < vecEnd; jt += 32 {
-					tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
+		// Tiles outermost: the nibble walk and the tile-major table walk
+		// both advance strictly sequentially per worker.
+		for jt := lo; jt < vecEnd; jt += 32 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
+			d0 := out[jt : jt+8 : jt+8]
+			d1 := out[jt+8 : jt+16 : jt+16]
+			d2 := out[jt+16 : jt+24 : jt+24]
+			d3 := out[jt+24 : jt+32 : jt+32]
+			if sm != nil {
+				tab := sm[(jt/q4Tile)*groups*q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
+					gsf := archsimd.BroadcastFloat32x8(gsumF[g])
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
@@ -59,28 +72,26 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 						v = loadU8x16(row[48:]).ExtendToUint16()
 						a3 = a3.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 					}
-					u := loadU32x8(smrow[jt:])
+					tg := tab[g*q4Tile:]
+					u := loadU32x8(tg)
 					f := a0.ConvertToFloat32().Mul(u.ShiftAllLeft(16).AsFloat32x8()).Sub(gsf.Mul(u.And(mMin).AsFloat32x8()))
-					storeF32x8(loadF32x8(out[jt:]).Add(f), out[jt:])
-					u = loadU32x8(smrow[jt+8:])
+					storeF32x8(loadF32x8(d0).Add(f), d0)
+					u = loadU32x8(tg[8:])
 					f = a1.ConvertToFloat32().Mul(u.ShiftAllLeft(16).AsFloat32x8()).Sub(gsf.Mul(u.And(mMin).AsFloat32x8()))
-					storeF32x8(loadF32x8(out[jt+8:]).Add(f), out[jt+8:])
-					u = loadU32x8(smrow[jt+16:])
+					storeF32x8(loadF32x8(d1).Add(f), d1)
+					u = loadU32x8(tg[16:])
 					f = a2.ConvertToFloat32().Mul(u.ShiftAllLeft(16).AsFloat32x8()).Sub(gsf.Mul(u.And(mMin).AsFloat32x8()))
-					storeF32x8(loadF32x8(out[jt+16:]).Add(f), out[jt+16:])
-					u = loadU32x8(smrow[jt+24:])
+					storeF32x8(loadF32x8(d2).Add(f), d2)
+					u = loadU32x8(tg[24:])
 					f = a3.ConvertToFloat32().Mul(u.ShiftAllLeft(16).AsFloat32x8()).Sub(gsf.Mul(u.And(mMin).AsFloat32x8()))
-					storeF32x8(loadF32x8(out[jt+24:]).Add(f), out[jt+24:])
+					storeF32x8(loadF32x8(d3).Add(f), d3)
 				}
-			}
-		} else {
-			for g := 0; g < len(gsum); g++ {
-				ib := g * group / 4
-				ie := min(ib+group/4, quads)
-				corr := archsimd.BroadcastInt32x8(8 * gsum[g])
-				srow := scale[g*cols:]
-				for jt := lo; jt < vecEnd; jt += 32 {
-					tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
+			} else {
+				tab := scale[(jt/q4Tile)*groups*q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
+					corr := archsimd.BroadcastInt32x8(gsum8[g])
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						xp := archsimd.BroadcastUint32x8(xq[i4]).AsInt8x32()
@@ -94,10 +105,11 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 						v = loadU8x16(row[48:]).ExtendToUint16()
 						a3 = a3.Add(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32().DotProductPairsSaturated(xp).DotProductPairs(ones))
 					}
-					storeF32x8(loadF32x8(out[jt:]).Add(a0.Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[jt:]))), out[jt:])
-					storeF32x8(loadF32x8(out[jt+8:]).Add(a1.Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[jt+8:]))), out[jt+8:])
-					storeF32x8(loadF32x8(out[jt+16:]).Add(a2.Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[jt+16:]))), out[jt+16:])
-					storeF32x8(loadF32x8(out[jt+24:]).Add(a3.Sub(corr).ConvertToFloat32().Mul(loadF32x8(srow[jt+24:]))), out[jt+24:])
+					tg := tab[g*q4Tile:]
+					storeF32x8(loadF32x8(d0).Add(a0.Sub(corr).ConvertToFloat32().Mul(loadF32x8(tg))), d0)
+					storeF32x8(loadF32x8(d1).Add(a1.Sub(corr).ConvertToFloat32().Mul(loadF32x8(tg[8:]))), d1)
+					storeF32x8(loadF32x8(d2).Add(a2.Sub(corr).ConvertToFloat32().Mul(loadF32x8(tg[16:]))), d2)
+					storeF32x8(loadF32x8(d3).Add(a3.Sub(corr).ConvertToFloat32().Mul(loadF32x8(tg[24:]))), d3)
 				}
 			}
 		}
@@ -112,19 +124,31 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 	}
 }
 
-// q4matmulCols4 is the four-row batched form: per eight-column tile each
+// q4matmulCols4 is the four-row batched form: per eight-column step each
 // sixteen-byte nibble load unpacks once and feeds four broadcast
-// activation quads, amortizing the nibble traffic fourfold.
+// activation quads, amortizing the nibble traffic fourfold; steps stay
+// outermost so both streams advance sequentially.
 func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	if !hasAVX2 {
 		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, lo, hi)
 		return
 	}
 	quads := len(xus[0]) / 4
+	groups := len(gsums[0])
 	xq := make([]uint32, 4*quads)
 	for r := 0; r < 4; r++ {
 		for i4 := 0; i4 < quads; i4++ {
 			xq[i4*4+r] = q4xQuad(xus[r], i4)
+		}
+	}
+	// Flat copies keep the folds free of nested-slice loads: one indexed
+	// read per row instead of a header chase and two bounds checks.
+	gsf := make([]Float, 4*groups)
+	gsc := make([]int32, 4*groups)
+	for r := 0; r < 4; r++ {
+		for g, v := range gsums[r] {
+			gsf[4*g+r] = Float(v)
+			gsc[4*g+r] = 8 * v
 		}
 	}
 	vecEnd := lo + ((hi - lo) &^ 7)
@@ -140,17 +164,17 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 		for r := 0; r < 4; r++ {
 			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
 		}
-		if sm != nil {
-			for g := 0; g < len(gsums[0]); g++ {
-				ib := g * group / 4
-				ie := min(ib+group/4, quads)
-				smrow := sm[g*cols:]
-				gsf0 := archsimd.BroadcastFloat32x8(Float(gsums[0][g]))
-				gsf1 := archsimd.BroadcastFloat32x8(Float(gsums[1][g]))
-				gsf2 := archsimd.BroadcastFloat32x8(Float(gsums[2][g]))
-				gsf3 := archsimd.BroadcastFloat32x8(Float(gsums[3][g]))
-				for jt := lo; jt < vecEnd; jt += 8 {
-					tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+		for jt := lo; jt < vecEnd; jt += 8 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+			d0 := o0[jt : jt+8 : jt+8]
+			d1 := o1[jt : jt+8 : jt+8]
+			d2 := o2[jt : jt+8 : jt+8]
+			d3 := o3[jt : jt+8 : jt+8]
+			if sm != nil {
+				tab := sm[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
@@ -161,26 +185,24 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 						a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
 						a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
 					}
-					u := loadU32x8(smrow[jt:])
+					u := loadU32x8(tab[g*q4Tile:])
 					sc := u.ShiftAllLeft(16).AsFloat32x8()
 					mn := u.And(mMin).AsFloat32x8()
-					storeF32x8(loadF32x8(o0[jt:]).Add(a0.ConvertToFloat32().Mul(sc).Sub(gsf0.Mul(mn))), o0[jt:])
-					storeF32x8(loadF32x8(o1[jt:]).Add(a1.ConvertToFloat32().Mul(sc).Sub(gsf1.Mul(mn))), o1[jt:])
-					storeF32x8(loadF32x8(o2[jt:]).Add(a2.ConvertToFloat32().Mul(sc).Sub(gsf2.Mul(mn))), o2[jt:])
-					storeF32x8(loadF32x8(o3[jt:]).Add(a3.ConvertToFloat32().Mul(sc).Sub(gsf3.Mul(mn))), o3[jt:])
+					gr := gsf[4*g : 4*g+4 : 4*g+4]
+					f := a0.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[0]).Mul(mn))
+					storeF32x8(loadF32x8(d0).Add(f), d0)
+					f = a1.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[1]).Mul(mn))
+					storeF32x8(loadF32x8(d1).Add(f), d1)
+					f = a2.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[2]).Mul(mn))
+					storeF32x8(loadF32x8(d2).Add(f), d2)
+					f = a3.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[3]).Mul(mn))
+					storeF32x8(loadF32x8(d3).Add(f), d3)
 				}
-			}
-		} else {
-			for g := 0; g < len(gsums[0]); g++ {
-				ib := g * group / 4
-				ie := min(ib+group/4, quads)
-				srow := scale[g*cols:]
-				corr0 := archsimd.BroadcastInt32x8(8 * gsums[0][g])
-				corr1 := archsimd.BroadcastInt32x8(8 * gsums[1][g])
-				corr2 := archsimd.BroadcastInt32x8(8 * gsums[2][g])
-				corr3 := archsimd.BroadcastInt32x8(8 * gsums[3][g])
-				for jt := lo; jt < vecEnd; jt += 8 {
-					tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+			} else {
+				tab := scale[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
 					var a0, a1, a2, a3 archsimd.Int32x8
 					for i4 := ib; i4 < ie; i4++ {
 						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
@@ -191,11 +213,16 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 						a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
 						a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
 					}
-					sc := loadF32x8(srow[jt:])
-					storeF32x8(loadF32x8(o0[jt:]).Add(a0.Sub(corr0).ConvertToFloat32().Mul(sc)), o0[jt:])
-					storeF32x8(loadF32x8(o1[jt:]).Add(a1.Sub(corr1).ConvertToFloat32().Mul(sc)), o1[jt:])
-					storeF32x8(loadF32x8(o2[jt:]).Add(a2.Sub(corr2).ConvertToFloat32().Mul(sc)), o2[jt:])
-					storeF32x8(loadF32x8(o3[jt:]).Add(a3.Sub(corr3).ConvertToFloat32().Mul(sc)), o3[jt:])
+					sc := loadF32x8(tab[g*q4Tile:])
+					gr := gsc[4*g : 4*g+4 : 4*g+4]
+					f := a0.Sub(archsimd.BroadcastInt32x8(gr[0])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d0).Add(f), d0)
+					f = a1.Sub(archsimd.BroadcastInt32x8(gr[1])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d1).Add(f), d1)
+					f = a2.Sub(archsimd.BroadcastInt32x8(gr[2])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d2).Add(f), d2)
+					f = a3.Sub(archsimd.BroadcastInt32x8(gr[3])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d3).Add(f), d3)
 				}
 			}
 		}

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -43,7 +43,7 @@ func TestQuantize4MatVec(t *testing.T) {
 					acc += nib * xs
 					gs += xs
 				}
-				want[j] += float64(acc-8*gs) * float64(q.Scale[g*c.cols+j])
+				want[j] += float64(acc-8*gs) * float64(q.Scale[q.TableIndex(g, j)])
 			}
 			want[j] *= float64(sx)
 		}
@@ -108,7 +108,7 @@ func TestQuantize4Group32(t *testing.T) {
 					}
 				}
 				s := maxAbs / 7
-				q.Scale[g*c.cols+j] = s
+				q.Scale[q.TableIndex(g, j)] = s
 				for i := rlo; i < rhi; i++ {
 					n := 0
 					if s != 0 {
@@ -153,7 +153,7 @@ func TestQuantize4Group32(t *testing.T) {
 					acc += nib * xs
 					gs += xs
 				}
-				want += float64(acc-8*gs) * float64(q.Scale[g*c.cols+j])
+				want += float64(acc-8*gs) * float64(q.Scale[q.TableIndex(g, j)])
 			}
 			want *= float64(sx)
 			if diff := math.Abs(float64(out[j]) - want); diff > 1e-3*(1+math.Abs(want)) {
@@ -208,8 +208,8 @@ func TestQuantize4MinForm(t *testing.T) {
 				// value = s*q + lo = s*q - min; the pack rounds the pair
 				// to bfloat16, so quantize against what the kernel will
 				// actually unpack.
-				q.ScaleMin[g*c.cols+j] = PackScaleMin((hi-lo)/15, -lo)
-				s, mn := UnpackScaleMin(q.ScaleMin[g*c.cols+j])
+				q.ScaleMin[q.TableIndex(g, j)] = PackScaleMin((hi-lo)/15, -lo)
+				s, mn := UnpackScaleMin(q.ScaleMin[q.TableIndex(g, j)])
 				lo = -mn
 				for i := rlo; i < rhi; i++ {
 					n := 0
@@ -245,7 +245,7 @@ func TestQuantize4MinForm(t *testing.T) {
 					acc += qv * xs
 					gs += xs
 				}
-				sc, mn := UnpackScaleMin(q.ScaleMin[g*c.cols+j])
+				sc, mn := UnpackScaleMin(q.ScaleMin[q.TableIndex(g, j)])
 				want += float64(acc)*float64(sc) - float64(gs)*float64(mn)
 			}
 			want *= float64(sx)

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -1153,7 +1153,7 @@ func TestGPUQ4MatMul(t *testing.T) {
 				var want float64
 				for i := 0; i < c.rows; i++ {
 					nib := float64(q.Q[q.Index(i, j)]>>(4*(i%2))&0x0F) - 8
-					sc := float64(q.Scale[(i/64)*c.cols+j])
+					sc := float64(q.Scale[q.TableIndex(i/64, j)])
 					want += float64(x.Data[r*c.rows+i]) * nib * sc
 				}
 				gotv := float64(out.Data[r*c.cols+j])

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -2194,7 +2194,9 @@ func (g *GPU) UploadQ4(q *Q4Matrix) (*GPUQ4Matrix, error) {
 	groups := (q.Rows + 63) / 64 // q4Group
 	scales := make([]float32, groups*words*4)
 	for gi := 0; gi < groups; gi++ {
-		copy(scales[gi*words*4:], q.Scale[gi*q.Cols:(gi+1)*q.Cols])
+		for j := 0; j < q.Cols; j++ {
+			scales[gi*words*4+j] = q.Scale[q.TableIndex(gi, j)]
+		}
 	}
 
 	g.mu.Lock()


### PR DESCRIPTION
Three changes that together take the min-form batch kernel from 30 to 157 GB/s and decode past 19 tok/s on a 1.5B Q4_K_M -q4:

- Scale tables move to the same tile-major order as the nibbles (Q4Matrix.TableIndex), and the kernels walk tiles outermost with groups inside, so a worker's nibble stream and table stream both advance strictly sequentially. The striding table walk was most of what separated the min-form kernel from the symmetric one.
- The folds' operands flatten out of Go's composite indexing: per-row group sums copy into flat arrays once per call, and destination rows slice once per column step. The nested gsums[r][g] loads and per-statement out[jt:] re-slicing compiled to dozens of scalar stack operations per fold — a 5x penalty on the min-form batch kernel that a vector-spill scan can't see, because every spilled value is a slice header or bounds temp.
- A first attempt kept four float accumulators live across the group loop; that blew the register budget and halved the symmetric matvec, so the folds stay memory-accumulated.

Kernel: batch symmetric 135 to 164 GB/s, batch min-form 120 to 157; matvec symmetric ~31, min-form 21.6 to 27 (real traffic ~34 GB/s counting tables). End to end interleaved on AC: decode 16.0 to 19.1-19.7 tok/s, prefill 820 to 670ms; Q4_0, Q4_K_M under both widths, Q8_0, and Phi-3 all answer correctly. The Q4_0 repack's scale write initially escaped the migration and only the end-to-end run caught it — noted as a test-coverage gap for the example's repackers.