### PR TITLE
Group prefill attention by KV head

### DIFF
--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -635,7 +635,10 @@ func mmb(x, w *tensai.Matrix, q *qmat, bias []float32) *tensai.Matrix {
 // attendHead runs one head of cached-KV attention: SIMD dot-product
 // scores over the cache, a float64 softmax, and SIMD weighted value
 // accumulation into attn's slot for the head. Heads touch disjoint
-// output ranges, so callers fan heads out across goroutines freely.
+// output ranges, so callers fan heads out across goroutines freely —
+// which is why decode uses it: at short and medium contexts the KV
+// rows sit in L3 anyway, so attendGroup's shared streaming buys
+// nothing there while head-level fan-out keeps every core busy.
 func (m *qwen) attendHead(b *qblock, q, attn []float32, h, group, steps int, scores []float64) {
 	// Sliding-window layers (Gemma) see only the last window positions.
 	start := 0
@@ -670,6 +673,63 @@ func (m *qwen) attendHead(b *qblock, q, attn []float32, h, group, steps int, sco
 	out := attn[qOff : qOff+m.headSz]
 	for t := start; t < steps; t++ {
 		tensai.Axpy(float32(scores[t]/sum), b.vc[t][kvOff:kvOff+m.headSz], out)
+	}
+}
+
+// attendGroup runs one KV head's worth of cached-KV attention — the
+// `group` query heads that share it — streaming each cached key and
+// value row once for all of them: grouped SIMD scores (DotVecs), a
+// per-head float64 softmax, and grouped SIMD value accumulation
+// (Axpys). Per head the arithmetic order matches the old one-head-at-
+// a-time path exactly, so the output is bit-identical; KV heads touch
+// disjoint output ranges, so callers fan them out across goroutines.
+// scores needs group*steps float64s, ws group*steps float32s.
+func (m *qwen) attendGroup(b *qblock, q, attn []float32, kh, group, steps int, scores []float64, ws []float32) {
+	// Sliding-window layers (Gemma, gpt-oss) see only the last window
+	// positions.
+	start := 0
+	if b.window > 0 && steps > b.window {
+		start = steps - b.window
+	}
+	d := m.headSz
+	qOff := kh * group * d
+	kvOff := kh * d
+	scale := 1 / math.Sqrt(float64(d))
+	qg := q[qOff : qOff+group*d]
+	for t := start; t < steps; t++ {
+		tensai.DotVecs(qg, b.kc[t][kvOff:kvOff+d], ws[t*group:(t+1)*group])
+	}
+	for i := 0; i < group; i++ {
+		si := scores[i*steps : (i+1)*steps]
+		maxs := math.Inf(-1)
+		for t := start; t < steps; t++ {
+			s := float64(ws[t*group+i]) * scale
+			si[t] = s
+			if s > maxs {
+				maxs = s
+			}
+		}
+		h := kh*group + i
+		if b.sinks != nil && float64(b.sinks[h]) > maxs {
+			maxs = float64(b.sinks[h])
+		}
+		var sum float64
+		for t := start; t < steps; t++ {
+			si[t] = math.Exp(si[t] - maxs)
+			sum += si[t]
+		}
+		if b.sinks != nil {
+			// The sink is an extra softmax slot with no value: it only
+			// absorbs probability mass.
+			sum += math.Exp(float64(b.sinks[h]) - maxs)
+		}
+		for t := start; t < steps; t++ {
+			ws[t*group+i] = float32(si[t] / sum)
+		}
+	}
+	og := attn[qOff : qOff+group*d]
+	for t := start; t < steps; t++ {
+		tensai.Axpys(ws[t*group:(t+1)*group], b.vc[t][kvOff:kvOff+d], og)
 	}
 }
 
@@ -823,13 +883,14 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				scores := make([]float64, startPos+n)
+				scores := make([]float64, group*(startPos+n))
+				ws := make([]float32, group*(startPos+n))
 				for t := range rowCh {
 					steps := startPos + t + 1
 					qr := qkv.Data[t*qkvW : t*qkvW+qDim]
 					ar := attn.Data[t*qDim : (t+1)*qDim]
-					for h := 0; h < cfg.Heads; h++ {
-						m.attendHead(b, qr, ar, h, group, steps, scores[:steps])
+					for kh := 0; kh < cfg.KVHeads; kh++ {
+						m.attendGroup(b, qr, ar, kh, group, steps, scores, ws)
 					}
 				}
 			}()

--- a/kernels.go
+++ b/kernels.go
@@ -185,3 +185,19 @@ func axpyGeneric(a Float, x, y []Float) {
 		y[i] += a * x[i]
 	}
 }
+
+// dotVecsGeneric and axpysGeneric are the scalar bodies of the grouped
+// DotVecs and Axpys attention helpers.
+func dotVecsGeneric(qs, k []Float, out []Float) {
+	d := len(k)
+	for i := range out {
+		out[i] = dotVecGeneric(qs[i*d:(i+1)*d], k)
+	}
+}
+
+func axpysGeneric(ws []Float, v, outs []Float) {
+	d := len(v)
+	for i := range ws {
+		axpyGeneric(ws[i], v, outs[i*d:(i+1)*d])
+	}
+}

--- a/kernels_test.go
+++ b/kernels_test.go
@@ -178,3 +178,49 @@ func TestSiluMul(t *testing.T) {
 		}
 	}
 }
