### PR TITLE
quant: pad batch row tails; gguf: release consumed pages

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -1203,6 +1203,7 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer g.Release("output.weight")
 		if _, _, ok := g.Info("output.weight"); ok {
 			if q := linDirectAuto([]string{"output.weight"}, []int{0}); q != nil {
 				m.qLmT = q
@@ -1332,6 +1333,14 @@ func loadGGUF(path string, bits int, direct bool) (*qwen, *tokenizer.Tokenizer, 
 				unpermuteVec(vecOpt(p+"attn_q.bias"), qPerm),
 				unpermuteVec(vecOpt(p+"attn_k.bias"), kPerm),
 				vecOpt(p+"attn_v.bias"))
+			// The layer's file pages will not be read again: let them go
+			// now so a big load's repacked weights are not the pages the
+			// kernel chooses to evict.
+			for _, name := range g.Names() {
+				if strings.HasPrefix(name, p) {
+					g.Release(name)
+				}
+			}
 		}(i)
 	}
 	wg.Wait()

--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -443,18 +443,21 @@ func activate(gate, up []float32, geglu bool) {
 // router's softmax picks topK experts, each contributes its SwiGLU
 // output scaled by its routing weight, and qwen2moe's shared expert
 // adds its sigmoid-gated output on top.
-func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
-	logits := mv(a, b.router, nil, b.routerBias)
-	type pick struct {
-		e int
-		w float32
-	}
-	picks := make([]pick, 0, b.topK)
+// moePick is one routed expert and its mixing weight.
+type moePick struct {
+	e int
+	w float32
+}
+
+// route turns one row's router logits into its top-k experts and
+// weights; logits are consumed as scratch.
+func (b *qblock) route(logits []float32) []moePick {
+	picks := make([]moePick, 0, b.topK)
 	if b.softmaxK {
 		// gpt-oss: pick the top-k logits, softmax over just those.
 		for e, w := range logits {
 			if len(picks) < b.topK {
-				picks = append(picks, pick{e, w})
+				picks = append(picks, moePick{e, w})
 				continue
 			}
 			lo := 0
@@ -464,7 +467,7 @@ func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
 				}
 			}
 			if w > picks[lo].w {
-				picks[lo] = pick{e, w}
+				picks[lo] = moePick{e, w}
 			}
 		}
 		maxL := picks[0].w
@@ -498,7 +501,7 @@ func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
 		}
 		for e, w := range logits {
 			if len(picks) < b.topK {
-				picks = append(picks, pick{e, w})
+				picks = append(picks, moePick{e, w})
 				continue
 			}
 			lo := 0
@@ -508,7 +511,7 @@ func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
 				}
 			}
 			if w > picks[lo].w {
-				picks[lo] = pick{e, w}
+				picks[lo] = moePick{e, w}
 			}
 		}
 		if b.normTopK {
@@ -521,6 +524,11 @@ func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
 			}
 		}
 	}
