### PR TITLE
Cap GPU prefill chunks at 512 tokens

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -191,10 +191,12 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 // next-token logits after the last position. With this, -gpu never
 // touches the CPU KV cache at all.
 func (gq *gpuQwen) prefill(tokens []int, startPos int) []float32 {
-	// The widest intermediate is a gate/up projection row, so batches
-	// whose activations would exceed the device's storage-buffer limit
-	// split into chunks; the KV cache carries across them.
-	chunk := len(tokens)
+	// Batches split into chunks, the KV cache carrying across them: the
+	// widest intermediate (a gate/up projection row) must fit the
+	// device's storage-buffer limit, and a chunk caps at 512 tokens so
+	// no single submission runs long enough for the OS's GPU watchdog
+	// (Windows TDR behind dozen) to declare the device lost.
+	chunk := 512
 	if lim := gq.g.StorageLimit(); lim > 0 {
 		w := gq.m.cfg.Intermediate
 		if gq.m.cfg.MoeFF > w {


### PR DESCRIPTION
A prefill chunk runs as one submission since the single-pass batching, and a multi-second submission risks the OS's GPU watchdog (Windows TDR behind dozen) declaring the device lost, which killed a 1.5B serve mid-request. 512 tokens keeps each submission short; the extra chunk boundaries cost a few milliseconds on a 0.5B prefill.