### PR TITLE
tensai: MXFP4 matrices and kernels

### DIFF
--- a/encoding/gguf/gguf.go
+++ b/encoding/gguf/gguf.go
@@ -6,7 +6,7 @@
 // Reading is lazy: Open parses only the header, and each Tensor call reads
 // just that tensor's bytes. F32 comes back as-is; F16 and BF16 convert to
 // float32; the block-quantized types Q8_0, Q4_0, Q4_1, Q5_0, Q5_1 and the
-// K-quants Q2_K through Q6_K plus IQ4_NL dequantize to float32 on the way
+// K-quants Q2_K through Q6_K plus IQ4_NL and MXFP4 dequantize to float32 on the way
 // out, which covers the encodings llama.cpp's published checkpoints
 // usually ship (the Q2_K..Q5_K_M mixes, their Q6_K tensors, and the
 // IQ4_NL blocks imatrix mixes lean on). Dimensions arrive in tensai's row-major order (GGUF stores
@@ -52,6 +52,7 @@ const (
 	typeQ6_K  = 14
 	typeIQ4NL = 20
 	typeBF16  = 30
+	typeMXFP4 = 39
 )
 
 var typeNames = map[uint32]string{
@@ -60,6 +61,7 @@ var typeNames = map[uint32]string{
 	typeQ4_K: "Q4_K", typeQ5_K: "Q5_K", typeQ6_K: "Q6_K",
 	typeQ5_0: "Q5_0", typeQ5_1: "Q5_1",
 	typeQ2_K: "Q2_K", typeQ3_K: "Q3_K", typeIQ4NL: "IQ4_NL",
+	typeMXFP4: "MXFP4",
 }
 
 // blockSpec describes one quantization block: how many values it decodes
@@ -74,6 +76,7 @@ var blockSpec = map[uint32]struct{ values, bytes int64 }{
 	typeQ5_0:  {32, 2 + 4 + 16},     // f16 scale + high-bit plane + nibbles
 	typeQ5_1:  {32, 2 + 2 + 4 + 16}, // + f16 min
 	typeIQ4NL: {32, 2 + 16},         // f16 scale + nibbles through a nonlinear table
+	typeMXFP4: {32, 1 + 16},         // e8m0 exponent + fp4 codes through a nonlinear table
 	// K-quants: 256-value super-blocks with quantized sub-scales.
 	typeQ2_K: {256, 16 + 64 + 2 + 2},       // 4-bit scale/min pairs, 2-bit quants
 	typeQ3_K: {256, 32 + 64 + 12 + 2},      // high-bit plane, 2-bit quants, 6-bit scales
@@ -454,6 +457,18 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 				dst[b*32+int64(i)+16] = s * iq4nl[q>>4]
 			}
 		}
