### PR TITLE
quant8g: the Q4 tile treatment for the grouped int8 layout

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -142,15 +142,14 @@ func repackQ8(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap fun
 		}
 		for b := 0; b < nb; b++ {
 			blk := raw[(r*nb+b)*34:]
-			dst.Scale[b*dst.Cols+j] = gguf.Float16(binary.LittleEndian.Uint16(blk))
+			dst.Scale[dst.TableIndex(b, j)] = gguf.Float16(binary.LittleEndian.Uint16(blk))
 			var sum int32
 			for i := 0; i < 32; i++ {
 				w := int8(blk[2+i])
-				gi := b*32 + i
-				dst.Q[(gi/4)*4*dst.Cols+4*j+gi%4] = w
+				dst.Q[dst.Index(b*32+i, j)] = w
 				sum += int32(w)
 			}
-			dst.ColSum64[b*dst.Cols+j] = 64 * sum
+			dst.ColSum64[dst.TableIndex(b, j)] = 64 * sum
 		}
 	}
 }
@@ -279,13 +278,12 @@ func repackQ6K(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap fu
 			for is := 0; is < 16; is++ {
 				var sum int32
 				for k, w := range q[is*16 : is*16+16] {
-					gi := b*256 + is*16 + k
-					dst.Q[(gi/4)*4*dst.Cols+4*j+gi%4] = w
+					dst.Q[dst.Index(b*256+is*16+k, j)] = w
 					sum += int32(w)
 				}
 				g := b*16 + is
-				dst.Scale[g*dst.Cols+j] = d * float32(int8(sc[is]))
-				dst.ColSum64[g*dst.Cols+j] = 64 * sum
+				dst.Scale[dst.TableIndex(g, j)] = d * float32(int8(sc[is]))
+				dst.ColSum64[dst.TableIndex(g, j)] = 64 * sum
 			}
 		}
 	}
@@ -413,7 +411,7 @@ func repackQ4K8(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap f
 				}
 				g := b*8 + is
 				s8 := amax / 127
-				dst.Scale[g*dst.Cols+j] = s8
+				dst.Scale[dst.TableIndex(g, j)] = s8
 				if s8 == 0 {
 					continue
 				}
@@ -428,10 +426,9 @@ func repackQ4K8(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap f
 					}
 					n := int8(f)
 					sum += int32(n)
-					gi := b*256 + is*32 + k
-					dst.Q[(gi/4)*4*dst.Cols+4*j+gi%4] = n
+					dst.Q[dst.Index(b*256+is*32+k, j)] = n
 				}
-				dst.ColSum64[g*dst.Cols+j] = 64 * sum
+				dst.ColSum64[dst.TableIndex(g, j)] = 64 * sum
 			}
 		}
 	}
@@ -493,7 +490,7 @@ func repackQ5K8(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap f
 				}
 				g := b*8 + is
 				s8 := amax / 127
-				dst.Scale[g*dst.Cols+j] = s8
+				dst.Scale[dst.TableIndex(g, j)] = s8
 				if s8 == 0 {
 					continue
 				}
@@ -508,10 +505,9 @@ func repackQ5K8(dst *tensai.Q8GMatrix, raw []byte, out, in, colOff int, colMap f
 					}
 					n := int8(f)
 					sum += int32(n)
-					gi := b*256 + is*32 + k
-					dst.Q[(gi/4)*4*dst.Cols+4*j+gi%4] = n
+					dst.Q[dst.Index(b*256+is*32+k, j)] = n
 				}
-				dst.ColSum64[g*dst.Cols+j] = 64 * sum
+				dst.ColSum64[dst.TableIndex(g, j)] = 64 * sum
 			}
 		}
 	}

