### PR TITLE
Warm GPU kernels at model upload instead of the first prefill

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -172,6 +172,15 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 		l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
 		l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
 	}
+	// Warm every kernel the decode and both prefill batch sizes touch:
+	// drivers like dozen compile a pipeline's GPU code at first dispatch,
+	// which otherwise lands in the first timed prefill. The dummy tokens
+	// rewind afterwards, and the real prefill overwrites their cache rows.
+	warm := make([]int, 33)
+	gq.prefill(warm, 0)
+	gq.prefill(warm[:4], 33)
+	gq.step(0, 37)
+	gq.gpuLen = 0
 	return gq, nil
 }
 


### PR DESCRIPTION
Drivers like dozen compile a pipeline's GPU code at its first dispatch, so the first timed prefill carried a few hundred milliseconds of one-off compilation. newGPUQwen now feeds dummy tokens through both prefill batch shapes and one decode step, then rewinds the cache; the real prefill overwrites the dummy rows. On dozen the first 551-token Q8 prefill of Qwen2.5-0.5B improves from 0.86s to 0.74s best-case, with the compile time moving into the reported upload phase.