+
+// TestDotVecsAxpys pins the grouped attention helpers to their per-row
+// twins bit for bit, across group widths, head sizes, and both the
+// vector and sub-16 generic paths.
+func TestDotVecsAxpys(t *testing.T) {
+	rng := rand.New(rand.NewSource(63))
+	for _, d := range []int{8, 16, 64, 128, 130} {
+		for nq := 1; nq <= 8; nq++ {
+			qs := make([]Float, nq*d)
+			k := make([]Float, d)
+			for i := range qs {
+				qs[i] = Float(rng.NormFloat64())
+			}
+			for i := range k {
+				k[i] = Float(rng.NormFloat64())
+			}
+			out := make([]Float, nq)
+			DotVecs(qs, k, out)
+			for i := 0; i < nq; i++ {
+				if want := DotVec(qs[i*d:(i+1)*d], k); out[i] != want {
+					t.Fatalf("DotVecs d=%d nq=%d row %d: got %v want %v", d, nq, i, out[i], want)
+				}
+			}
+
+			ws := make([]Float, nq)
+			for i := range ws {
+				ws[i] = Float(rng.NormFloat64())
+			}
+			outs := make([]Float, nq*d)
+			ref := make([]Float, nq*d)
+			for i := range outs {
+				outs[i] = Float(rng.NormFloat64())
+				ref[i] = outs[i]
+			}
+			Axpys(ws, k, outs)
+			for i := 0; i < nq; i++ {
+				Axpy(ws[i], k, ref[i*d:(i+1)*d])
+			}
+			for i := range outs {
+				if outs[i] != ref[i] {
+					t.Fatalf("Axpys d=%d nq=%d elem %d: got %v want %v", d, nq, i, outs[i], ref[i])
+				}
+			}
+		}
+	}
+}

--- a/mathvec_generic.go
+++ b/mathvec_generic.go
@@ -34,3 +34,7 @@ func lnBwdRow(out, g, xhat, gamma, gradGamma, gradBeta []Float, invStd Float) {
 
 func dotVec(a, b []Float) Float  { return dotVecGeneric(a, b) }
 func axpy(a Float, x, y []Float) { axpyGeneric(a, x, y) }
+
+func dotVecs(qs, k []Float, out []Float) { dotVecsGeneric(qs, k, out) }
+
+func axpys(ws []Float, v, outs []Float) { axpysGeneric(ws, v, outs) }

--- a/mathvec_simd.go
+++ b/mathvec_simd.go
@@ -441,3 +441,489 @@ func axpy(a Float, x, y []Float) {
 		y[i] += a * x[i]
 	}
 }
