### PR TITLE
Batch eight rows per Q4 weight stream

### DIFF
--- a/quant4.go
+++ b/quant4.go
@@ -228,29 +228,41 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 			gsums[r][min(i/grp, groups-1)] += int32(u) - 64
 		}
 	}
-	// See padRows8: the row tail pads to one full block over a shared
-	// scratch matrix so the weights stream once.
+	// See padRows8: the row tail pads to a full block over a shared
+	// scratch matrix so the weights stream once. A tail of exactly four
+	// takes the four-row kernel instead of padding to eight — the madd
+	// work scales with padded rows too, and speculative decoding's
+	// four-row verification block must not pay double.
 	var pxus [][]uint8
 	var psxs []Float
 	var pgs [][]int32
 	var scratch *Matrix
-	if rows%4 != 0 {
-		t := rows - rows%4
+	rem := rows % 8
+	if rem != 0 && rem != 4 {
+		t := rows - rem
 		pxus, psxs, scratch = padRows8(xus[t:], sxs[t:], len(xus[0]), q.Cols)
-		pgs = make([][]int32, 4)
+		pgs = make([][]int32, 8)
 		copy(pgs, gsums[t:])
-		for i := rows - t; i < 4; i++ {
+		for i := rem; i < 8; i++ {
 			pgs[i] = make([]int32, groups)
 		}
 	}
 	run := func(lo, hi int) {
 		var r int
-		for ; r+4 <= rows; r += 4 {
-			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+		for ; r+8 <= rows; r += 8 {
+			q4matmulCols8(out, xus[r:r+8], sxs[r:r+8], gsums[r:r+8], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 		}
-		if r < rows {
-			q4matmulCols4(scratch, pxus[:4], psxs[:4], pgs, 0, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
-			for i := 0; i < rows-r; i++ {
+		switch {
+		case rem == 0:
+		case rem == 4:
+			q4matmulCols4(out, xus[r:r+4], sxs[r:r+4], gsums[r:r+4], r, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+		default:
+			if rem < 4 {
+				q4matmulCols4(scratch, pxus[:4], psxs[:4], pgs[:4], 0, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+			} else {
+				q4matmulCols8(scratch, pxus, psxs, pgs, 0, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
+			}
+			for i := 0; i < rem; i++ {
 				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
 			}
 		}

--- a/quant4_generic.go
+++ b/quant4_generic.go
@@ -12,3 +12,8 @@ func q4matvecCols(out []Float, xu []uint8, xq []uint32, sx Float, gsum []int32, 
 func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
 	q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, lo, hi)
 }
+
+func q4matmulCols8(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+	q4matmulCols4Generic(out, xus[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, lo, hi)
+	q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, lo, hi)
+}

--- a/quant4_simd.go
+++ b/quant4_simd.go
@@ -239,3 +239,153 @@ func q4matmulCols4(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 
 		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, vecEnd, hi)
 	}
 }
+
+// q4matmulCols8 is the eight-row batched body: one nibble unpack and one
+// scale-table fold feed eight output rows, halving both against the
+// four-row kernel while the multiplies stay one broadcast and two madds
+// per row. The eight Int32x8 accumulators plus the unpack temporaries
+// still fit the sixteen-register file — named variables only, flat
+// tables, hoisted row slices (the spill traps notes on the four-row
+// kernel apply verbatim).
+func q4matmulCols8(out *Matrix, xus [][]uint8, sxs []Float, gsums [][]int32, r0 int, qw []uint8, scale []Float, sm []uint32, group, cols, lo, hi int) {
+	if !hasAVX2 {
+		q4matmulCols4Generic(out, xus[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, lo, hi)
+		q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, lo, hi)
+		return
+	}
+	quads := len(xus[0]) / 4
+	groups := len(gsums[0])
+	xq := make([]uint32, 8*quads)
+	for r := 0; r < 8; r++ {
+		for i4 := 0; i4 < quads; i4++ {
+			xq[i4*8+r] = q4xQuad(xus[r], i4)
+		}
+	}
+	gsf := make([]Float, 8*groups)
+	gsc := make([]int32, 8*groups)
+	for r := 0; r < 8; r++ {
+		for g, v := range gsums[r] {
+			gsf[8*g+r] = Float(v)
+			gsc[8*g+r] = 8 * v
+		}
+	}
+	vecEnd := lo + ((hi - lo) &^ 7)
+	if vecEnd > lo {
+		mLo := archsimd.BroadcastUint16x16(0x000F)
+		mHi := archsimd.BroadcastUint16x16(0x0F00)
+		ones := archsimd.BroadcastInt16x16(1)
+		o0 := out.Data[r0*cols:]
+		o1 := out.Data[(r0+1)*cols:]
+		o2 := out.Data[(r0+2)*cols:]
+		o3 := out.Data[(r0+3)*cols:]
+		o4 := out.Data[(r0+4)*cols:]
+		o5 := out.Data[(r0+5)*cols:]
+		o6 := out.Data[(r0+6)*cols:]
+		o7 := out.Data[(r0+7)*cols:]
+		for r := 0; r < 8; r++ {
+			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
+		}
+		for jt := lo; jt < vecEnd; jt += 8 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+			d0 := o0[jt : jt+8 : jt+8]
+			d1 := o1[jt : jt+8 : jt+8]
+			d2 := o2[jt : jt+8 : jt+8]
+			d3 := o3[jt : jt+8 : jt+8]
+			d4 := o4[jt : jt+8 : jt+8]
+			d5 := o5[jt : jt+8 : jt+8]
+			d6 := o6[jt : jt+8 : jt+8]
+			d7 := o7[jt : jt+8 : jt+8]
+			if sm != nil {
+				tab := sm[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
+					var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
+					for i4 := ib; i4 < ie; i4++ {
+						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
+						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
+						xf := xq[i4*8 : i4*8+8 : i4*8+8]
+						a0 = a0.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[0]).AsInt8x32()).DotProductPairs(ones))
+						a1 = a1.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[1]).AsInt8x32()).DotProductPairs(ones))
+						a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
+						a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
+						a4 = a4.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[4]).AsInt8x32()).DotProductPairs(ones))
+						a5 = a5.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[5]).AsInt8x32()).DotProductPairs(ones))
+						a6 = a6.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[6]).AsInt8x32()).DotProductPairs(ones))
+						a7 = a7.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[7]).AsInt8x32()).DotProductPairs(ones))
+					}
+					u := loadU32x8(tab[g*q4Tile:])
+					sc := u.ShiftAllLeft(16).AsFloat32x8()
+					mn := u.And(archsimd.BroadcastUint32x8(0xFFFF0000)).AsFloat32x8()
+					gr := gsf[8*g : 8*g+8 : 8*g+8]
+					f := a0.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[0]).Mul(mn))
+					storeF32x8(loadF32x8(d0).Add(f), d0)
+					f = a1.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[1]).Mul(mn))
+					storeF32x8(loadF32x8(d1).Add(f), d1)
+					f = a2.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[2]).Mul(mn))
+					storeF32x8(loadF32x8(d2).Add(f), d2)
+					f = a3.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[3]).Mul(mn))
+					storeF32x8(loadF32x8(d3).Add(f), d3)
+					f = a4.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[4]).Mul(mn))
+					storeF32x8(loadF32x8(d4).Add(f), d4)
+					f = a5.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[5]).Mul(mn))
+					storeF32x8(loadF32x8(d5).Add(f), d5)
+					f = a6.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[6]).Mul(mn))
+					storeF32x8(loadF32x8(d6).Add(f), d6)
+					f = a7.ConvertToFloat32().Mul(sc).Sub(archsimd.BroadcastFloat32x8(gr[7]).Mul(mn))
+					storeF32x8(loadF32x8(d7).Add(f), d7)
+				}
+			} else {
+				tab := scale[(jt/q4Tile)*groups*q4Tile+jt%q4Tile:]
+				for g := 0; g < groups; g++ {
+					ib := g * group / 4
+					ie := min(ib+group/4, quads)
+					var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x8
+					for i4 := ib; i4 < ie; i4++ {
+						v := loadU8x16(tile[i4*2*q4Tile:]).ExtendToUint16()
+						pair := v.And(mLo).Or(v.ShiftAllLeft(4).And(mHi)).AsUint8x32()
+						xf := xq[i4*8 : i4*8+8 : i4*8+8]
+						a0 = a0.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[0]).AsInt8x32()).DotProductPairs(ones))
+						a1 = a1.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[1]).AsInt8x32()).DotProductPairs(ones))
+						a2 = a2.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[2]).AsInt8x32()).DotProductPairs(ones))
+						a3 = a3.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[3]).AsInt8x32()).DotProductPairs(ones))
+						a4 = a4.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[4]).AsInt8x32()).DotProductPairs(ones))
+						a5 = a5.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[5]).AsInt8x32()).DotProductPairs(ones))
+						a6 = a6.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[6]).AsInt8x32()).DotProductPairs(ones))
+						a7 = a7.Add(pair.DotProductPairsSaturated(archsimd.BroadcastUint32x8(xf[7]).AsInt8x32()).DotProductPairs(ones))
+					}
+					sc := loadF32x8(tab[g*q4Tile:])
+					gr := gsc[8*g : 8*g+8 : 8*g+8]
+					f := a0.Sub(archsimd.BroadcastInt32x8(gr[0])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d0).Add(f), d0)
+					f = a1.Sub(archsimd.BroadcastInt32x8(gr[1])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d1).Add(f), d1)
+					f = a2.Sub(archsimd.BroadcastInt32x8(gr[2])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d2).Add(f), d2)
+					f = a3.Sub(archsimd.BroadcastInt32x8(gr[3])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d3).Add(f), d3)
+					f = a4.Sub(archsimd.BroadcastInt32x8(gr[4])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d4).Add(f), d4)
+					f = a5.Sub(archsimd.BroadcastInt32x8(gr[5])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d5).Add(f), d5)
+					f = a6.Sub(archsimd.BroadcastInt32x8(gr[6])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d6).Add(f), d6)
+					f = a7.Sub(archsimd.BroadcastInt32x8(gr[7])).ConvertToFloat32().Mul(sc)
+					storeF32x8(loadF32x8(d7).Add(f), d7)
+				}
+			}
+		}
+		for r := 0; r < 8; r++ {
+			sxv := archsimd.BroadcastFloat32x8(sxs[r])
+			o := out.Data[(r0+r)*cols:]
+			for j := lo; j < vecEnd; j += 8 {
+				storeF32x8(loadF32x8(o[j:]).Mul(sxv), o[j:])
+			}
+		}
+	}
+	archsimd.ClearAVXUpperBits()
+	if vecEnd < hi {
+		q4matmulCols4Generic(out, xus[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, vecEnd, hi)
+		q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, vecEnd, hi)
+	}
+}

