### PR TITLE
Scale MatMul worker count by batch rows

### DIFF
--- a/quant.go
+++ b/quant.go
@@ -274,7 +274,7 @@ func (q *QMatrix) MatMul(x, out *Matrix) error {
 			}
 		}
 	}
-	workers := matvecWorkerCount(q.Cols, q.Rows)
+	workers := matvecWorkerCount(q.Cols, q.Rows*rows)
 	if workers == 1 {
 		run(0, q.Cols)
 		return nil

--- a/quant4.go
+++ b/quant4.go
@@ -274,7 +274,7 @@ func (q *Q4Matrix) MatMul(x, out *Matrix) error {
 			}
 		}
 	}
-	workers := matvecWorkerCount(q.Cols, q.Rows)
+	workers := matvecWorkerCount(q.Cols, q.Rows*rows)
 	if workers == 1 {
 		run(0, q.Cols)
 		return nil

--- a/quant8g.go
+++ b/quant8g.go
@@ -122,7 +122,7 @@ func (q *Q8GMatrix) MatMul(x, out *Matrix) error {
 			}
 		}
 	}
-	workers := matvecWorkerCount(q.Cols, q.Rows)
+	workers := matvecWorkerCount(q.Cols, q.Rows*rows)
 	if workers == 1 {
 		run(0, q.Cols)
 		return nil


### PR DESCRIPTION
The batched MatMul paths sized their worker pool with matvecWorkerCount, which looks only at the weight matrix and is tuned for single-token matvecs. The QKV projection (896x1152) falls just under its 1<<20 threshold, so prefill ran every attention projection on a single goroutine no matter how many tokens were in the batch. Multiply by the batch row count so the threshold reflects the actual work: a 551-token Q8 prefill of Qwen2.5-0.5B drops from 2.71s to 1.60s (204 -> 345 tok/s) on a Ryzen 7 7735HS, with decode speed and greedy output unchanged.