### PR TITLE
Split GPU prefill into chunks that fit the storage-buffer limit

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -191,6 +191,28 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 // next-token logits after the last position. With this, -gpu never
 // touches the CPU KV cache at all.
 func (gq *gpuQwen) prefill(tokens []int, startPos int) []float32 {
+	// The widest intermediate is a gate/up projection row, so batches
+	// whose activations would exceed the device's storage-buffer limit
+	// split into chunks; the KV cache carries across them.
+	chunk := len(tokens)
+	if lim := gq.g.StorageLimit(); lim > 0 {
+		w := gq.m.cfg.Intermediate
+		if gq.m.cfg.MoeFF > w {
+			w = gq.m.cfg.MoeFF
+		}
+		if c := int(lim / uint64(4*w)); c > 0 && c < chunk {
+			chunk = c
+		}
+	}
+	for len(tokens) > chunk {
+		gq.prefillChunk(tokens[:chunk], startPos)
+		tokens = tokens[chunk:]
+		startPos += chunk
+	}
+	return gq.prefillChunk(tokens, startPos)
+}
+
+func (gq *gpuQwen) prefillChunk(tokens []int, startPos int) []float32 {
 	m := gq.m
 	cfg := m.cfg
 	hs := cfg.HiddenSize


### PR DESCRIPTION
A long prompt's gate/up activations can exceed the device's per-buffer storage limit — dozen allows 128MiB, which a ~4600-token prefill of Qwen2.5-1.5B overruns — and the whole request panicked. prefill now splits the batch so the widest intermediate stays under the limit, carrying the KV cache across chunks. Found running a 100-note nostr timeline summary through the -serve API on the GPU.