+
+// dotVecs computes out[i] = qs[i*d:(i+1)*d] . k for the len(out) query
+// vectors packed contiguously in qs, streaming the shared k once for up
+// to four rows per pass. Each row keeps dotVec's exact accumulation
+// order — same chunked FMA, same linear horizontal sum, same scalar
+// tail — so every result is bit-identical to per-row dotVec.
+func dotVecs(qs, k []Float, out []Float) {
+	if !hasAVX2 || len(k) < 16 {
+		dotVecsGeneric(qs, k, out)
+		return
+	}
+	d := len(k)
+	switch len(out) {
+	case 8:
+		dotVec8(qs, k, out)
+		return
+	case 7:
+		dotVec7(qs, k, out)
+		return
+	case 6:
+		dotVec6(qs, k, out)
+		return
+	}
+	i := 0
+	for ; i+4 <= len(out); i += 4 {
+		dotVec4(qs[i*d:(i+4)*d], k, out[i:i+4])
+	}
+	if i+2 <= len(out) {
+		dotVec2(qs[i*d:(i+2)*d], k, out[i:i+2])
+		i += 2
+	}
+	if i < len(out) {
+		out[i] = dotVec(qs[i*d:(i+1)*d], k)
+	}
+}
+
+func dotVec4(qs, k []Float, out []Float) {
+	d := len(k)
+	q0 := qs[0*d : 1*d : 1*d]
+	q1 := qs[1*d : 2*d : 2*d]
+	q2 := qs[2*d : 3*d : 3*d]
+	q3 := qs[3*d : 4*d : 4*d]
+	n := d &^ 7
+	n2 := d &^ 15
+	var a0, a1, a2, a3 archsimd.Float32x8
+	// Two chunks per iteration: the four loop-carried accumulators make
+	// the compiler rotate registers at the back edge, so halving the
+	// trips halves that tax; the FMA order per accumulator is unchanged.
+	for i := 0; i < n2; i += 16 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		a2 = loadF32x8(q2[i:]).MulAdd(kv, a2)
+		a3 = loadF32x8(q3[i:]).MulAdd(kv, a3)
+		kw := loadF32x8(k[i+8:])
+		a0 = loadF32x8(q0[i+8:]).MulAdd(kw, a0)
+		a1 = loadF32x8(q1[i+8:]).MulAdd(kw, a1)
+		a2 = loadF32x8(q2[i+8:]).MulAdd(kw, a2)
+		a3 = loadF32x8(q3[i+8:]).MulAdd(kw, a3)
+	}
+	for i := n2; i < n; i += 8 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		a2 = loadF32x8(q2[i:]).MulAdd(kv, a2)
+		a3 = loadF32x8(q3[i:]).MulAdd(kv, a3)
+	}
+	// One buffer per accumulator, all stored before any is read: reusing
+	// a single slot chains the horizontal sums through store-to-load
+	// dependencies, and with six of them back to back per position there
+	// is no surrounding work to hide that latency under.
+	var buf0, buf1, buf2, buf3 [8]Float
+	storeF32x8(a0, buf0[:])
+	storeF32x8(a1, buf1[:])
+	storeF32x8(a2, buf2[:])
+	storeF32x8(a3, buf3[:])
+	s0 := buf0[0] + buf0[1] + buf0[2] + buf0[3] + buf0[4] + buf0[5] + buf0[6] + buf0[7]
+	s1 := buf1[0] + buf1[1] + buf1[2] + buf1[3] + buf1[4] + buf1[5] + buf1[6] + buf1[7]
+	s2 := buf2[0] + buf2[1] + buf2[2] + buf2[3] + buf2[4] + buf2[5] + buf2[6] + buf2[7]
+	s3 := buf3[0] + buf3[1] + buf3[2] + buf3[3] + buf3[4] + buf3[5] + buf3[6] + buf3[7]
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		s0 += q0[i] * k[i]
+		s1 += q1[i] * k[i]
+		s2 += q2[i] * k[i]
+		s3 += q3[i] * k[i]
+	}
+	out[0], out[1], out[2], out[3] = s0, s1, s2, s3
+}
+
+func dotVec2(qs, k []Float, out []Float) {
+	d := len(k)
+	q0 := qs[0*d : 1*d : 1*d]
+	q1 := qs[1*d : 2*d : 2*d]
+	n := d &^ 7
+	n2 := d &^ 15
+	var a0, a1 archsimd.Float32x8
+	for i := 0; i < n2; i += 16 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		kw := loadF32x8(k[i+8:])
+		a0 = loadF32x8(q0[i+8:]).MulAdd(kw, a0)
+		a1 = loadF32x8(q1[i+8:]).MulAdd(kw, a1)
+	}
+	for i := n2; i < n; i += 8 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+	}
+	var buf0, buf1 [8]Float
+	storeF32x8(a0, buf0[:])
+	storeF32x8(a1, buf1[:])
+	s0 := buf0[0] + buf0[1] + buf0[2] + buf0[3] + buf0[4] + buf0[5] + buf0[6] + buf0[7]
+	s1 := buf1[0] + buf1[1] + buf1[2] + buf1[3] + buf1[4] + buf1[5] + buf1[6] + buf1[7]
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		s0 += q0[i] * k[i]
+		s1 += q1[i] * k[i]
+	}
+	out[0], out[1] = s0, s1
+}
+
+// axpys accumulates outs[i*d:(i+1)*d] += ws[i] * v for the len(ws) rows
+// packed contiguously in outs, streaming the shared v once for up to
+// four rows per pass; per row it is bit-identical to axpy.
+func axpys(ws []Float, v, outs []Float) {
+	if !hasAVX2 || len(v) < 16 {
+		axpysGeneric(ws, v, outs)
+		return
+	}
+	d := len(v)
+	switch len(ws) {
+	case 8:
+		axpy8(ws, v, outs)
+		return
+	case 7:
+		axpy7(ws, v, outs)
+		return
+	case 6:
+		axpy6(ws, v, outs)
+		return
+	}
+	i := 0
+	for ; i+4 <= len(ws); i += 4 {
+		axpy4(ws[i:i+4], v, outs[i*d:(i+4)*d])
+	}
+	if i+2 <= len(ws) {
+		axpy2(ws[i:i+2], v, outs[i*d:(i+2)*d])
+		i += 2
+	}
+	if i < len(ws) {
+		axpy(ws[i], v, outs[i*d:(i+1)*d])
+	}
+}
+
+func axpy4(ws []Float, v, outs []Float) {
+	d := len(v)
+	o0 := outs[0*d : 1*d : 1*d]
+	o1 := outs[1*d : 2*d : 2*d]
+	o2 := outs[2*d : 3*d : 3*d]
+	o3 := outs[3*d : 4*d : 4*d]
+	w0 := archsimd.BroadcastFloat32x8(ws[0])
+	w1 := archsimd.BroadcastFloat32x8(ws[1])
+	w2 := archsimd.BroadcastFloat32x8(ws[2])
+	w3 := archsimd.BroadcastFloat32x8(ws[3])
+	n := d &^ 7
+	for i := 0; i < n; i += 8 {
+		vv := loadF32x8(v[i:])
+		storeF32x8(vv.MulAdd(w0, loadF32x8(o0[i:])), o0[i:])
+		storeF32x8(vv.MulAdd(w1, loadF32x8(o1[i:])), o1[i:])
+		storeF32x8(vv.MulAdd(w2, loadF32x8(o2[i:])), o2[i:])
+		storeF32x8(vv.MulAdd(w3, loadF32x8(o3[i:])), o3[i:])
+	}
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		o0[i] += ws[0] * v[i]
+		o1[i] += ws[1] * v[i]
+		o2[i] += ws[2] * v[i]
+		o3[i] += ws[3] * v[i]
+	}
+}
+
+func axpy2(ws []Float, v, outs []Float) {
+	d := len(v)
+	o0 := outs[0*d : 1*d : 1*d]
+	o1 := outs[1*d : 2*d : 2*d]
+	w0 := archsimd.BroadcastFloat32x8(ws[0])
+	w1 := archsimd.BroadcastFloat32x8(ws[1])
+	n := d &^ 7
+	for i := 0; i < n; i += 8 {
+		vv := loadF32x8(v[i:])
+		storeF32x8(vv.MulAdd(w0, loadF32x8(o0[i:])), o0[i:])
+		storeF32x8(vv.MulAdd(w1, loadF32x8(o1[i:])), o1[i:])
+	}
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		o0[i] += ws[0] * v[i]
+		o1[i] += ws[1] * v[i]
+	}
+}
+
+// dotVec6/7/8 and axpy6/7/8 are the single-pass forms for the group
+// widths real models use (llama 4, qwen 6-7, gpt-oss 8): one call, one
+// k stream, one horizontal-sum block per position.
+func dotVec6(qs, k []Float, out []Float) {
+	d := len(k)
+	q0 := qs[0*d : 1*d : 1*d]
+	q1 := qs[1*d : 2*d : 2*d]
+	q2 := qs[2*d : 3*d : 3*d]
+	q3 := qs[3*d : 4*d : 4*d]
+	q4 := qs[4*d : 5*d : 5*d]
+	q5 := qs[5*d : 6*d : 6*d]
+	n := d &^ 7
+	var a0, a1, a2, a3, a4, a5 archsimd.Float32x8
+	for i := 0; i < n; i += 8 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		a2 = loadF32x8(q2[i:]).MulAdd(kv, a2)
+		a3 = loadF32x8(q3[i:]).MulAdd(kv, a3)
+		a4 = loadF32x8(q4[i:]).MulAdd(kv, a4)
+		a5 = loadF32x8(q5[i:]).MulAdd(kv, a5)
+	}
+	var buf0, buf1, buf2, buf3, buf4, buf5 [8]Float
+	storeF32x8(a0, buf0[:])
+	storeF32x8(a1, buf1[:])
+	storeF32x8(a2, buf2[:])
+	storeF32x8(a3, buf3[:])
+	storeF32x8(a4, buf4[:])
+	storeF32x8(a5, buf5[:])
+	s0 := buf0[0] + buf0[1] + buf0[2] + buf0[3] + buf0[4] + buf0[5] + buf0[6] + buf0[7]
+	s1 := buf1[0] + buf1[1] + buf1[2] + buf1[3] + buf1[4] + buf1[5] + buf1[6] + buf1[7]
+	s2 := buf2[0] + buf2[1] + buf2[2] + buf2[3] + buf2[4] + buf2[5] + buf2[6] + buf2[7]
+	s3 := buf3[0] + buf3[1] + buf3[2] + buf3[3] + buf3[4] + buf3[5] + buf3[6] + buf3[7]
+	s4 := buf4[0] + buf4[1] + buf4[2] + buf4[3] + buf4[4] + buf4[5] + buf4[6] + buf4[7]
+	s5 := buf5[0] + buf5[1] + buf5[2] + buf5[3] + buf5[4] + buf5[5] + buf5[6] + buf5[7]
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		s0 += q0[i] * k[i]
+		s1 += q1[i] * k[i]
+		s2 += q2[i] * k[i]
+		s3 += q3[i] * k[i]
+		s4 += q4[i] * k[i]
+		s5 += q5[i] * k[i]
+	}
+	out[0] = s0
+	out[1] = s1
+	out[2] = s2
+	out[3] = s3
+	out[4] = s4
+	out[5] = s5
+}
+
+func dotVec7(qs, k []Float, out []Float) {
+	d := len(k)
+	q0 := qs[0*d : 1*d : 1*d]
+	q1 := qs[1*d : 2*d : 2*d]
+	q2 := qs[2*d : 3*d : 3*d]
+	q3 := qs[3*d : 4*d : 4*d]
+	q4 := qs[4*d : 5*d : 5*d]
+	q5 := qs[5*d : 6*d : 6*d]
+	q6 := qs[6*d : 7*d : 7*d]
+	n := d &^ 7
+	var a0, a1, a2, a3, a4, a5, a6 archsimd.Float32x8
+	for i := 0; i < n; i += 8 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		a2 = loadF32x8(q2[i:]).MulAdd(kv, a2)
+		a3 = loadF32x8(q3[i:]).MulAdd(kv, a3)
+		a4 = loadF32x8(q4[i:]).MulAdd(kv, a4)
+		a5 = loadF32x8(q5[i:]).MulAdd(kv, a5)
+		a6 = loadF32x8(q6[i:]).MulAdd(kv, a6)
+	}
+	var buf0, buf1, buf2, buf3, buf4, buf5, buf6 [8]Float
+	storeF32x8(a0, buf0[:])
+	storeF32x8(a1, buf1[:])
+	storeF32x8(a2, buf2[:])
+	storeF32x8(a3, buf3[:])
+	storeF32x8(a4, buf4[:])
+	storeF32x8(a5, buf5[:])
+	storeF32x8(a6, buf6[:])
+	s0 := buf0[0] + buf0[1] + buf0[2] + buf0[3] + buf0[4] + buf0[5] + buf0[6] + buf0[7]
+	s1 := buf1[0] + buf1[1] + buf1[2] + buf1[3] + buf1[4] + buf1[5] + buf1[6] + buf1[7]
+	s2 := buf2[0] + buf2[1] + buf2[2] + buf2[3] + buf2[4] + buf2[5] + buf2[6] + buf2[7]
+	s3 := buf3[0] + buf3[1] + buf3[2] + buf3[3] + buf3[4] + buf3[5] + buf3[6] + buf3[7]
+	s4 := buf4[0] + buf4[1] + buf4[2] + buf4[3] + buf4[4] + buf4[5] + buf4[6] + buf4[7]
+	s5 := buf5[0] + buf5[1] + buf5[2] + buf5[3] + buf5[4] + buf5[5] + buf5[6] + buf5[7]
+	s6 := buf6[0] + buf6[1] + buf6[2] + buf6[3] + buf6[4] + buf6[5] + buf6[6] + buf6[7]
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		s0 += q0[i] * k[i]
+		s1 += q1[i] * k[i]
+		s2 += q2[i] * k[i]
+		s3 += q3[i] * k[i]
+		s4 += q4[i] * k[i]
+		s5 += q5[i] * k[i]
+		s6 += q6[i] * k[i]
+	}
+	out[0] = s0
+	out[1] = s1
+	out[2] = s2
+	out[3] = s3
+	out[4] = s4
+	out[5] = s5
+	out[6] = s6
+}
+
+func dotVec8(qs, k []Float, out []Float) {
+	d := len(k)
+	q0 := qs[0*d : 1*d : 1*d]
+	q1 := qs[1*d : 2*d : 2*d]
+	q2 := qs[2*d : 3*d : 3*d]
+	q3 := qs[3*d : 4*d : 4*d]
+	q4 := qs[4*d : 5*d : 5*d]
+	q5 := qs[5*d : 6*d : 6*d]
+	q6 := qs[6*d : 7*d : 7*d]
+	q7 := qs[7*d : 8*d : 8*d]
+	n := d &^ 7
+	var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Float32x8
+	for i := 0; i < n; i += 8 {
+		kv := loadF32x8(k[i:])
+		a0 = loadF32x8(q0[i:]).MulAdd(kv, a0)
+		a1 = loadF32x8(q1[i:]).MulAdd(kv, a1)
+		a2 = loadF32x8(q2[i:]).MulAdd(kv, a2)
+		a3 = loadF32x8(q3[i:]).MulAdd(kv, a3)
+		a4 = loadF32x8(q4[i:]).MulAdd(kv, a4)
+		a5 = loadF32x8(q5[i:]).MulAdd(kv, a5)
+		a6 = loadF32x8(q6[i:]).MulAdd(kv, a6)
+		a7 = loadF32x8(q7[i:]).MulAdd(kv, a7)
+	}
+	var buf0, buf1, buf2, buf3, buf4, buf5, buf6, buf7 [8]Float
+	storeF32x8(a0, buf0[:])
+	storeF32x8(a1, buf1[:])
+	storeF32x8(a2, buf2[:])
+	storeF32x8(a3, buf3[:])
+	storeF32x8(a4, buf4[:])
+	storeF32x8(a5, buf5[:])
+	storeF32x8(a6, buf6[:])
+	storeF32x8(a7, buf7[:])
+	s0 := buf0[0] + buf0[1] + buf0[2] + buf0[3] + buf0[4] + buf0[5] + buf0[6] + buf0[7]
+	s1 := buf1[0] + buf1[1] + buf1[2] + buf1[3] + buf1[4] + buf1[5] + buf1[6] + buf1[7]
+	s2 := buf2[0] + buf2[1] + buf2[2] + buf2[3] + buf2[4] + buf2[5] + buf2[6] + buf2[7]
+	s3 := buf3[0] + buf3[1] + buf3[2] + buf3[3] + buf3[4] + buf3[5] + buf3[6] + buf3[7]
+	s4 := buf4[0] + buf4[1] + buf4[2] + buf4[3] + buf4[4] + buf4[5] + buf4[6] + buf4[7]
+	s5 := buf5[0] + buf5[1] + buf5[2] + buf5[3] + buf5[4] + buf5[5] + buf5[6] + buf5[7]
+	s6 := buf6[0] + buf6[1] + buf6[2] + buf6[3] + buf6[4] + buf6[5] + buf6[6] + buf6[7]
+	s7 := buf7[0] + buf7[1] + buf7[2] + buf7[3] + buf7[4] + buf7[5] + buf7[6] + buf7[7]
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		s0 += q0[i] * k[i]
+		s1 += q1[i] * k[i]
+		s2 += q2[i] * k[i]
+		s3 += q3[i] * k[i]
+		s4 += q4[i] * k[i]
+		s5 += q5[i] * k[i]
+		s6 += q6[i] * k[i]
+		s7 += q7[i] * k[i]
+	}
+	out[0] = s0
+	out[1] = s1
+	out[2] = s2
+	out[3] = s3
+	out[4] = s4
+	out[5] = s5
+	out[6] = s6
+	out[7] = s7
+}
+
+func axpy6(ws []Float, v, outs []Float) {
+	d := len(v)
+	o0 := outs[0*d : 1*d : 1*d]
+	o1 := outs[1*d : 2*d : 2*d]
+	o2 := outs[2*d : 3*d : 3*d]
+	o3 := outs[3*d : 4*d : 4*d]
+	o4 := outs[4*d : 5*d : 5*d]
+	o5 := outs[5*d : 6*d : 6*d]
+	w0 := archsimd.BroadcastFloat32x8(ws[0])
+	w1 := archsimd.BroadcastFloat32x8(ws[1])
+	w2 := archsimd.BroadcastFloat32x8(ws[2])
+	w3 := archsimd.BroadcastFloat32x8(ws[3])
+	w4 := archsimd.BroadcastFloat32x8(ws[4])
+	w5 := archsimd.BroadcastFloat32x8(ws[5])
+	n := d &^ 7
+	for i := 0; i < n; i += 8 {
+		vv := loadF32x8(v[i:])
+		storeF32x8(vv.MulAdd(w0, loadF32x8(o0[i:])), o0[i:])
+		storeF32x8(vv.MulAdd(w1, loadF32x8(o1[i:])), o1[i:])
+		storeF32x8(vv.MulAdd(w2, loadF32x8(o2[i:])), o2[i:])
+		storeF32x8(vv.MulAdd(w3, loadF32x8(o3[i:])), o3[i:])
+		storeF32x8(vv.MulAdd(w4, loadF32x8(o4[i:])), o4[i:])
+		storeF32x8(vv.MulAdd(w5, loadF32x8(o5[i:])), o5[i:])
+	}
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		o0[i] += ws[0] * v[i]
+		o1[i] += ws[1] * v[i]
+		o2[i] += ws[2] * v[i]
+		o3[i] += ws[3] * v[i]
+		o4[i] += ws[4] * v[i]
+		o5[i] += ws[5] * v[i]
+	}
+}
+
+func axpy7(ws []Float, v, outs []Float) {
+	d := len(v)
+	o0 := outs[0*d : 1*d : 1*d]
+	o1 := outs[1*d : 2*d : 2*d]
+	o2 := outs[2*d : 3*d : 3*d]
+	o3 := outs[3*d : 4*d : 4*d]
+	o4 := outs[4*d : 5*d : 5*d]
+	o5 := outs[5*d : 6*d : 6*d]
+	o6 := outs[6*d : 7*d : 7*d]
+	w0 := archsimd.BroadcastFloat32x8(ws[0])
+	w1 := archsimd.BroadcastFloat32x8(ws[1])
+	w2 := archsimd.BroadcastFloat32x8(ws[2])
+	w3 := archsimd.BroadcastFloat32x8(ws[3])
+	w4 := archsimd.BroadcastFloat32x8(ws[4])
+	w5 := archsimd.BroadcastFloat32x8(ws[5])
+	w6 := archsimd.BroadcastFloat32x8(ws[6])
+	n := d &^ 7
+	for i := 0; i < n; i += 8 {
+		vv := loadF32x8(v[i:])
+		storeF32x8(vv.MulAdd(w0, loadF32x8(o0[i:])), o0[i:])
+		storeF32x8(vv.MulAdd(w1, loadF32x8(o1[i:])), o1[i:])
+		storeF32x8(vv.MulAdd(w2, loadF32x8(o2[i:])), o2[i:])
+		storeF32x8(vv.MulAdd(w3, loadF32x8(o3[i:])), o3[i:])
+		storeF32x8(vv.MulAdd(w4, loadF32x8(o4[i:])), o4[i:])
+		storeF32x8(vv.MulAdd(w5, loadF32x8(o5[i:])), o5[i:])
+		storeF32x8(vv.MulAdd(w6, loadF32x8(o6[i:])), o6[i:])
+	}
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		o0[i] += ws[0] * v[i]
+		o1[i] += ws[1] * v[i]
+		o2[i] += ws[2] * v[i]
+		o3[i] += ws[3] * v[i]
+		o4[i] += ws[4] * v[i]
+		o5[i] += ws[5] * v[i]
+		o6[i] += ws[6] * v[i]
+	}
+}
+
+func axpy8(ws []Float, v, outs []Float) {
+	d := len(v)
+	o0 := outs[0*d : 1*d : 1*d]
+	o1 := outs[1*d : 2*d : 2*d]
+	o2 := outs[2*d : 3*d : 3*d]
+	o3 := outs[3*d : 4*d : 4*d]
+	o4 := outs[4*d : 5*d : 5*d]
+	o5 := outs[5*d : 6*d : 6*d]
+	o6 := outs[6*d : 7*d : 7*d]
+	o7 := outs[7*d : 8*d : 8*d]
+	w0 := archsimd.BroadcastFloat32x8(ws[0])
+	w1 := archsimd.BroadcastFloat32x8(ws[1])
+	w2 := archsimd.BroadcastFloat32x8(ws[2])
+	w3 := archsimd.BroadcastFloat32x8(ws[3])
+	w4 := archsimd.BroadcastFloat32x8(ws[4])
+	w5 := archsimd.BroadcastFloat32x8(ws[5])
+	w6 := archsimd.BroadcastFloat32x8(ws[6])
+	w7 := archsimd.BroadcastFloat32x8(ws[7])
+	n := d &^ 7
+	for i := 0; i < n; i += 8 {
+		vv := loadF32x8(v[i:])
+		storeF32x8(vv.MulAdd(w0, loadF32x8(o0[i:])), o0[i:])
+		storeF32x8(vv.MulAdd(w1, loadF32x8(o1[i:])), o1[i:])
+		storeF32x8(vv.MulAdd(w2, loadF32x8(o2[i:])), o2[i:])
+		storeF32x8(vv.MulAdd(w3, loadF32x8(o3[i:])), o3[i:])
+		storeF32x8(vv.MulAdd(w4, loadF32x8(o4[i:])), o4[i:])
+		storeF32x8(vv.MulAdd(w5, loadF32x8(o5[i:])), o5[i:])
+		storeF32x8(vv.MulAdd(w6, loadF32x8(o6[i:])), o6[i:])
+		storeF32x8(vv.MulAdd(w7, loadF32x8(o7[i:])), o7[i:])
+	}
+	archsimd.ClearAVXUpperBits()
+	for i := n; i < d; i++ {
+		o0[i] += ws[0] * v[i]
+		o1[i] += ws[1] * v[i]
+		o2[i] += ws[2] * v[i]
+		o3[i] += ws[3] * v[i]
+		o4[i] += ws[4] * v[i]
+		o5[i] += ws[5] * v[i]
+		o6[i] += ws[6] * v[i]
+		o7[i] += ws[7] * v[i]
+	}
+}