--- a/quant8g.go
+++ b/quant8g.go
@@ -35,9 +35,9 @@ func NewQ8GMatrix(rows, cols, group int) *Q8GMatrix {
 	return &Q8GMatrix{
 		Rows:     rows,
 		Cols:     cols,
-		Q:        make([]int8, quads*4*cols+32),
-		Scale:    make([]Float, groups*cols),
-		ColSum64: make([]int32, groups*cols),
+		Q:        make([]int8, ((cols+q4Tile-1)/q4Tile)*quads*4*q4Tile+32),
+		Scale:    make([]Float, ((cols+q4Tile-1)/q4Tile)*groups*q4Tile),
+		ColSum64: make([]int32, ((cols+q4Tile-1)/q4Tile)*groups*q4Tile),
 		Group:    group,
 	}
 }
@@ -48,6 +48,21 @@ func (q *Q8GMatrix) group() int {
 		return q.Group
 	}
 	return q8Group
+}
+
+// Index returns the position in Q of row i, column j: 32-column tiles
+// store their row quads back to back (128 bytes apiece), so a kernel
+// worker streams sequential memory.
+func (q *Q8GMatrix) Index(i, j int) int {
+	quads := (q.Rows + 3) / 4
+	return (j/q4Tile)*quads*4*q4Tile + (i/4)*4*q4Tile + (j%q4Tile)*4 + i%4
+}
+
+// TableIndex returns the position in Scale and ColSum64 of group g,
+// column j; tables are tile-major like the weights.
+func (q *Q8GMatrix) TableIndex(g, j int) int {
+	groups := (q.Rows + q.group() - 1) / q.group()
+	return ((j/q4Tile)*groups+g)*q4Tile + j%q4Tile
 }
 
 // MatVec computes out = x @ Q for a single activation row: len(x) must be
@@ -64,7 +79,7 @@ func (q *Q8GMatrix) MatVec(x, out []Float) error {
 		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
-	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
 		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
 	})
 	return nil
@@ -98,7 +113,7 @@ func (q *Q8GMatrix) MatMul(x, out *Matrix) error {
 		run(0, q.Cols)
 		return nil
 	}
-	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
 		run(lo, hi)
 	})
 	return nil
