### PR TITLE
qwen: prefer cached fast Q8 weights

### DIFF
--- a/_example/qwen/gguf.go
+++ b/_example/qwen/gguf.go
@@ -1223,6 +1223,18 @@ func loadGGUF(path string, bits int, direct, cache bool) (*qwen, *tokenizer.Toke
 	// A valid repack cache stands in for the whole tensor load: the
 	// weights map straight from the cache file as clean pages.
 	useCache := cache && bits != 0
+	// Requantization's per-column scales decode materially faster than
+	// the direct Q8_0 group scales. Once a user has paid its one-time
+	// conversion cost, prefer that valid cache on ordinary -q8 runs too.
+	// A missing, stale, or corrupt fast cache silently leaves the normal
+	// direct-repack path unchanged.
+	if useCache && direct && bits == 8 {
+		fastPath := cachePath(path, bits, false)
+		if m, err := loadWeightCache(fastPath, path, bits, false, cfg, headSz); err == nil {
+			fmt.Fprintf(os.Stderr, "using faster requantized cache: %s\n", fastPath)
+			return m, tok, nil
+		}
+	}
 	cpath := cachePath(path, bits, direct)
 	if useCache {
 		if m, err := loadWeightCache(cpath, path, bits, direct, cfg, headSz); err == nil {


### PR DESCRIPTION
## Summary
- prefer a valid requantized Q8 cache during ordinary CPU `-q8` runs
- preserve the direct repack path when the fast cache is missing, stale, or corrupt

## Performance
Qwen2.5-0.5B Q8_0, 128-token decode, Ryzen 7 7735HS:
- direct cache: 38.1-39.5 tok/s
- requantized cache: 43.4-45.9 tok/s
- improvement: approximately 14%

## Validation
- `go test ./...`
- `GOEXPERIMENT=simd go test ./...`