### PR TITLE
Prepack Q8 batch activations and batch KV cache rows

### DIFF
--- a/_example/qwen/model.go
+++ b/_example/qwen/model.go
@@ -850,6 +850,10 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 		b := &m.blocks[li]
 		norm(b.ln1)
 		qkv := mmb(a, b.wQKV, b.qQKV, b.bQKV)
+		// Two batch-wide backings detach the cache rows from the wide
+		// fused buffer instead of 2n little allocations per layer.
+		kb := make([]float32, n*kvDim)
+		vb := make([]float32, n*kvDim)
 		for t := 0; t < n; t++ {
 			pos := startPos + t
 			row := qkv.Data[t*qkvW : (t+1)*qkvW]
@@ -865,9 +869,12 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 					m.rope(kr[h*m.headSz:(h+1)*m.headSz], pos, b)
 				}
 			}
-			// Copies detach the cache rows from the wide fused buffer.
-			b.kc = append(b.kc, append(make([]float32, 0, kvDim), kr...))
-			b.vc = append(b.vc, append(make([]float32, 0, kvDim), row[qDim+kvDim:]...))
+			kt := kb[t*kvDim : (t+1)*kvDim : (t+1)*kvDim]
+			vt := vb[t*kvDim : (t+1)*kvDim : (t+1)*kvDim]
+			copy(kt, kr)
+			copy(vt, row[qDim+kvDim:])
+			b.kc = append(b.kc, kt)
+			b.vc = append(b.vc, vt)
 		}
 
 		// Causal attention: row t sees cache positions [0, startPos+t].

--- a/quant.go
+++ b/quant.go
@@ -39,6 +39,23 @@ func padRows8(xus [][]uint8, sxs []Float, rowLen, cols int) ([][]uint8, []Float,
 	return pxus, psxs, NewMatrix(8, cols)
 }
 
+// packQuadsRows8 packs eight quantized activation rows into the
+// quad-major interleaved stream the batched kernels broadcast from:
+// entry i4*8+r holds row r's quad i4, so the inner loop walks one
+// contiguous group of eight per weight load. Packing here runs once
+// per row block instead of once per column chunk.
+func packQuadsRows8(xus [][]uint8) []uint32 {
+	quads := len(xus[0]) / 4
+	xq := make([]uint32, 8*quads)
+	for r, xu := range xus {
+		for i4 := 0; i4 < quads; i4++ {
+			xq[i4*8+r] = uint32(xu[4*i4]) | uint32(xu[4*i4+1])<<8 |
+				uint32(xu[4*i4+2])<<16 | uint32(xu[4*i4+3])<<24
+		}
+	}
+	return xq
+}
+
 // parallelChunks splits [0, n) into align-rounded chunks across the
 // workers, the calling goroutine taking the first chunk itself: a
 // matvec fan-out spawns workers-1 goroutines and the caller streams