@@ -118,16 +133,16 @@ func q8gMatvecColsGeneric(out []Float, xu []uint8, sx Float, qw []int8, scale []
 		for i4 := ib; i4 < ie; i4++ {
 			x0, x1 := int32(xu[4*i4]), int32(xu[4*i4+1])
 			x2, x3 := int32(xu[4*i4+2]), int32(xu[4*i4+3])
-			row := qw[i4*4*cols:]
+			row := qw[i4*4*q4Tile:]
 			for j := lo; j < hi; j++ {
-				acc[j-lo] += x0*int32(row[4*j]) + x1*int32(row[4*j+1]) +
-					x2*int32(row[4*j+2]) + x3*int32(row[4*j+3])
+				o := (j/q4Tile)*quads*4*q4Tile + (j%q4Tile)*4
+				acc[j-lo] += x0*int32(row[o]) + x1*int32(row[o+1]) +
+					x2*int32(row[o+2]) + x3*int32(row[o+3])
 			}
 		}
-		srow := scale[g*cols:]
-		csrow := colSum64[g*cols:]
 		for j := lo; j < hi; j++ {
-			out[j] += Float(acc[j-lo]-csrow[j]) * srow[j]
+			t := ((j/q4Tile)*groups + g) * q4Tile
+			out[j] += Float(acc[j-lo]-colSum64[t+j%q4Tile]) * scale[t+j%q4Tile]
 		}
 	}
 	for j := lo; j < hi; j++ {
@@ -153,23 +168,23 @@ func q8gMatmulRows8Generic(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw [
 			clear(acc[r])
 		}
 		for i4 := ib; i4 < ie; i4++ {
-			row := qw[i4*4*cols:]
+			row := qw[i4*4*q4Tile:]
 			for r := 0; r < 8; r++ {
 				x0, x1 := int32(xus[r][4*i4]), int32(xus[r][4*i4+1])
 				x2, x3 := int32(xus[r][4*i4+2]), int32(xus[r][4*i4+3])
 				a := acc[r]
 				for j := lo; j < hi; j++ {
-					a[j-lo] += x0*int32(row[4*j]) + x1*int32(row[4*j+1]) +
-						x2*int32(row[4*j+2]) + x3*int32(row[4*j+3])
+					o := (j/q4Tile)*quads*4*q4Tile + (j%q4Tile)*4
+					a[j-lo] += x0*int32(row[o]) + x1*int32(row[o+1]) +
+						x2*int32(row[o+2]) + x3*int32(row[o+3])
 				}
 			}
 		}
-		srow := scale[g*cols:]
-		csrow := colSum64[g*cols:]
 		for r := 0; r < 8; r++ {
 			o := out.Data[(r0+r)*cols:]
 			for j := lo; j < hi; j++ {
-				o[j] += Float(acc[r][j-lo]-csrow[j]) * srow[j]
+				t := ((j/q4Tile)*groups + g) * q4Tile
+				o[j] += Float(acc[r][j-lo]-colSum64[t+j%q4Tile]) * scale[t+j%q4Tile]
 			}
 		}
 	}

--- a/quant8g_simd.go
+++ b/quant8g_simd.go
@@ -22,26 +22,38 @@ func q8gMatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, 
 	vecEnd := lo + ((hi - lo) &^ 31)
 	if vecEnd > lo {
 		clear(out[lo:vecEnd])
-		for g := 0; g < groups; g++ {
-			ib := g * group / 4
-			ie := min(ib+group/4, quads)
-			srow := scale[g*cols:]
-			csrow := colSum64[g*cols:]
-			for jt := lo; jt < vecEnd; jt += 32 {
+		// Tiles outermost: weight and table streams both advance
+		// strictly sequentially per worker.
+		for jt := lo; jt < vecEnd; jt += 32 {
+			tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
+			stab := scale[(jt/q4Tile)*groups*q4Tile:]
+			ctab := colSum64[(jt/q4Tile)*groups*q4Tile:]
+			d0 := out[jt : jt+8 : jt+8]
+			d1 := out[jt+8 : jt+16 : jt+16]
+			d2 := out[jt+16 : jt+24 : jt+24]
+			d3 := out[jt+24 : jt+32 : jt+32]
+			for g := 0; g < groups; g++ {
+				ib := g * group / 4
+				ie := min(ib+group/4, quads)
 				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
 					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsUint8x32()
-					row := qw[i4*4*cols+4*jt:]
+					row := tile[i4*4*q4Tile:]
 					a0 = a0.Add(xp.DotProductPairsSaturated(loadI8x32(row)).DotProductPairs(ones))
 					a1 = a1.Add(xp.DotProductPairsSaturated(loadI8x32(row[32:])).DotProductPairs(ones))
 					a2 = a2.Add(xp.DotProductPairsSaturated(loadI8x32(row[64:])).DotProductPairs(ones))
 					a3 = a3.Add(xp.DotProductPairsSaturated(loadI8x32(row[96:])).DotProductPairs(ones))
 				}
-				for k, a := range [4]archsimd.Int32x8{a0, a1, a2, a3} {
-					j := jt + 8*k
-					f := a.Sub(loadI32x8(csrow[j:])).ConvertToFloat32().Mul(loadF32x8(srow[j:]))
-					storeF32x8(loadF32x8(out[j:]).Add(f), out[j:])
-				}
+				sg := stab[g*q4Tile:]
+				cg := ctab[g*q4Tile:]
+				f := a0.Sub(loadI32x8(cg)).ConvertToFloat32().Mul(loadF32x8(sg))
+				storeF32x8(loadF32x8(d0).Add(f), d0)
+				f = a1.Sub(loadI32x8(cg[8:])).ConvertToFloat32().Mul(loadF32x8(sg[8:]))
+				storeF32x8(loadF32x8(d1).Add(f), d1)
+				f = a2.Sub(loadI32x8(cg[16:])).ConvertToFloat32().Mul(loadF32x8(sg[16:]))
+				storeF32x8(loadF32x8(d2).Add(f), d2)
+				f = a3.Sub(loadI32x8(cg[24:])).ConvertToFloat32().Mul(loadF32x8(sg[24:]))
+				storeF32x8(loadF32x8(d3).Add(f), d3)
 			}
 		}
 		sxv := archsimd.BroadcastFloat32x8(sx)
@@ -55,8 +67,9 @@ func q8gMatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, 
 	}
 }
 
-// q8gMatmulRows8 is the eight-row batched form: per eight-column tile each
-// 32-byte weight load feeds eight broadcast activation quads.
+// q8gMatmulRows8 is the eight-row batched form: per eight-column step
+// each 32-byte weight load feeds eight broadcast activation quads, with
+// steps outermost so both streams advance sequentially.
 func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, group, cols, lo, hi int) {
 	if !hasAVX2 {
 		q8gMatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, group, cols, lo, hi)
@@ -76,15 +89,32 @@ func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, 
 		for r := 0; r < 8; r++ {
 			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
 		}
-		for g := 0; g < groups; g++ {
-			ib := g * group / 4
-			ie := min(ib+group/4, quads)
-			srow := scale[g*cols:]
-			csrow := colSum64[g*cols:]
-			for jt := lo; jt < vecEnd; jt += 8 {
+		o0 := out.Data[r0*cols:]
+		o1 := out.Data[(r0+1)*cols:]
+		o2 := out.Data[(r0+2)*cols:]
+		o3 := out.Data[(r0+3)*cols:]
+		o4 := out.Data[(r0+4)*cols:]
+		o5 := out.Data[(r0+5)*cols:]
+		o6 := out.Data[(r0+6)*cols:]
+		o7 := out.Data[(r0+7)*cols:]
+		for jt := lo; jt < vecEnd; jt += 8 {
+			tile := qw[(jt/q4Tile)*quads*4*q4Tile+(jt%q4Tile)*4:]
+			stab := scale[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+			ctab := colSum64[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+			d0 := o0[jt : jt+8 : jt+8]
+			d1 := o1[jt : jt+8 : jt+8]
+			d2 := o2[jt : jt+8 : jt+8]
+			d3 := o3[jt : jt+8 : jt+8]
+			d4 := o4[jt : jt+8 : jt+8]
+			d5 := o5[jt : jt+8 : jt+8]
+			d6 := o6[jt : jt+8 : jt+8]
+			d7 := o7[jt : jt+8 : jt+8]
+			for g := 0; g < groups; g++ {
+				ib := g * group / 4
+				ie := min(ib+group/4, quads)
 				var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
-					w := loadI8x32(qw[i4*4*cols+4*jt:])
+					w := loadI8x32(tile[i4*4*q4Tile:])
 					xf := xq[i4*8 : i4*8+8]
 					a0 = a0.Add(archsimd.BroadcastUint32x8(xf[0]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 					a1 = a1.Add(archsimd.BroadcastUint32x8(xf[1]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
@@ -95,13 +125,16 @@ func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, 
 					a6 = a6.Add(archsimd.BroadcastUint32x8(xf[6]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 					a7 = a7.Add(archsimd.BroadcastUint32x8(xf[7]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 				}
-				cs := loadI32x8(csrow[jt:])
-				sc := loadF32x8(srow[jt:])
-				for r, a := range [8]archsimd.Int32x8{a0, a1, a2, a3, a4, a5, a6, a7} {
-					o := out.Data[(r0+r)*cols:]
-					f := a.Sub(cs).ConvertToFloat32().Mul(sc)
-					storeF32x8(loadF32x8(o[jt:]).Add(f), o[jt:])
-				}
+				cs := loadI32x8(ctab[g*q4Tile:])
+				sc := loadF32x8(stab[g*q4Tile:])
+				storeF32x8(loadF32x8(d0).Add(a0.Sub(cs).ConvertToFloat32().Mul(sc)), d0)
+				storeF32x8(loadF32x8(d1).Add(a1.Sub(cs).ConvertToFloat32().Mul(sc)), d1)
+				storeF32x8(loadF32x8(d2).Add(a2.Sub(cs).ConvertToFloat32().Mul(sc)), d2)
+				storeF32x8(loadF32x8(d3).Add(a3.Sub(cs).ConvertToFloat32().Mul(sc)), d3)
+				storeF32x8(loadF32x8(d4).Add(a4.Sub(cs).ConvertToFloat32().Mul(sc)), d4)
+				storeF32x8(loadF32x8(d5).Add(a5.Sub(cs).ConvertToFloat32().Mul(sc)), d5)
+				storeF32x8(loadF32x8(d6).Add(a6.Sub(cs).ConvertToFloat32().Mul(sc)), d6)
+				storeF32x8(loadF32x8(d7).Add(a7.Sub(cs).ConvertToFloat32().Mul(sc)), d7)
 			}
 		}
 		for r := 0; r < 8; r++ {

--- a/quant8g_test.go
+++ b/quant8g_test.go
@@ -29,7 +29,7 @@ func buildQ8G(m *Matrix, group int) *Q8GMatrix {
 				}
 			}
 			s := maxAbs / 127
-			q.Scale[g*m.Cols+j] = s
+			q.Scale[q.TableIndex(g, j)] = s
 			var sum int32
 			for i := rlo; i < rhi; i++ {
 				n := 0
@@ -42,10 +42,10 @@ func buildQ8G(m *Matrix, group int) *Q8GMatrix {
 					}
 					n = int(v)
 				}
-				q.Q[(i/4)*4*m.Cols+4*j+i%4] = int8(n)
+				q.Q[q.Index(i, j)] = int8(n)
 				sum += int32(n)
 			}
-			q.ColSum64[g*m.Cols+j] = 64 * sum
+			q.ColSum64[q.TableIndex(g, j)] = 64 * sum
 		}
 	}
 	return q
@@ -85,10 +85,10 @@ func TestQ8GMatVecAndMatMul(t *testing.T) {
 				rlo, rhi := g*group, min((g+1)*group, c.rows)
 				var acc int64
 				for i := rlo; i < rhi; i++ {
-					w := int64(q.Q[(i/4)*4*c.cols+4*j+i%4])
+					w := int64(q.Q[q.Index(i, j)])
 					acc += w * (int64(xu[i]) - 64)
 				}
-				want += float64(acc) * float64(q.Scale[g*c.cols+j])
+				want += float64(acc) * float64(q.Scale[q.TableIndex(g, j)])
 			}
 			want *= float64(sx)
 			if diff := math.Abs(float64(out[j]) - want); diff > 1e-3*(1+math.Abs(want)) {


### PR DESCRIPTION
Same three changes #75 applied to Q4Matrix, ported to Q8GMatrix: int8 quads tile 32 columns wide (Index), Scale and ColSum64 go tile-major beside them (TableIndex), and the kernels walk tiles outermost with unrolled folds over hoisted destination slices.

The grouped-int8 path had it worse than Q4 — two striding tables per fold instead of one — and gains more: a 0.5B Q8_0 decodes at 31.7-33.2 tok/s against 22.3-22.4 before (+45%), and a Q4_K_M 1.5B under -q8 goes 10.1-10.7 to 12.0-12.2 tok/s, interleaved on AC. The GGUF repackers (Q8_0, Q6_K, the K-quant int8 requants) and the test builder write through the new indexers; Q8_0, Q4_K_M under both widths, and Q4_0 all answer correctly end to end.