### PR TITLE
quant: tile the ungrouped int8 layout too

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -84,14 +84,21 @@ func sliceQ(q *tensai.QMatrix, lo, hi int) *tensai.QMatrix {
 	out := &tensai.QMatrix{
 		Rows:     q.Rows,
 		Cols:     cols,
-		Q:        make([]int8, quads*4*cols+32),
+		Q:        make([]int8, ((cols+31)/32)*quads*4*32+32),
 		Scale:    make([]float32, cols),
 		ColSum64: make([]int32, cols+8),
 	}
 	copy(out.Scale, q.Scale[lo:hi])
 	copy(out.ColSum64, q.ColSum64[lo:hi])
-	for i4 := 0; i4 < quads; i4++ {
-		copy(out.Q[i4*4*cols:i4*4*cols+4*cols], q.Q[i4*4*q.Cols+4*lo:i4*4*q.Cols+4*hi])
+	if lo%32 == 0 && cols%32 == 0 {
+		block := quads * 4 * 32
+		copy(out.Q[:(cols/32)*block], q.Q[(lo/32)*block:(hi/32)*block])
+	} else {
+		for j := 0; j < cols; j++ {
+			for i := 0; i < 4*quads; i++ {
+				out.Q[out.Index(i, j)] = q.Q[q.Index(i, lo+j)]
+			}
+		}
 	}
 	return out
 }

--- a/quant.go
+++ b/quant.go
@@ -59,6 +59,14 @@ type QMatrix struct {
 	ColSum64   []int32
 }
 
+// Index returns the position in Q of row i, column j: 32-column tiles
+// store their row quads back to back (128 bytes apiece), so a kernel
+// worker streams sequential memory.
+func (q *QMatrix) Index(i, j int) int {
+	quads := (q.Rows + 3) / 4
+	return (j/q4Tile)*quads*4*q4Tile + (i/4)*4*q4Tile + (j%q4Tile)*4 + i%4
+}
+
 // QuantizeMatrix quantizes column-wise, symmetric around zero with
 // round-to-nearest. Columns are independent, so large matrices split
 // across CPUs — quantize-at-load of a whole checkpoint is bound by this.
@@ -67,7 +75,7 @@ func QuantizeMatrix(m *Matrix) *QMatrix {
 	q := &QMatrix{
 		Rows:     m.Rows,
 		Cols:     m.Cols,
-		Q:        make([]int8, quads*4*m.Cols+32),
+		Q:        make([]int8, ((m.Cols+q4Tile-1)/q4Tile)*quads*4*q4Tile+32),
 		Scale:    make([]Float, m.Cols),
 		ColSum64: make([]int32, m.Cols+8), // padded for 8-wide loads
 	}
@@ -128,7 +136,7 @@ func quantizeColumns(m *Matrix, q *QMatrix, colLo, colHi int) {
 				v -= 0.5
 			}
 			w := int8(v)
-			q.Q[(i/4)*4*m.Cols+4*j+i%4] = w
+			q.Q[q.Index(i, j)] = w
 			sum += int32(w)
 		}
 		q.ColSum64[j] = 64 * sum
@@ -203,7 +211,7 @@ func (q *QMatrix) MatVec(x, out []Float) error {
 		return nil
 	}
 	// Chunks stay multiples of 8 so only the last one has a scalar tail.
-	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
 		qmatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 	})
 	return nil
@@ -239,7 +247,7 @@ func (q *QMatrix) MatMul(x, out *Matrix) error {
 		run(0, q.Cols)
 		return nil
 	}
-	parallelChunks(q.Cols, workers, 8, func(lo, hi int) {
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
 		run(lo, hi)
 	})
 	return nil
@@ -254,14 +262,15 @@ func qmatmulRows8Generic(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []i
 	}
 	quads := len(xus[0]) / 4
 	for i4 := 0; i4 < quads; i4++ {
-		row := qw[i4*4*cols:]
+		row := qw[i4*4*q4Tile:]
 		for r := 0; r < 8; r++ {
 			x0, x1 := int32(xus[r][4*i4]), int32(xus[r][4*i4+1])
 			x2, x3 := int32(xus[r][4*i4+2]), int32(xus[r][4*i4+3])
 			a := acc[r]
 			for j := lo; j < hi; j++ {
-				a[j-lo] += x0*int32(row[4*j]) + x1*int32(row[4*j+1]) +
-					x2*int32(row[4*j+2]) + x3*int32(row[4*j+3])
+				o := (j/q4Tile)*quads*4*q4Tile + (j%q4Tile)*4
+				a[j-lo] += x0*int32(row[o]) + x1*int32(row[o+1]) +
+					x2*int32(row[o+2]) + x3*int32(row[o+3])
 			}
 		}
 	}