@@ -256,19 +273,25 @@ func (q *QMatrix) MatMul(x, out *Matrix) error {
 	// shared by every column chunk (they write disjoint ranges), and
 	// only the real rows copy back — so the tail streams the weights
 	// once instead of once per row.
+	xqb := make([][]uint32, rows/8)
+	for b := range xqb {
+		xqb[b] = packQuadsRows8(xus[b*8 : b*8+8])
+	}
 	var pxus [][]uint8
+	var pxq []uint32
 	var psxs []Float
 	var scratch *Matrix
 	if rows%8 != 0 {
 		pxus, psxs, scratch = padRows8(xus[rows-rows%8:], sxs[rows-rows%8:], len(xus[0]), q.Cols)
+		pxq = packQuadsRows8(pxus)
 	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+8 <= rows; r += 8 {
-			qmatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+			qmatmulRows8(out, xus[r:r+8], xqb[r/8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 		}
 		if r < rows {
-			qmatmulRows8(scratch, pxus, psxs, 0, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
+			qmatmulRows8(scratch, pxus, pxq, psxs, 0, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 			for i := 0; i < rows-r; i++ {
 				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
 			}

--- a/quant8g.go
+++ b/quant8g.go
@@ -104,19 +104,25 @@ func (q *Q8GMatrix) MatMul(x, out *Matrix) error {
 	// shared by every column chunk (they write disjoint ranges), and
 	// only the real rows copy back — so the tail streams the weights
 	// once instead of once per row.
+	xqb := make([][]uint32, rows/8)
+	for b := range xqb {
+		xqb[b] = packQuadsRows8(xus[b*8 : b*8+8])
+	}
 	var pxus [][]uint8
+	var pxq []uint32
 	var psxs []Float
 	var scratch *Matrix
 	if rows%8 != 0 {
 		pxus, psxs, scratch = padRows8(xus[rows-rows%8:], sxs[rows-rows%8:], len(xus[0]), q.Cols)
+		pxq = packQuadsRows8(pxus)
 	}
 	run := func(lo, hi int) {
 		var r int
 		for ; r+8 <= rows; r += 8 {
-			q8gMatmulRows8(out, xus[r:r+8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
+			q8gMatmulRows8(out, xus[r:r+8], xqb[r/8], sxs[r:r+8], r, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
 		}
 		if r < rows {
-			q8gMatmulRows8(scratch, pxus, psxs, 0, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
+			q8gMatmulRows8(scratch, pxus, pxq, psxs, 0, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
 			for i := 0; i < rows-r; i++ {
 				copy(out.Data[(r+i)*q.Cols+lo:(r+i)*q.Cols+hi], scratch.Data[i*q.Cols+lo:i*q.Cols+hi])
 			}

--- a/quant8g_generic.go
+++ b/quant8g_generic.go
@@ -9,6 +9,6 @@ func q8gMatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, 
 	q8gMatvecColsGeneric(out, xu, sx, qw, scale, colSum64, group, cols, lo, hi)
 }
 
-func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, group, cols, lo, hi int) {
+func q8gMatmulRows8(out *Matrix, xus [][]uint8, xq []uint32, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, group, cols, lo, hi int) {
 	q8gMatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, group, cols, lo, hi)
 }

--- a/quant8g_simd.go
+++ b/quant8g_simd.go
@@ -70,19 +70,13 @@ func q8gMatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, 
 // q8gMatmulRows8 is the eight-row batched form: per eight-column step
 // each 32-byte weight load feeds eight broadcast activation quads, with
 // steps outermost so both streams advance sequentially.
-func q8gMatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, group, cols, lo, hi int) {
+func q8gMatmulRows8(out *Matrix, xus [][]uint8, xq []uint32, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, group, cols, lo, hi int) {
 	if !hasAVX2 {
 		q8gMatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, group, cols, lo, hi)
 		return
 	}
 	quads := len(xus[0]) / 4
 	groups := (len(xus[0]) + group - 1) / group
-	xq := make([]uint32, 8*quads)
-	for r := 0; r < 8; r++ {
-		for i4 := 0; i4 < quads; i4++ {
-			xq[i4*8+r] = qxQuad(xus[r], i4)
-		}
-	}
 	ones := archsimd.BroadcastInt16x16(1)
 	vecEnd := lo + ((hi - lo) &^ 7)
 	if vecEnd > lo {

--- a/quant_generic.go
+++ b/quant_generic.go
@@ -9,6 +9,6 @@ func qmatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, co
 	qmatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, lo, hi)
 }
 
-func qmatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+func qmatmulRows8(out *Matrix, xus [][]uint8, xq []uint32, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, cols, lo, hi int) {
 	qmatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
 }

--- a/quant_simd.go
+++ b/quant_simd.go
@@ -59,22 +59,16 @@ func qmatvecCols(out []Float, xu []uint8, sx Float, qw []int8, scale []Float, co
 // 32-byte weight load feeds eight broadcast activation quads, so the
 // weight stream that dominates a single matvec amortizes eightfold while
 // every row still costs just the two multiplies per load.
-func qmatmulRows8(out *Matrix, xus [][]uint8, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, cols, lo, hi int) {
+func qmatmulRows8(out *Matrix, xus [][]uint8, xq []uint32, sxs []Float, r0 int, qw []int8, scale []Float, colSum64 []int32, cols, lo, hi int) {
 	if !hasAVX2 {
 		qmatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
 		return
 	}
 	quads := len(xus[0]) / 4
-	// The packed activation quads, interleaved per quad row so the inner
-	// loop walks one contiguous stream. Accumulators are eight named
-	// variables: an array of SIMD values would live on the stack and turn
-	// every multiply-add into a load-op-store round trip.
-	xq := make([]uint32, 8*quads)
-	for r := 0; r < 8; r++ {
-		for i4 := 0; i4 < quads; i4++ {
-			xq[i4*8+r] = qxQuad(xus[r], i4)
-		}
-	}
+	// xq holds the caller-packed activation quads, interleaved per quad
+	// row so the inner loop walks one contiguous stream. Accumulators are
+	// eight named variables: an array of SIMD values would live on the
+	// stack and turn every multiply-add into a load-op-store round trip.
 	ones := archsimd.BroadcastInt16x16(1)
 	vecEnd := lo + ((hi - lo) &^ 7)
 	for jt := lo; jt < vecEnd; jt += 8 {


### PR DESCRIPTION
The Q8 batch kernels packed the eight activation rows into their interleaved quad stream on every call, repeating the same packing and its allocation once per column chunk per row block; MatMul now packs each row block once and passes the stream in, as the Q4 path has done since #95. qwen's forwardBatch also allocated two small cache-row copies per token per layer to detach them from the fused QKV buffer; two batch-wide backings per layer replace those, cutting GC scan work during prefill. A 551-token Q8 prefill of Qwen2.5-0.5B drops from 1.74s to 1.43s (317 -> 385 tok/s) on a Ryzen 7 7735HS, with greedy output identical and decode speed unchanged.