--- a/tensor.go
+++ b/tensor.go
@@ -317,3 +317,26 @@ func SiluMul(gate, up []Float) {
 	}
 	siluMul(gate, up)
 }
+
+// DotVecs is the grouped-query form of DotVec: out[i] gets the dot of k
+// with the i-th of len(out) query vectors packed contiguously in qs, the
+// shared k streamed once for up to four of them per pass — the score
+// kernel of grouped-query attention, where several query heads share one
+// cached key row. Every result is bit-identical to the matching DotVec.
+func DotVecs(qs, k []Float, out []Float) {
+	if len(qs) != len(out)*len(k) {
+		panic("tensai: DotVecs length mismatch")
+	}
+	dotVecs(qs, k, out)
+}
+
+// Axpys is the grouped form of Axpy: the i-th of len(ws) rows packed
+// contiguously in outs accumulates ws[i]*v, the shared v streamed once
+// for up to four rows per pass — grouped-query attention's weighted
+// value accumulation. Bit-identical to per-row Axpy.
+func Axpys(ws []Float, v, outs []Float) {
+	if len(outs) != len(ws)*len(v) {
+		panic("tensai: Axpys length mismatch")
+	}
+	axpys(ws, v, outs)
+}


### PR DESCRIPTION
Grouped-query attention scores every query head against the same cached rows, and prefill walked them one head at a time — each k and v row re-streamed once per query head, each 128-float pass paying its own call, bounds, and horizontal-sum overhead. New DotVecs/Axpys helpers process all the query heads sharing one KV head in a single pass per cached row: one k stream feeds up to eight dot accumulators, one v stream feeds up to eight output rows. Per head the arithmetic order matches DotVec/Axpy exactly, so outputs are bit-identical (pinned by a new test across group widths 1–8 and both build flavors; dense and gpt-oss E2E outputs diffed identical).

Two findings shaped the kernels. Reusing one stack buffer for the horizontal sums chained them through store-to-load dependencies, and with six back to back per position there is no surrounding work to hide that latency under — separate buffers per accumulator, all stored before any is read, took the grouped path from 1.6x slower than the per-head loop to 1.15x faster. And the leftover-block split (4+2) spent almost as much in the two-row call as the four-row one, so the group widths real models use (llama 4, qwen 6–7, gpt-oss 8) get single-pass kernels: 1.57x over the per-head loop on the isolated 900-step microbenchmark, ~7–10% on a 921-token 1.5B Q4_K_M prefill.

Decode keeps the per-head path: at practical context lengths the KV rows sit in L3 anyway, so shared streaming buys nothing there, while fanning out only kvHeads goroutines instead of heads cost 20% — measured, and retreated from.