@@ -279,13 +288,15 @@ func qmatmulRows8Generic(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []i
 // quant_generic.go) dispatches to the AVX2 kernel when available.
 func qmatvecColsGeneric(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, colSum64 []int32, cols, lo, hi int) {
 	acc := make([]int32, hi-lo)
-	for i4 := 0; i4 < len(xu)/4; i4++ {
+	quads := len(xu) / 4
+	for i4 := 0; i4 < quads; i4++ {
 		x0, x1 := int32(xu[4*i4]), int32(xu[4*i4+1])
 		x2, x3 := int32(xu[4*i4+2]), int32(xu[4*i4+3])
-		row := qw[i4*4*cols:]
+		row := qw[i4*4*q4Tile:]
 		for j := lo; j < hi; j++ {
-			acc[j-lo] += x0*int32(row[4*j]) + x1*int32(row[4*j+1]) +
-				x2*int32(row[4*j+2]) + x3*int32(row[4*j+3])
+			o := (j/q4Tile)*quads*4*q4Tile + (j%q4Tile)*4
+			acc[j-lo] += x0*int32(row[o]) + x1*int32(row[o+1]) +
+				x2*int32(row[o+2]) + x3*int32(row[o+3])
 		}
 	}
 	for j := lo; j < hi; j++ {

--- a/quant_simd.go
+++ b/quant_simd.go
@@ -32,10 +32,11 @@ func qmatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, co
 	ones := archsimd.BroadcastInt16x16(1)
 	vecEnd := lo + ((hi - lo) &^ 31)
 	for jt := lo; jt < vecEnd; jt += 32 {
+		tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
 		var a0, a1, a2, a3 archsimd.Int32x8
 		for i4 := 0; i4 < quads; i4++ {
 			xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsUint8x32()
-			row := qw[i4*4*cols+4*jt:]
+			row := tile[i4*4*q4Tile:]
 			a0 = a0.Add(xp.DotProductPairsSaturated(loadI8x32(row)).DotProductPairs(ones))
 			a1 = a1.Add(xp.DotProductPairsSaturated(loadI8x32(row[32:])).DotProductPairs(ones))
 			a2 = a2.Add(xp.DotProductPairsSaturated(loadI8x32(row[64:])).DotProductPairs(ones))
@@ -77,9 +78,10 @@ func qmatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, sc
 	ones := archsimd.BroadcastInt16x16(1)
 	vecEnd := lo + ((hi - lo) &^ 7)
 	for jt := lo; jt < vecEnd; jt += 8 {
+		tile := qw[(jt/q4Tile)*quads*4*q4Tile+(jt%q4Tile)*4:]
 		var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
 		for i4 := 0; i4 < quads; i4++ {
-			w := loadI8x32(qw[i4*4*cols+4*jt:])
+			w := loadI8x32(tile[i4*4*q4Tile:])
 			xf := xq[i4*8 : i4*8+8]
 			a0 = a0.Add(archsimd.BroadcastUint32x8(xf[0]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
 			a1 = a1.Add(archsimd.BroadcastUint32x8(xf[1]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))

--- a/quant_test.go
+++ b/quant_test.go
@@ -31,7 +31,7 @@ func TestQuantizeMatVec(t *testing.T) {
 		want := make([]float64, c.cols)
 		for i := 0; i < c.rows; i++ {
 			for j := 0; j < c.cols; j++ {
-				w := q.Q[(i/4)*4*c.cols+4*j+i%4]
+				w := q.Q[q.Index(i, j)]
 				want[j] += float64(int(xu[i])-64) * float64(w)
 			}
 		}

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -716,7 +716,7 @@ func TestGPUQ8MatMul(t *testing.T) {
 			for j := 0; j < c.cols; j++ {
 				var want float64
 				for i := 0; i < c.rows; i++ {
-					wq := float64(q.Q[(i/4)*4*c.cols+4*j+i%4]) * float64(q.Scale[j])
+					wq := float64(q.Q[q.Index(i, j)]) * float64(q.Scale[j])
 					want += float64(x.Data[r*c.rows+i]) * wq
 				}
 				gotv := float64(out.Data[r*c.cols+j])

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -1710,9 +1710,8 @@ func (g *GPU) UploadQ8(q *QMatrix) (*GPUQMatrix, error) {
 	words := (q.Cols + 3) / 4
 	packed := make([]uint32, q.Rows*words)
 	for i := 0; i < q.Rows; i++ {
-		base := (i / 4) * 4 * q.Cols
 		for j := 0; j < q.Cols; j++ {
-			b := uint32(uint8(q.Q[base+4*j+i%4]))
+			b := uint32(uint8(q.Q[q.Index(i, j)]))
 			packed[i*words+j/4] |= b << (8 * (j % 4))
 		}
 	}


### PR DESCRIPTION
The last of the three quantized layouts gets the 32-column tiling (QMatrix.Index): int8 quads pack per tile, kernels hoist the tile base out of the inner loop, the GPU upload and column slicer read through the indexer, and matvec chunks align to tiles. The per-column scale and column-sum tables were already contiguous at the fold, so this is purely the weight stream — and the ungrouped path gains the most of the three: a 0.5B Q8_0 through the requantized route decodes at 39.2-39.9 tok/s against 24.0-24.9 before, interleaved on AC. The safetensors -q8 loaders and the gpt2 example ride the same kernels; Q8_0 direct, requant, and Q4_K_M outputs unchanged, wgpu suite (which covers UploadQ8 against the float reference) green.