--- a/quant4_test.go
+++ b/quant4_test.go
@@ -162,19 +162,23 @@ func TestQuantize4Group32(t *testing.T) {
 		}
 
 		// Batch equals per-row MatVec bit for bit at this group length too.
-		xb := RandomMatrix(6, c.rows, rng)
-		ob := NewMatrix(6, c.cols)
-		if err := q.MatMul(xb, ob); err != nil {
-			t.Fatal(err)
-		}
-		row := make([]Float, c.cols)
-		for r := 0; r < 6; r++ {
-			if err := q.MatVec(xb.Data[r*c.rows:(r+1)*c.rows], row); err != nil {
+		// 6 pads to one eight-row block, 9 runs a block plus a padded
+		// tail, 12 a block plus the exact four-row kernel.
+		for _, batch := range []int{6, 9, 12} {
+			xb := RandomMatrix(batch, c.rows, rng)
+			ob := NewMatrix(batch, c.cols)
+			if err := q.MatMul(xb, ob); err != nil {
 				t.Fatal(err)
 			}
-			for j := range row {
-				if ob.Data[r*c.cols+j] != row[j] {
-					t.Fatalf("%v row %d col %d differs", c, r, j)
+			row := make([]Float, c.cols)
+			for r := 0; r < batch; r++ {
+				if err := q.MatVec(xb.Data[r*c.rows:(r+1)*c.rows], row); err != nil {
+					t.Fatal(err)
+				}
+				for j := range row {
+					if ob.Data[r*c.cols+j] != row[j] {
+						t.Fatalf("%v batch %d row %d col %d differs", c, batch, r, j)
+					}
 				}
 			}
 		}
@@ -262,19 +266,23 @@ func TestQuantize4MinForm(t *testing.T) {
 			}
 		}
 
-		xb := RandomMatrix(6, c.rows, rng)
-		ob := NewMatrix(6, c.cols)
-		if err := q.MatMul(xb, ob); err != nil {
-			t.Fatal(err)
-		}
-		row := make([]Float, c.cols)
-		for r := 0; r < 6; r++ {
-			if err := q.MatVec(xb.Data[r*c.rows:(r+1)*c.rows], row); err != nil {
+		// 6 pads to one eight-row block, 9 runs a block plus a padded
+		// tail, 12 a block plus the exact four-row kernel.
+		for _, batch := range []int{6, 9, 12} {
+			xb := RandomMatrix(batch, c.rows, rng)
+			ob := NewMatrix(batch, c.cols)
+			if err := q.MatMul(xb, ob); err != nil {
 				t.Fatal(err)
 			}
-			for j := range row {
-				if ob.Data[r*c.cols+j] != row[j] {
-					t.Fatalf("%v row %d col %d differs", c, r, j)
+			row := make([]Float, c.cols)
+			for r := 0; r < batch; r++ {
+				if err := q.MatVec(xb.Data[r*c.rows:(r+1)*c.rows], row); err != nil {
+					t.Fatal(err)
+				}
+				for j := range row {
+					if ob.Data[r*c.cols+j] != row[j] {
+						t.Fatalf("%v batch %d row %d col %d differs", c, batch, r, j)
+					}
 				}
 			}
 		}

--- a/quant_test.go
+++ b/quant_test.go
@@ -303,3 +303,26 @@ func TestQuantizeActsAgree(t *testing.T) {
 		}
 	}
 }
+
+// BenchmarkQ4PrefillMinForm is the batched matmul over the asymmetric
+// Group-32 form GGUF's Q4_K repacks into — the shape a Q4_K_M prefill
+// actually runs.
+func BenchmarkQ4PrefillMinForm(b *testing.B) {
+	rng := rand.New(rand.NewSource(52))
+	q := NewQ4Matrix(1536, 8960, 32, true)
+	for i := range q.Q {
+		q.Q[i] = uint8(rng.Intn(256))
+	}
+	for i := range q.ScaleMin {
+		q.ScaleMin[i] = PackScaleMin(0.01, 0.2)
+	}
+	x := RandomMatrix(64, 1536, rng)
+	out := NewMatrix(64, 8960)
+	b.SetBytes(int64(64 * 1536 * 8960))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := q.MatMul(x, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
The four-bit batched kernel processed four activation rows per pass, so each nibble unpack and each scale-table fold was paid twice as often as the int8 kernels'. q4matmulCols8 feeds eight rows from one unpack and one fold; each row's integer accumulation and fold sequence is unchanged, so outputs stay bit-identical, and the batch-equals-matvec tests now also cover a padded eight-row block, a block plus a padded tail, and a block plus the exact four-row kernel on both the group-32 and min-form layouts.

Eight live accumulators push past the sixteen-register file and the compiler spills three per fold step. That was measured and kept: an unpack-to-stack-buffer variant with two four-accumulator passes — no spills at all — lost by ~40% to the store/reload traffic, so a few register spills beat rebuilding the shared operand from memory. A tail of exactly four rows still takes the four-row kernel, so speculative decoding's verification block does not pay for four zero rows.

Microbench (64×1536×8960): symmetric 4.9→4.4ms, min-form (new BenchmarkQ4PrefillMinForm) 5.3→4.7ms. A 921-token Q4_K_M 1.5B prefill drops ~8% end to end in interleaved A/B, output identical.