+	return picks
+}
+
+func (m *qwen) moeFFN(b *qblock, a []float32) []float32 {
+	picks := b.route(mv(a, b.router, nil, b.routerBias))
 	out := make([]float32, m.cfg.HiddenSize)
 	moeFF := m.cfg.MoeFF
 	for _, p := range picks {
@@ -825,7 +833,11 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 		var down *tensai.Matrix
 		if len(b.experts) > 0 {
 			// Each row routes to its own experts, so the batch runs
-			// row-wise, rows spread across CPUs.
+			// row-wise, rows spread across CPUs. (An expert-grouped GEMM
+			// was tried and lost: the four-row kernel's multiply work
+			// scales with rows x weights either way, the per-expert
+			// weights sit in L3 across rows, and the orchestration cost
+			// is real — a deeper batch kernel is the actual lever.)
 			down = tensai.NewMatrix(n, hs)
 			var wg sync.WaitGroup
 			rowCh := make(chan int, n)

--- a/encoding/gguf/gguf.go
+++ b/encoding/gguf/gguf.go
@@ -216,6 +216,31 @@ func (f *File) Close() error {
 	return err
 }
 
+// Release hints that a tensor's bytes will not be read again: when the
+// file is memory-mapped, the kernel may drop those page-cache pages
+// right away instead of letting them crowd out the caller's own
+// memory during a large load. Harmless otherwise.
+func (f *File) Release(name string) {
+	t, ok := f.tensors[name]
+	if !ok || f.data == nil {
+		return
+	}
+	spec, ok := blockSpec[t.typ]
+	if !ok {
+		return
+	}
+	n := int64(1)
+	for _, d := range t.shape {
+		n *= int64(d)
+	}
+	nbytes := n / spec.values * spec.bytes
+	lo := f.dataBase + t.offset
+	if lo < 0 || lo+nbytes > int64(len(f.data)) {
+		return
+	}
+	mmapfile.Release(f.data[lo : lo+nbytes])
+}
+
 // Names returns the tensor names in sorted order.
 func (f *File) Names() []string { return append([]string(nil), f.names...) }
 

--- a/internal/mmapfile/addr.go
+++ b/internal/mmapfile/addr.go
@@ -1,0 +1,8 @@
+package mmapfile
+
+import "unsafe"
+
+// addrOf returns the address of the first byte of b.
+func addrOf(b []byte) unsafe.Pointer {
+	return unsafe.Pointer(unsafe.SliceData(b))
+}

--- a/internal/mmapfile/release_other.go
+++ b/internal/mmapfile/release_other.go
@@ -1,0 +1,6 @@
+//go:build !linux && !darwin
+
+package mmapfile
+
+// Release is a no-op where madvise is unavailable.
+func Release(b []byte) {}

--- a/internal/mmapfile/release_unix.go
+++ b/internal/mmapfile/release_unix.go
@@ -1,0 +1,28 @@
+//go:build linux || darwin
+
+package mmapfile
+
+import "syscall"
+
+// Release tells the kernel the mapped range will not be needed again:
+// its clean page-cache pages can drop immediately instead of crowding
+// out the caller's own allocations. A later touch simply refaults from
+// the file. b must lie within a mapping returned by Map; the range is
+// rounded inward to page boundaries.
+func Release(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	page := syscall.Getpagesize()
+	// Round the start up and the end down so we never advise bytes
+	// outside b (madvise needs page-aligned addresses).
+	start := 0
+	if off := int(uintptr(addrOf(b)) % uintptr(page)); off != 0 {
+		start = page - off
+	}
+	end := start + (len(b)-start)/page*page
+	if end <= start {
+		return
+	}
+	syscall.Madvise(b[start:end], syscall.MADV_DONTNEED)
+}

--- a/mxfp4.go
+++ b/mxfp4.go
@@ -96,13 +96,27 @@ func (q *MXFP4Matrix) MatMul(x, out *Matrix) error {
 	for r := 0; r < rows; r++ {
 		xus[r], sxs[r] = quantizeActs(x.Data[r*x.Cols : (r+1)*x.Cols])
 	}
+	// The row tail (rows%8 leftovers) pads to one full block: zero
+	// rows are harmless in the integer kernels, the scratch matrix is
+	// shared by every column chunk (they write disjoint ranges), and
+	// only the real rows copy back — so the tail streams the weights
+	// once instead of once per row.
+	var pxus [][]uint8
+	var psxs []Float
+	var scratch *Matrix
+	if rows%8 != 0 {
+		pxus, psxs, scratch = padRows8(xus[rows-rows%8:], sxs[rows-rows%8:], len(xus[0]), q.Cols)
+	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+8 <= rows; r += 8 {
 			mxfp4MatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 		}
-		for ; r < rows; r++ {
-			mxfp4MatvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+		if r < rows {
+			mxfp4MatmulRows8(scratch, pxus, psxs, 0, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+			for i := 0; i < rows-r; i++ {
+				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
+			}
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)

--- a/quant.go
+++ b/quant.go
@@ -21,6 +21,24 @@ func matvecWorkerCount(cols, rows int) int {
 	return workers
 }
 
+// padRows8 pads a tail of quantized activation rows (fewer than eight)
+// to a full block: zero rows are harmless in the integer kernels, and a
+// scratch matrix receives the block so callers copy back only the real
+// rows. The Q4 path uses the first four entries.
+func padRows8(xus [][]uint8, sxs []Float, rowLen, cols int) ([][]uint8, []Float, *Matrix) {
+	pxus := make([][]uint8, 8)
+	psxs := make([]Float, 8)
+	zero := make([]uint8, rowLen)
+	for i := 0; i < 8; i++ {
+		if i < len(xus) {
+			pxus[i], psxs[i] = xus[i], sxs[i]
+		} else {
+			pxus[i] = zero
+		}
+	}
+	return pxus, psxs, NewMatrix(8, cols)
+}
+
 // parallelChunks splits [0, n) into align-rounded chunks across the
 // workers, the calling goroutine taking the first chunk itself: a
 // matvec fan-out spawns workers-1 goroutines and the caller streams
@@ -233,13 +251,27 @@ func (q *QMatrix) MatMul(x, out *Matrix) error {
 	for r := 0; r < rows; r++ {
 		xus[r], sxs[r] = quantizeActs(x.Data[r*x.Cols : (r+1)*x.Cols])
 	}
+	// The row tail (rows%8 leftovers) pads to one full block: zero
+	// rows are harmless in the integer kernels, the scratch matrix is
+	// shared by every column chunk (they write disjoint ranges), and
+	// only the real rows copy back — so the tail streams the weights
+	// once instead of once per row.
+	var pxus [][]uint8
+	var psxs []Float
+	var scratch *Matrix
+	if rows%8 != 0 {
+		pxus, psxs, scratch = padRows8(xus[rows-rows%8:], sxs[rows-rows%8:], len(xus[0]), q.Cols)
+	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+8 <= rows; r += 8 {
 			qmatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 		}
-		for ; r < rows; r++ {
-			qmatvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+		if r < rows {
+			qmatmulRows8(scratch, pxus, psxs, 0, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+			for i := 0; i < rows-r; i++ {
+				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
+			}
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)

--- a/quant4.go
+++ b/quant4.go
@@ -228,13 +228,31 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 			gsums[r][min(i/grp, groups-1)] += int32(u) - 64
 		}
 	}
+	// See padRows8: the row tail pads to one full block over a shared
+	// scratch matrix so the weights stream once.
+	var pxus [][]uint8
+	var psxs []Float
+	var pgs [][]int32
+	var scratch *Matrix
+	if rows%4 != 0 {
+		t := rows - rows%4
+		pxus, psxs, scratch = padRows8(xus[t:], sxs[t:], len(xus[0]), q.Cols)
+		pgs = make([][]int32, 4)
+		copy(pgs, gsums[t:])
+		for i := rows - t; i < 4; i++ {
+			pgs[i] = make([]int32, groups)
+		}
+	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+4 <= rows; r += 4 {
 			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
-		for ; r < rows; r++ {
-			q4matvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], packQuads(xus[r]), sxs[r], gsums[r], q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+		if r < rows {
+			q4matmulCols4(scratch, pxus[:4], psxs[:4], pgs, 0, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+			for i := 0; i < rows-r; i++ {
+				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
+			}
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)

--- a/quant8g.go
+++ b/quant8g.go
@@ -99,13 +99,27 @@ func (q *Q8GMatrix) MatMul(x, out *Matrix) error {
 	for r := 0; r < rows; r++ {
 		xus[r], sxs[r] = quantizeActs(x.Data[r*x.Cols : (r+1)*x.Cols])
 	}
+	// The row tail (rows%8 leftovers) pads to one full block: zero
+	// rows are harmless in the integer kernels, the scratch matrix is
+	// shared by every column chunk (they write disjoint ranges), and
+	// only the real rows copy back — so the tail streams the weights
+	// once instead of once per row.
+	var pxus [][]uint8
+	var psxs []Float
+	var scratch *Matrix
+	if rows%8 != 0 {
+		pxus, psxs, scratch = padRows8(xus[rows-rows%8:], sxs[rows-rows%8:], len(xus[0]), q.Cols)
+	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+8 <= rows; r += 8 {
 			q8gMatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
 		}
-		for ; r < rows; r++ {
-			q8gMatvecCols(out.Data[r*q.Cols:(r+1)*q.Cols], xus[r], sxs[r], q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
+		if r < rows {
+			q8gMatmulRows8(scratch, pxus, psxs, 0, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
+			for i := 0; i < rows-r; i++ {
+				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
+			}
 		}
 	}
 	workers := matvecWorkerCount(q.Cols, q.Rows)


### PR DESCRIPTION
Two findings from chasing the llama.cpp gap on MoE prefill.

The batch kernels process rows in blocks (eight; four for Q4), and leftover rows fell to the row kernels — one full weight stream per leftover row. The tail now pads to a whole block with zero rows over a scratch matrix shared by the column chunks, so it streams the weights once; the batch-equals-matvec tests pin the padded path bit-for-bit. A 940-token dense prefill gains ~10%, and speculative decoding's four-row verification drops from four weight streams to one on the int8 layouts.

gguf.Release (madvise DONTNEED via mmapfile) lets the loader drop a tensor's file pages once repacked; the example releases each layer as it finishes. Chasing a 2.5-second lm_head matvec on gpt-oss-20b led to /proc/vmstat showing a single run swapping out 7.6GB on this 15GB machine — the repacked weights lose the residency fight against the mapped file, which is the structural reason llama.cpp's mmap approach wins oversized models (clean file pages, no swap writeback). Releasing helps at the margin; the real fix is a repack cache the runtime can mmap, noted as follow-up.

An expert-grouped MoE prefill was built, measured, and retreated from: the four-row kernel's multiply work scales with rows×weights either way, each expert's weights sit in L3 across a batch's rows, and the orchestration cost made it a 2x net loss — the actual lever is a deeper batch kernel that unpacks weights once for more rows. The routing selection stays factored out (qblock.route). Full suite green both builds; MoE, dense, Mistral, and gpt-oss answers unchanged.