### PR TITLE
qwen: reuse sampling probability buckets

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -41,8 +41,9 @@ type sampleCandidate struct {
 }
 
 type sampleScratch struct {
-	ps    []float64
-	cands []sampleCandidate
+	ps      []float64
+	buckets []uint16
+	cands   []sampleCandidate
 }
 
 var sampleScratchPool sync.Pool
@@ -159,6 +160,10 @@ func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 		scratch.ps = make([]float64, len(logits))
 	}
 	ps := scratch.ps[:len(logits)]
+	if cap(scratch.buckets) < len(logits) {
+		scratch.buckets = make([]uint16, len(logits))
+	}
+	buckets := scratch.buckets[:len(logits)]
 	cands := scratch.cands[:0]
 	defer func() {
 		scratch.cands = cands[:0]
@@ -204,9 +209,11 @@ func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 		}
 		return b
 	}
-	for _, p := range ps {
+	for i, p := range ps {
 		if p > 0 {
-			bsum[bucket(p)] += p
+			b := bucket(p)
+			buckets[i] = uint16(b)
+			bsum[b] += p
 		}
 	}
 	target := topP * sum
@@ -220,7 +227,7 @@ func sample(logits []float32, temp, topP float64, rng *rand.Rand) int {
 		}
 	}
 	for i, p := range ps {
-		if p > 0 && bucket(p) <= cut {
+		if p > 0 && int(buckets[i]) <= cut {
 			cands = append(cands, sampleCandidate{i, p})
 		}
 	}


### PR DESCRIPTION
## Summary
- retain the exponent bucket for each probability during histogram construction
- reuse it during nucleus candidate selection instead of calling `math.Ilogb` twice
- preserve candidate ordering and seeded output exactly

## Performance
151,936-logit top-p sampling benchmark:
- before: ~7.2 ms/op
- after: ~6.32 ms/op
- improvement over the previous scratch-buffer implementation: approximately 12%
- cumulative improvement over the original sampler: approximately 27%

## Validation
- `GOEXPERIMENT=simd go test ./...`
- `GOEXPERIMENT=simd go test -race ./_example/qwen`
- byte-for-byte seeded 128-token output comparison