+	case typeMXFP4:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*17:]
+			// E8M0 exponent; the table carries twice the FP4 values, so
+			// the factor halves.
+			s := float32(math.Ldexp(1, int(blk[0])-128))
+			for i := 0; i < 16; i++ {
+				q := blk[1+i]
+				dst[b*32+int64(i)] = s * mxfp4[q&0x0F]
+				dst[b*32+int64(i)+16] = s * mxfp4[q>>4]
+			}
+		}
 	case typeQ2_K:
 		for b := int64(0); b < n/256; b++ {
 			dequantQ2K(raw[b*84:b*84+84], dst[b*256:b*256+256])
@@ -481,6 +496,10 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 // iq4nl is IQ4_NL's nonlinear codebook: sixteen levels spaced to match
 // the empirical weight distribution instead of uniformly.
 var iq4nl = [16]float32{-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113}
+
+// mxfp4 is the FP4 (E2M1) value table doubled onto an integer grid; the
+// per-block scale is halved to compensate.
+var mxfp4 = [16]float32{0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12}
 
 // scaleMinK4 unpacks the j-th 6-bit scale and min from a K-quant
 // super-block's 12 packed bytes (8 pairs: the first four pairs use the low

--- a/mxfp4.go
+++ b/mxfp4.go
@@ -1,0 +1,196 @@
+package tensai
+
+import (
+	"fmt"
+	"math"
+)
+
+// MXFP4Matrix is a weight matrix in microscaling FP4: 32-row groups per
+// column share one power-of-two E8M0 factor, and each weight is a 4-bit
+// FP4 code (E2M1: 0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6 before scaling) —
+// the format gpt-oss ships its expert weights in. Codes store in
+// Q4Matrix's tiled quad-nibble layout; the kernels expand each code to
+// twice its FP4 value on the integer grid {0, ±1..±4, ±6, ±8, ±12} with
+// a 16-entry table lookup and run the grouped-int8 multiply-add chain,
+// Scale carrying half the E8M0 factor so the products stay exact.
+type MXFP4Matrix struct {
+	Rows, Cols int
+	Q          []uint8 // FP4 codes, tiled quad nibbles (Index)
+	Scale      []Float // per (32-row group, column), tile-major (TableIndex)
+	ColSum64   []int32 // 64 * sum of a group's expanded codes, tile-major
+}
+
+// mxfp4LUT maps an FP4 code to twice its value; the high code bit is
+// the sign, and both zero encodings map to zero.
+var mxfp4LUT = [16]int8{0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12}
+
+// MXFP4Scale converts an E8M0 exponent byte to the matrix's Scale entry:
+// half of 2^(e-127), matching the doubled integer grid.
+func MXFP4Scale(e uint8) Float {
+	return Float(math.Ldexp(1, int(e)-128))
+}
+
+// MXFP4Value returns an FP4 code's expanded integer value (twice the FP4
+// value); callers building ColSum64 sum these.
+func MXFP4Value(code uint8) int8 {
+	return mxfp4LUT[code&0x0F]
+}
+
+// NewMXFP4Matrix allocates the layout for rows x cols; the caller fills
+// Q via Index and the tile-major tables via TableIndex.
+func NewMXFP4Matrix(rows, cols int) *MXFP4Matrix {
+	quads := (rows + 3) / 4
+	groups := (rows + 31) / 32
+	tiles := (cols + q4Tile - 1) / q4Tile
+	return &MXFP4Matrix{
+		Rows:     rows,
+		Cols:     cols,
+		Q:        make([]uint8, tiles*quads*2*q4Tile+32),
+		Scale:    make([]Float, tiles*groups*q4Tile),
+		ColSum64: make([]int32, tiles*groups*q4Tile),
+	}
+}
+
+// Index returns the position in Q of the byte carrying column j of rows
+// i and i+1 (low and high nibble; shift by 4*(i%2)).
+func (q *MXFP4Matrix) Index(i, j int) int {
+	quads := (q.Rows + 3) / 4
+	return (j/q4Tile)*quads*2*q4Tile + (i/4)*2*q4Tile + (j%q4Tile)*2 + (i%4)/2
+}
+
+// TableIndex returns the position in Scale and ColSum64 of group g,
+// column j.
+func (q *MXFP4Matrix) TableIndex(g, j int) int {
+	groups := (q.Rows + 31) / 32
+	return ((j/q4Tile)*groups+g)*q4Tile + j%q4Tile
+}
+
+// MatVec computes out = x @ Q for a single activation row: len(x) must
+// be Rows and len(out) Cols.
+func (q *MXFP4Matrix) MatVec(x, out []Float) error {
+	if len(x) != q.Rows || len(out) != q.Cols {
+		return fmt.Errorf("tensai: mxfp4 matvec shape mismatch: x=%d out=%d, want %dx%d",
+			len(x), len(out), q.Rows, q.Cols)
+	}
+	xu, sx := quantizeActs(x)
+	workers := matvecWorkerCount(q.Cols, q.Rows)
+	if workers == 1 {
+		mxfp4MatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, 0, q.Cols)
+		return nil
+	}
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+		mxfp4MatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+	})
+	return nil
+}
+
+// MatMul computes out = x @ Q for a batch of activation rows.
+func (q *MXFP4Matrix) MatMul(x, out *Matrix) error {
+	if x.Cols != q.Rows || out.Rows != x.Rows || out.Cols != q.Cols {
+		return fmt.Errorf("tensai: mxfp4 matmul shape mismatch: x %dx%d out %dx%d, want %dx%d",
+			x.Rows, x.Cols, out.Rows, out.Cols, q.Rows, q.Cols)
+	}
+	rows := x.Rows
+	xus := make([][]uint8, rows)
+	sxs := make([]Float, rows)
+	for r := 0; r < rows; r++ {
+		xus[r], sxs[r] = quantizeActs(x.Data[r*x.Cols : (r+1)*x.Cols])
+	}
+	run := func(lo, hi int) {
+		var r int
+		for ; r+8 <= rows; r += 8 {
+			mxfp4MatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+		}
+		for ; r < rows; r++ {
+			mxfp4MatvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+		}
+	}
+	workers := matvecWorkerCount(q.Cols, q.Rows)
+	if workers == 1 {
+		run(0, q.Cols)
+		return nil
+	}
+	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+		run(lo, hi)
+	})
+	return nil
+}
+
+// mxfp4MatvecColsGeneric accumulates out[lo:hi] in pure Go over the same
+// 7-bit activations as the AVX2 kernel, so both builds agree exactly.
+func mxfp4MatvecColsGeneric(out []Float, xu []uint8, sx Float, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	clear(out[lo:hi])
+	quads := len(xu) / 4
+	groups := (len(xu) + 31) / 32
+	acc := make([]int32, hi-lo)
+	for g := 0; g < groups; g++ {
+		ib := g * 8
+		ie := min(ib+8, quads)
+		clear(acc)
+		for i4 := ib; i4 < ie; i4++ {
+			x0, x1 := int32(xu[4*i4]), int32(xu[4*i4+1])
+			x2, x3 := int32(xu[4*i4+2]), int32(xu[4*i4+3])
+			row := qw[i4*2*q4Tile:]
+			for j := lo; j < hi; j++ {
+				o := (j/q4Tile)*quads*2*q4Tile + (j%q4Tile)*2
+				b0, b1 := row[o], row[o+1]
+				acc[j-lo] += x0*int32(mxfp4LUT[b0&0x0F]) + x1*int32(mxfp4LUT[b0>>4]) +
+					x2*int32(mxfp4LUT[b1&0x0F]) + x3*int32(mxfp4LUT[b1>>4])
+			}
+		}
+		for j := lo; j < hi; j++ {
+			t := ((j/q4Tile)*groups + g) * q4Tile
+			out[j] += Float(acc[j-lo]-colSum64[t+j%q4Tile]) * scale[t+j%q4Tile]
+		}
+	}
+	for j := lo; j < hi; j++ {
+		out[j] *= sx
+	}
+}
+
+// mxfp4MatmulRows8Generic is the eight-row batched body.
+func mxfp4MatmulRows8Generic(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	var acc [8][]int32
+	for r := range acc {
+		acc[r] = make([]int32, hi-lo)
+	}
+	quads := len(xus[0]) / 4
+	groups := (len(xus[0]) + 31) / 32
+	for r := 0; r < 8; r++ {
+		clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+hi])
+	}
+	for g := 0; g < groups; g++ {
+		ib := g * 8
+		ie := min(ib+8, quads)
+		for r := range acc {
+			clear(acc[r])
+		}
+		for i4 := ib; i4 < ie; i4++ {
+			row := qw[i4*2*q4Tile:]
+			for r := 0; r < 8; r++ {
+				x0, x1 := int32(xus[r][4*i4]), int32(xus[r][4*i4+1])
+				x2, x3 := int32(xus[r][4*i4+2]), int32(xus[r][4*i4+3])
+				a := acc[r]
+				for j := lo; j < hi; j++ {
+					o := (j/q4Tile)*quads*2*q4Tile + (j%q4Tile)*2
+					b0, b1 := row[o], row[o+1]
+					a[j-lo] += x0*int32(mxfp4LUT[b0&0x0F]) + x1*int32(mxfp4LUT[b0>>4]) +
+						x2*int32(mxfp4LUT[b1&0x0F]) + x3*int32(mxfp4LUT[b1>>4])
+				}
+			}
+		}
+		for r := 0; r < 8; r++ {
+			o := out.Data[(r0+r)*cols:]
+			for j := lo; j < hi; j++ {
+				t := ((j/q4Tile)*groups + g) * q4Tile
+				o[j] += Float(acc[r][j-lo]-colSum64[t+j%q4Tile]) * scale[t+j%q4Tile]
+			}
+		}
+	}
+	for r := 0; r < 8; r++ {
+		o := out.Data[(r0+r)*cols:]
+		for j := lo; j < hi; j++ {
+			o[j] *= sxs[r]
+		}
+	}
+}

