### PR TITLE
tokenizer: the o200k split (gpt-4o pre-tokenizer)

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -49,6 +49,8 @@ func ggufTokenizer(g *gguf.File) (*tokenizer.Tokenizer, error) {
 		preJSON = `{"type":"Sequence","pretokenizers":[{"type":"Digits","individual_digits":true},{"type":"ByteLevel","use_regex":true}]}`
 	case "qwen2", "llama-bpe", "llama3", "smaug-bpe", "deepseek-r1-qwen":
 		preJSON = `{"type":"Split","pattern":{"Regex":"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"}}`
+	case "gpt-4o":
+		preJSON = `{"type":"Split","pattern":{"Regex":"[^\\r\\n\\p{L}\\p{N}]?((?=[\\p{L}])([^a-z]))*((?=[\\p{L}])([^A-Z]))+(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|[^\\r\\n\\p{L}\\p{N}]?((?=[\\p{L}])([^a-z]))+((?=[\\p{L}])([^A-Z]))*(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"}}`
 	case "gpt-2", "olmo", "":
 		preJSON = `{"type":"ByteLevel","use_regex":true}`
 	default:

--- a/tokenizer/o200k_test.go
+++ b/tokenizer/o200k_test.go
@@ -1,0 +1,35 @@
+package tokenizer
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestO200KSplit pins the o200k scanner's pre-tokenization, verified
+// token-exact against llama-tokenize (--no-escape) with gpt-oss-20b's
+// vocabulary over a torture corpus and a fuzz corpus.
+func TestO200KSplit(t *testing.T) {
+	tok := &Tokenizer{cfg: o200kConfig}
+	for _, c := range []struct {
+		in   string
+		want []string
+	}{
+		{"camelCase", []string{"camel", "Case"}},
+		{"HTTPResponse", []string{"HTTPResponse"}},
+		{"I'm can't THEY'LL", []string{"I'm", " can't", " THEY'LL"}},
+		{" 'standalone", []string{" '", "standalone"}},
+		{"日本語abc", []string{"日本語abc"}},
+		{"abc日本語", []string{"abc日本語"}},
+		{"12345", []string{"123", "45"}},
+		{"a=1234", []string{"a", "=", "123", "4"}},
+		{"!!\n/next", []string{"!!\n/", "next"}},
+		{"paths/like/this", []string{"paths", "/like", "/this"}},
+		{"  x", []string{" ", " x"}},
+		{"x  ", []string{"x", "  "}},
+		{"line1\nline2", []string{"line", "1", "\n", "line", "2"}},
+	} {
+		if got := tok.split(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("split(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -53,11 +53,20 @@ type splitConfig struct {
 	// is its own pre-token, so a digit never absorbs a preceding space, and
 	// whitespace running into a digit behaves as if at end of text.
 	individualDigits bool
+	// caseWords selects o200k's case-aware word alternatives: a run of
+	// uppercase-ish letters (any letter but ASCII a-z) then a run of
+	// lowercase-ish ones (any letter but ASCII A-Z), with contractions
+	// attaching as a suffix instead of splitting on their own.
+	caseWords bool
+	// punctSlash admits '/' into the punctuation run's newline tail
+	// (o200k's "[\r\n/]*").
+	punctSlash bool
 }
 
 var (
 	gpt2Config   = splitConfig{}
 	cl100kConfig = splitConfig{ciContractions: true, letterPrefix: true, maxDigits: 3, newlineRuns: true}
+	o200kConfig  = splitConfig{ciContractions: true, letterPrefix: true, maxDigits: 3, newlineRuns: true, caseWords: true, punctSlash: true}
 )
 
 // jsonFile mirrors the subset of tokenizer.json this package understands.
@@ -213,6 +222,9 @@ func classifyRegex(re string) (splitConfig, error) {
 	switch {
 	case strings.HasPrefix(re, `'s|'t|'re|'ve|'m|'ll|'d`):
 		return gpt2Config, nil
+	case strings.HasPrefix(re, `[^\r\n\p{L}\p{N}]?((?=[\p{L}])([^a-z]))*`):
+		// o200k (gpt-4o and friends), in llama.cpp's lookahead spelling.
+		return o200kConfig, nil
 	case strings.HasPrefix(re, `(?i:'s|'t|'re|'ve|'m|'ll|'d)`):
 		cfg := cl100kConfig
 		if strings.Contains(re, `\p{N}{1,3}`) {
@@ -359,8 +371,9 @@ func (t *Tokenizer) split(s string) []string {
 	var out []string
 	i := 0
 	for i < len(rs) {
-		// Contractions.
-		if rs[i] == '\'' && i+1 < len(rs) {
+		// Contractions — standalone alternatives in the gpt2/cl100k
+		// patterns; o200k attaches them to the word instead.
+		if !cfg.caseWords && rs[i] == '\'' && i+1 < len(rs) {
 			if n := matchContraction(rs[i:], cfg.ciContractions); n > 0 {
 				out = append(out, string(rs[i:i+n]))
 				i += n
@@ -382,8 +395,26 @@ func (t *Tokenizer) split(s string) []string {
 		}
 		if pfx < len(rs) && unicode.IsLetter(rs[pfx]) {
 			j = pfx
-			for j < len(rs) && unicode.IsLetter(rs[j]) {
-				j++
+			if cfg.caseWords {
+				// o200k: an uppercase-ish run (letters except ASCII a-z)
+				// then a lowercase-ish one (letters except ASCII A-Z) —
+				// the backtracking-free reading of its two alternatives —
+				// plus an optional contraction suffix.
+				for j < len(rs) && unicode.IsLetter(rs[j]) && !(rs[j] >= 'a' && rs[j] <= 'z') {
+					j++
+				}
+				for j < len(rs) && unicode.IsLetter(rs[j]) && !(rs[j] >= 'A' && rs[j] <= 'Z') {
+					j++
+				}
+				if j < len(rs) && rs[j] == '\'' {
+					if n := matchContraction(rs[j:], true); n > 0 {
+						j += n
+					}
+				}
+			} else {
+				for j < len(rs) && unicode.IsLetter(rs[j]) {
+					j++
+				}
 			}
 			out = append(out, string(rs[start:j]))
 			i = j
@@ -435,7 +466,7 @@ func (t *Tokenizer) split(s string) []string {
 				j++
 			}
 			if cfg.newlineRuns {
-				for j < len(rs) && (rs[j] == '\r' || rs[j] == '\n') {
+				for j < len(rs) && (rs[j] == '\r' || rs[j] == '\n' || (cfg.punctSlash && rs[j] == '/')) {
 					j++
 				}
 			}


### PR DESCRIPTION
gpt-oss ships the o200k_harmony vocabulary. Its split has two case-aware word alternatives — an uppercase-ish run (letters except ASCII a-z) then a lowercase-ish one (letters except ASCII A-Z), contractions attaching as a suffix — plus cl100k-style digit and whitespace rules and a '/' admitted into the punctuation run's newline tail. The two alternatives collapse into one backtracking-free scan (upper-ish run then lower-ish run), implemented as the third scanner config; standalone contraction splitting turns off since o200k has no such alternative.

Verified token-exact against llama-tokenize --no-escape with the gpt-oss-20b vocabulary over a torture corpus and an 85-line fuzz corpus — the only mismatches turned out to be llama-tokenize's default escape processing eating backslashes from the reference input. A unit test pins the pre-token boundaries. Second of three gpt-oss PRs; the architecture itself follows.