### PR TITLE
qwen: reuse sampling scratch buffers

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -26,6 +26,7 @@ import (
 	"runtime/pprof"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	tensai "github.com/mattn/tensai"
@@ -33,6 +34,18 @@ import (
 )
 
 const defaultRepo = "Qwen/Qwen2.5-0.5B-Instruct"
+
+type sampleCandidate struct {
+	id int
+	p  float64
+}
+
+type sampleScratch struct {
+	ps    []float64
+	cands []sampleCandidate
+}
+
+var sampleScratchPool sync.Pool
 
 // hfBase is derived from the -repo flag before any download starts.
 var hfBase = "https://huggingface.co/" + defaultRepo + "/resolve/main/"
@@ -138,13 +151,25 @@ func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 		}
 		return best
 	}
+	scratch, _ := sampleScratchPool.Get().(*sampleScratch)
+	if scratch == nil {
+		scratch = &sampleScratch{}
+	}
+	if cap(scratch.ps) < len(logits) {
+		scratch.ps = make([]float64, len(logits))
+	}
+	ps := scratch.ps[:len(logits)]
+	cands := scratch.cands[:0]
+	defer func() {
+		scratch.cands = cands[:0]
+		sampleScratchPool.Put(scratch)
+	}()
 	maxl := logits[0]
 	for _, v := range logits {
 		if v > maxl {
 			maxl = v
 		}
 	}
-	ps := make([]float64, len(logits))
 	var sum float64
 	for i, v := range logits {
 		p := math.Exp(float64(v-maxl) / temp)
@@ -194,14 +219,9 @@ func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 			break
 		}
 	}
-	type cand struct {
-		id int
-		p  float64
-	}
-	var cands []cand
 	for i, p := range ps {
 		if p > 0 && bucket(p) <= cut {
-			cands = append(cands, cand{i, p})
+			cands = append(cands, sampleCandidate{i, p})
 		}
 	}
 	sort.Slice(cands, func(a, b int) bool { return cands[a].p > cands[b].p })

--- a/_example/qwen/main_test.go
+++ b/_example/qwen/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkSample(b *testing.B) {
+	logits := make([]float32, 151936)
+	for i := range logits {
+		logits[i] = float32((i*7919)%10000)/1000 - 10
+	}
+	rng := rand.New(rand.NewSource(1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sample(logits, 0.8, 0.9, rng)
+	}
+}


### PR DESCRIPTION
## Summary
- reuse the full-vocabulary probability buffer across temperature samples
- reuse the nucleus candidate backing array
- add a focused sampling benchmark

## Performance
151,936-logit top-p sample on Ryzen 7 7735HS:
- before: ~8.7 ms/op, 3.88 MB/op, 28 allocs/op
- after: ~7.2 ms/op, typically under 24 KB/op, 3 allocs/op
- sampling itself is approximately 17% faster

Seeded 128-token output remains byte-for-byte identical.

## Validation
- `go test ./...`
- `GOEXPERIMENT=simd go test ./...`
- `GOEXPERIMENT=simd go test -race ./_example/qwen`