--- a/mxfp4_generic.go
+++ b/mxfp4_generic.go
@@ -1,0 +1,14 @@
+//go:build !goexperiment.simd || !amd64
+
+package tensai
+
+// Portable dispatchers for the MXFP4 kernels; build with
+// GOEXPERIMENT=simd on amd64 for the AVX2 versions in mxfp4_simd.go.
+
+func mxfp4MatvecCols(out []Float, xu []uint8, sx Float, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	mxfp4MatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, lo, hi)
+}
+
+func mxfp4MatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	mxfp4MatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
+}

--- a/mxfp4_simd.go
+++ b/mxfp4_simd.go
@@ -1,0 +1,172 @@
+//go:build goexperiment.simd && amd64
+
+package tensai
+
+import "simd/archsimd"
+
+// 256-bit AVX2 kernels for the MXFP4 layout: the Q4 kernels' nibble
+// unpack lands the FP4 codes in quad-layout byte lanes, one VPSHUFB
+// expands them to the doubled integer grid, and the rest is the
+// grouped-int8 chain — raw 7-bit activations as the unsigned operand,
+// the 64x column-sum correction folded per 32-row group.
+
+// mxfp4LUT32 doubles the 16-entry code table across both shuffle lanes.
+var mxfp4LUT32 = func() [32]int8 {
+	var t [32]int8
+	copy(t[:16], mxfp4LUT[:])
+	copy(t[16:], mxfp4LUT[:])
+	return t
+}()
+
+func mxfp4MatvecCols(out []Float, xu []uint8, sx Float, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	if !hasAVX2 {
+		mxfp4MatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, lo, hi)
+		return
+	}
+	quads := len(xu) / 4
+	groups := (len(xu) + 31) / 32
+	vecEnd := lo + ((hi - lo) &^ 31)
+	if vecEnd > lo {
+		mLo := archsimd.BroadcastUint16x16(0x000F)
+		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		ones := archsimd.BroadcastInt16x16(1)
+		lut := loadI8x32(mxfp4LUT32[:])
+		clear(out[lo:vecEnd])
+		for jt := lo; jt < vecEnd; jt += 32 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
+			stab := scale[(jt/q4Tile)*groups*q4Tile:]
+			ctab := colSum64[(jt/q4Tile)*groups*q4Tile:]
+			d0 := out[jt : jt+8 : jt+8]
+			d1 := out[jt+8 : jt+16 : jt+16]
+			d2 := out[jt+16 : jt+24 : jt+24]
+			d3 := out[jt+24 : jt+32 : jt+32]
+			for g := 0; g < groups; g++ {
+				ib := g * 8
+				ie := min(ib+8, quads)
+				var a0, a1, a2, a3 archsimd.Int32x8
+				for i4 := ib; i4 < ie; i4++ {
+					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsUint8x32()
+					row := tile[i4*2*q4Tile:]
+					v := loadU8x16(row).ExtendToUint16()
+					w := lut.PermuteOrZeroGrouped(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsInt8x32())
+					a0 = a0.Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
+					v = loadU8x16(row[16:]).ExtendToUint16()
+					w = lut.PermuteOrZeroGrouped(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsInt8x32())
+					a1 = a1.Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
+					v = loadU8x16(row[32:]).ExtendToUint16()
+					w = lut.PermuteOrZeroGrouped(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsInt8x32())
+					a2 = a2.Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
+					v = loadU8x16(row[48:]).ExtendToUint16()
+					w = lut.PermuteOrZeroGrouped(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsInt8x32())
+					a3 = a3.Add(xp.DotProductPairsSaturated(w).DotProductPairs(ones))
+				}
+				tg := stab[g*q4Tile:]
+				cg := ctab[g*q4Tile:]
+				f := a0.Sub(loadI32x8(cg)).ConvertToFloat32().Mul(loadF32x8(tg))
+				storeF32x8(loadF32x8(d0).Add(f), d0)
+				f = a1.Sub(loadI32x8(cg[8:])).ConvertToFloat32().Mul(loadF32x8(tg[8:]))
+				storeF32x8(loadF32x8(d1).Add(f), d1)
+				f = a2.Sub(loadI32x8(cg[16:])).ConvertToFloat32().Mul(loadF32x8(tg[16:]))
+				storeF32x8(loadF32x8(d2).Add(f), d2)
+				f = a3.Sub(loadI32x8(cg[24:])).ConvertToFloat32().Mul(loadF32x8(tg[24:]))
+				storeF32x8(loadF32x8(d3).Add(f), d3)
+			}
+		}
+		sxv := archsimd.BroadcastFloat32x8(sx)
+		for j := lo; j < vecEnd; j += 8 {
+			storeF32x8(loadF32x8(out[j:]).Mul(sxv), out[j:])
+		}
+	}
+	archsimd.ClearAVXUpperBits()
+	if vecEnd < hi {
+		mxfp4MatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, vecEnd, hi)
+	}
+}
+
+// mxfp4MatmulRows8 is the eight-row batched form: the nibble unpack and
+// the shuffle run once per eight-column step and feed eight broadcast
+// activation quads.
+func mxfp4MatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []uint8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+	if !hasAVX2 {
+		mxfp4MatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
+		return
+	}
+	quads := len(xus[0]) / 4
+	groups := (len(xus[0]) + 31) / 32
+	xq := make([]uint32, 8*quads)
+	for r := 0; r < 8; r++ {
+		for i4 := 0; i4 < quads; i4++ {
+			xq[i4*8+r] = qxQuad(xus[r], i4)
+		}
+	}
+	vecEnd := lo + ((hi - lo) &^ 7)
+	if vecEnd > lo {
+		mLo := archsimd.BroadcastUint16x16(0x000F)
+		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		ones := archsimd.BroadcastInt16x16(1)
+		lut := loadI8x32(mxfp4LUT32[:])
+		for r := 0; r < 8; r++ {
+			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
+		}
+		o0 := out.Data[r0*cols:]
+		o1 := out.Data[(r0+1)*cols:]
+		o2 := out.Data[(r0+2)*cols:]
+		o3 := out.Data[(r0+3)*cols:]
+		o4 := out.Data[(r0+4)*cols:]
+		o5 := out.Data[(r0+5)*cols:]
+		o6 := out.Data[(r0+6)*cols:]
+		o7 := out.Data[(r0+7)*cols:]
+		for jt := lo; jt < vecEnd; jt += 8 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+			stab := scale[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+			ctab := colSum64[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+			d0 := o0[jt : jt+8 : jt+8]
+			d1 := o1[jt : jt+8 : jt+8]
+			d2 := o2[jt : jt+8 : jt+8]
+			d3 := o3[jt : jt+8 : jt+8]
+			d4 := o4[jt : jt+8 : jt+8]
+			d5 := o5[jt : jt+8 : jt+8]
+			d6 := o6[jt : jt+8 : jt+8]
+			d7 := o7[jt : jt+8 : jt+8]
+			for g := 0; g < groups; g++ {
+				ib := g * 8
+				ie := min(ib+8, quads)
+				var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
+				for i4 := ib; i4 < ie; i4++ {
+					v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
+					w := lut.PermuteOrZeroGrouped(v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsInt8x32())
+					xf := xq[i4*8 : i4*8+8]
+					a0 = a0.Add(archsimd.BroadcastUint32x8(xf[0]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a1 = a1.Add(archsimd.BroadcastUint32x8(xf[1]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a2 = a2.Add(archsimd.BroadcastUint32x8(xf[2]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a3 = a3.Add(archsimd.BroadcastUint32x8(xf[3]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a4 = a4.Add(archsimd.BroadcastUint32x8(xf[4]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a5 = a5.Add(archsimd.BroadcastUint32x8(xf[5]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a6 = a6.Add(archsimd.BroadcastUint32x8(xf[6]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+					a7 = a7.Add(archsimd.BroadcastUint32x8(xf[7]).AsUint8x32().DotProductPairsSaturated(w).DotProductPairs(ones))
+				}
+				cs := loadI32x8(ctab[g*q4Tile:])
+				sc := loadF32x8(stab[g*q4Tile:])
+				storeF32x8(loadF32x8(d0).Add(a0.Sub(cs).ConvertToFloat32().Mul(sc)), d0)
+				storeF32x8(loadF32x8(d1).Add(a1.Sub(cs).ConvertToFloat32().Mul(sc)), d1)
+				storeF32x8(loadF32x8(d2).Add(a2.Sub(cs).ConvertToFloat32().Mul(sc)), d2)
+				storeF32x8(loadF32x8(d3).Add(a3.Sub(cs).ConvertToFloat32().Mul(sc)), d3)
+				storeF32x8(loadF32x8(d4).Add(a4.Sub(cs).ConvertToFloat32().Mul(sc)), d4)
+				storeF32x8(loadF32x8(d5).Add(a5.Sub(cs).ConvertToFloat32().Mul(sc)), d5)
+				storeF32x8(loadF32x8(d6).Add(a6.Sub(cs).ConvertToFloat32().Mul(sc)), d6)
+				storeF32x8(loadF32x8(d7).Add(a7.Sub(cs).ConvertToFloat32().Mul(sc)), d7)
+			}
+		}
+		for r := 0; r < 8; r++ {
+			sxv := archsimd.BroadcastFloat32x8(sxs[r])
+			o := out.Data[(r0+r)*cols:]
+			for j := lo; j < vecEnd; j += 8 {
+				storeF32x8(loadF32x8(o[j:]).Mul(sxv), o[j:])
+			}
+		}
+	}
+	archsimd.ClearAVXUpperBits()
+	if vecEnd < hi {
+		mxfp4MatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, vecEnd, hi)
+	}
+}

--- a/mxfp4_test.go
+++ b/mxfp4_test.go
@@ -1,0 +1,75 @@
+package tensai
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestMXFP4MatVecAndMatMul(t *testing.T) {
+	rng := rand.New(rand.NewSource(63))
+	for _, c := range []struct{ rows, cols int }{
+		{768, 2304}, // parallel path, many groups
+		{100, 33},   // partial final group and tile, scalar tails
+		{5, 7},
+	} {
+		q := NewMXFP4Matrix(c.rows, c.cols)
+		for j := 0; j < c.cols; j++ {
+			for g := 0; g*32 < c.rows; g++ {
+				q.Scale[q.TableIndex(g, j)] = MXFP4Scale(uint8(120 + rng.Intn(12)))
+				var sum int32
+				for i := g * 32; i < min((g+1)*32, c.rows); i++ {
+					code := uint8(rng.Intn(16))
+					q.Q[q.Index(i, j)] |= code << (4 * (i % 2))
+					sum += int32(MXFP4Value(code))
+				}
+				q.ColSum64[q.TableIndex(g, j)] = 64 * sum
+			}
+		}
+		x := make([]Float, c.rows)
+		for i := range x {
+			x[i] = Float(rng.NormFloat64())
+		}
+		out := make([]Float, c.cols)
+		if err := q.MatVec(x, out); err != nil {
+			t.Fatalf("%v: %v", c, err)
+		}
+
+		// Exact reference over the same codes and 7-bit activations.
+		xu, sx := quantizeActs(x)
+		for j := 0; j < c.cols; j++ {
+			var want float64
+			for g := 0; g*32 < c.rows; g++ {
+				var acc int64
+				for i := g * 32; i < min((g+1)*32, c.rows); i++ {
+					w := int64(MXFP4Value(q.Q[q.Index(i, j)] >> (4 * (i % 2))))
+					acc += w * (int64(xu[i]) - 64)
+				}
+				want += float64(acc) * float64(q.Scale[q.TableIndex(g, j)])
+			}
+			want *= float64(sx)
+			if diff := math.Abs(float64(out[j]) - want); diff > 1e-3*(1+math.Abs(want)) {
+				t.Fatalf("%v col %d: got %v want %v", c, j, out[j], want)
+			}
+		}
+
+		// The batch must equal per-row MatVec bit for bit.
+		const batch = 11
+		xb := RandomMatrix(batch, c.rows, rng)
+		ob := NewMatrix(batch, c.cols)
+		if err := q.MatMul(xb, ob); err != nil {
+			t.Fatalf("%v: %v", c, err)
+		}
+		row := make([]Float, c.cols)
+		for r := 0; r < batch; r++ {
+			if err := q.MatVec(xb.Data[r*c.rows:(r+1)*c.rows], row); err != nil {
+				t.Fatal(err)
+			}
+			for j := range row {
+				if ob.Data[r*c.cols+j] != row[j] {
+					t.Fatalf("%v row %d col %d: batch %v matvec %v", c, r, j, ob.Data[r*c.cols+j], row[j])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The format gpt-oss ships its expert weights in: 32-value groups share one power-of-two E8M0 exponent, each weight a 4-bit FP4 code. MXFP4Matrix stores the codes in Q4Matrix's tiled quad-nibble layout with tile-major tables, and the kernels expand each code to twice its FP4 value on the integer grid {0, ±1..±4, ±6, ±8, ±12} with one VPSHUFB against a 16-entry table — Scale carries half the E8M0 factor, so the integer products are exact and the rest is the grouped-int8 multiply-add chain. encoding/gguf learns to dequantize the type (39), and the kernel test pins both builds to an exact integer reference with the batch path bit-equal to the row path.

First of three gpt-oss PRs; the o200k tokenizer and the architecture itself (attention sinks, alternating sliding window, YaRN, clamped SwiGLU, per-expert biases, harmony template) follow.