### PR TITLE
Keep the GPU KV cache in half precision where shader-f16 exists

### DIFF
--- a/_example/qwen/gpu.go
+++ b/_example/qwen/gpu.go
@@ -133,6 +133,10 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 	hs := m.cfg.Heads * m.headSz // query dimension; equals hidden except qwen3
 	inter := m.cfg.Intermediate
 	gq := &gpuQwen{m: m, g: g, nCtx: nCtx, layers: make([]gpuLayer, len(m.blocks))}
+	// A half-precision KV cache halves the resident cache when the device
+	// has shader-f16 and the model's head grouping fits the f16 kernel.
+	group := m.cfg.Heads / m.cfg.KVHeads
+	useF16 := g.HasF16() && group > 1 && group <= 8 && m.headSz <= 256
 	// upSlice uploads a column range of a fused weight in whichever width
 	// it was quantized to; up uploads a whole one.
 	upSlice := func(q *qmat, lo, hi int) gpuMat {
@@ -170,8 +174,13 @@ func newGPUQwen(m *qwen, g *tensai.GPU, nCtx int) (*gpuQwen, error) {
 		l.qGate = upSlice(b.qGU, 0, inter)
 		l.qUp = upSlice(b.qGU, inter, 2*inter)
 		l.qDown = up(b.qDown)
-		l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
-		l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+		if useF16 {
+			l.kc = must(g.NewF16Tensor(nCtx, kvDim))
+			l.vc = must(g.NewF16Tensor(nCtx, kvDim))
+		} else {
+			l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+			l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+		}
 	}
 	// Warm every kernel the decode and both prefill batch sizes touch:
 	// drivers like dozen compile a pipeline's GPU code at first dispatch,

--- a/wgpu.go
+++ b/wgpu.go
@@ -39,7 +39,9 @@ type GPU struct {
 	queue      uintptr
 	module     uintptr
 	module2    uintptr // optional integer-dot module; 0 if unsupported
+	module3    uintptr // optional f16 module; 0 if unsupported
 	hasIntDot  bool
+	hasF16     bool
 	pipes      gpuPipelines
 	readback   gpuReadbackBuffer
 	pool       gpuBufferPool
@@ -542,6 +544,7 @@ func (g *GPU) Close() {
 		fn func(uintptr)
 		h  uintptr
 	}{
+		{fnShaderModRelease, g.module3},
 		{fnShaderModRelease, g.module2},
 		{fnShaderModRelease, g.module},
 		{fnQueueRelease, g.queue},

--- a/wgpu24.go
+++ b/wgpu24.go
@@ -44,7 +44,9 @@ type GPU struct {
 	queue      uintptr
 	module     uintptr
 	module2    uintptr // optional integer-dot module; 0 if unsupported
+	module3    uintptr // optional f16 module; 0 if unsupported
 	hasIntDot  bool
+	hasF16     bool
 	pipes      gpuPipelines
 	readback   gpuReadbackBuffer
 	pool       gpuBufferPool
@@ -268,6 +270,7 @@ type wgpuAdapterInfo struct {
 var (
 	fnCreateInstance          func(*wgpuInstanceDescriptor) uintptr
 	fnAdapterGetInfo          func(uintptr, *wgpuAdapterInfo) uint32
+	fnAdapterHasFeature       func(uintptr, uint32) uint32
 	fnAdapterGetLimits        func(uintptr, *wgpuLimits) uint32
 	fnDeviceGetQueue          func(uintptr) uintptr
 	fnDeviceCreateShaderMod   func(uintptr, *wgpuShaderModuleDescriptor) uintptr
@@ -380,6 +383,7 @@ func loadWGPU() error {
 		}{
 			{&fnCreateInstance, "wgpuCreateInstance"},
 			{&fnAdapterGetInfo, "wgpuAdapterGetInfo"},
+			{&fnAdapterHasFeature, "wgpuAdapterHasFeature"},
 			{&fnAdapterGetLimits, "wgpuAdapterGetLimits"},
 			{&fnDeviceGetQueue, "wgpuDeviceGetQueue"},
 			{&fnDeviceCreateShaderMod, "wgpuDeviceCreateShaderModule"},
@@ -523,11 +527,29 @@ func OpenGPU(power ...GPUPower) (*GPU, error) {
 		dDesc.requiredLimits = uintptr(unsafe.Pointer(&lim))
 		g.maxStorage = min(lim.maxStorageBufferBindingSize, lim.maxBufferSize)
 	}
+	// Shader-f16 halves the resident KV cache; ask for it when the
+	// adapter advertises it, and drop it if the device still refuses.
+	const featShaderF16 = 0x0B // WGPUFeatureName_ShaderF16
+	feats := []uint32{featShaderF16}
+	if fnAdapterHasFeature(g.adapter, featShaderF16) == 1 {
+		dDesc.requiredFeatureCount = 1
+		dDesc.requiredFeatures = uintptr(unsafe.Pointer(&feats[0]))
+		g.hasF16 = true
+	}
 	requestDevice(g.adapter, &dDesc, wgpuCallbackInfo{
 		mode: wgpuCallbackModeAllowSpontaneous, callback: deviceCB,
 	})
+	if cbDevice == 0 && g.hasF16 {
+		g.hasF16 = false
+		dDesc.requiredFeatureCount = 0
+		dDesc.requiredFeatures = 0
+		requestDevice(g.adapter, &dDesc, wgpuCallbackInfo{
+			mode: wgpuCallbackModeAllowSpontaneous, callback: deviceCB,
+		})
+	}
 	runtime.KeepAlive(&dDesc)
 	runtime.KeepAlive(&lim)
+	runtime.KeepAlive(feats)
 	if cbDevice == 0 {
 		g.Close()
 		return nil, fmt.Errorf("tensai: wgpu device request failed: %s", cbFailMsg)
@@ -619,6 +641,7 @@ func (g *GPU) Close() {
 		fn func(uintptr)
 		h  uintptr
 	}{
+		{fnShaderModRelease, g.module3},
 		{fnShaderModRelease, g.module2},
 		{fnShaderModRelease, g.module},
 		{fnQueueRelease, g.queue},

--- a/wgpu_qwen_shape_test.go
+++ b/wgpu_qwen_shape_test.go
@@ -80,3 +80,136 @@ func TestGPUGroupedCausalAttentionQwenShape(t *testing.T) {
 		}
 	}
 }
+
+// TestGPUGroupedCausalAttentionF16 runs the same shape against the
+// half-precision cache path: rows convert in through CopyRowsInto, and
+// the scores tolerate f16's coarser K/V.
+func TestGPUGroupedCausalAttentionF16(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	if !g.HasF16() {
+		t.Skip("device has no shader-f16")
+	}
+	rng := rand.New(rand.NewSource(16))
+
+	const heads, kvHeads, dh = 14, 2, 64
+	const d, kvDim = heads * dh, kvHeads * dh
+	const seq, seqKV = 70, 70
+	group := heads / kvHeads
+	k := randTensor(rng, seqKV, kvDim)
+	v := randTensor(rng, seqKV, kvDim)
+	upload16 := func(src *Tensor) *GPUTensor {
+		t.Helper()
+		f32, err := g.Upload(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f32.Free()
+		c, err := g.NewF16Tensor(seqKV, kvDim)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f32.CopyRowsInto(c, 0); err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	gk := upload16(k)
+	defer gk.Free()
+	gv := upload16(v)
+	defer gv.Free()
+	q := randTensor(rng, seq, d)
+	gq, err := g.Upload(q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gq.Free()
+	got, err := gq.GroupedCausalAttention(gk, gv, heads, kvHeads, seqKV, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Free()
+	out, err := got.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference in f64 over f16-rounded K/V, so the tolerance covers the
+	// kernel, not the storage narrowing itself.
+	h16 := func(x float32) float64 {
+		return float64(float16round(x))
+	}
+	scale := 1 / math.Sqrt(dh)
+	for qi := 0; qi < seq; qi++ {
+		limit := qi + seqKV - seq + 1
+		for h := 0; h < heads; h++ {
+			kvOff := (h / group) * dh
+			scores := make([]float64, limit)
+			maxs := math.Inf(-1)
+			for j := 0; j < limit; j++ {
+				var s float64
+				for c := 0; c < dh; c++ {
+					s += float64(q.Data[qi*d+h*dh+c]) * h16(k.Data[j*kvDim+kvOff+c])
+				}
+				scores[j] = s * scale
+				maxs = math.Max(maxs, scores[j])
+			}
+			var sum float64
+			for j := range scores {
+				scores[j] = math.Exp(scores[j] - maxs)
+				sum += scores[j]
+			}
+			for c := 0; c < dh; c++ {
+				var want float64
+				for j := 0; j < limit; j++ {
+					want += scores[j] / sum * h16(v.Data[j*kvDim+kvOff+c])
+				}
+				gotv := float64(out.Data[qi*d+h*dh+c])
+				if diff := math.Abs(gotv - want); diff > 2e-3*(1+math.Abs(want)) {
+					t.Fatalf("query %d head %d chan %d: got %v want %v", qi, h, c, gotv, want)
+				}
+			}
+		}
+	}
+}
+
+// float16round rounds a float32 through IEEE half precision.
+func float16round(x float32) float32 {
+	b := math.Float32bits(x)
+	sign := b >> 31 << 15
+	exp := int32(b>>23&0xff) - 127 + 15
+	man := b >> 13 & 0x3ff
+	// Round to nearest even on the dropped mantissa bits.
+	if b&0x1fff > 0x1000 || (b&0x1fff == 0x1000 && man&1 == 1) {
+		man++
+		if man == 0x400 {
+			man = 0
+			exp++
+		}
+	}
+	var h uint16
+	switch {
+	case int32(b>>23&0xff) == 0xff:
+		h = uint16(sign | 0x7c00)
+	case exp <= 0:
+		h = uint16(sign) // flush tiny values to zero
+	case exp >= 31:
+		h = uint16(sign | 0x7c00)
+	default:
+		h = uint16(sign | uint32(exp)<<10 | man)
+	}
+	// Expand back.
+	he := uint32(h>>10) & 0x1f
+	hm := uint32(h) & 0x3ff
+	hs := uint32(h>>15) << 31
+	switch {
+	case he == 0 && hm == 0:
+		return math.Float32frombits(hs)
+	case he == 0x1f:
+		return math.Float32frombits(hs | 0x7f800000)
+	case he == 0:
+		return math.Float32frombits(hs) // subnormals flushed above
+	default:
+		return math.Float32frombits(hs | (he-15+127)<<23 | hm<<13)
+	}
+}

--- a/wgpu_stub.go
+++ b/wgpu_stub.go
@@ -116,6 +116,9 @@ func (g *GPU) UploadQ8(q *QMatrix) (*GPUQMatrix, error) { return nil, errNoWGPU 
 // MatMul always fails in builds without the wgpu tag.
 func (q *GPUQMatrix) MatMul(x *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
 
+// MatMulOpts always fails in builds without the wgpu tag.
+func (q *GPUQMatrix) MatMulOpts(x, bias, dst *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
 // Shape returns zeros in builds without the wgpu tag.
 func (q *GPUQMatrix) Shape() (int, int) { return 0, 0 }
 
@@ -138,8 +141,17 @@ type GPUQ4Matrix struct{}
 // UploadQ4 always fails in builds without the wgpu tag.
 func (g *GPU) UploadQ4(q *Q4Matrix) (*GPUQ4Matrix, error) { return nil, errNoWGPU }
 
+// HasF16 reports false in builds without the wgpu tag.
+func (g *GPU) HasF16() bool { return false }
+
+// NewF16Tensor always fails in builds without the wgpu tag.
+func (g *GPU) NewF16Tensor(shape ...int) (*GPUTensor, error) { return nil, errNoWGPU }
+
 // MatMul always fails in builds without the wgpu tag.
 func (q *GPUQ4Matrix) MatMul(x *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
+
+// MatMulOpts always fails in builds without the wgpu tag.
+func (q *GPUQ4Matrix) MatMulOpts(x, bias, dst *GPUTensor) (*GPUTensor, error) { return nil, errNoWGPU }
 
 // Shape returns zeros in builds without the wgpu tag.
 func (q *GPUQ4Matrix) Shape() (int, int) { return 0, 0 }

--- a/wgputensor.go
+++ b/wgputensor.go
@@ -1199,6 +1199,189 @@ fn qmatmul_i(@builtin(workgroup_id) wid: vec3<u32>,
 }
 `
 
+// attnF16WGSL is the f16 module: the grouped attention kernel reading a
+// half-precision KV cache, and the conversion kernel that appends f32
+// rows into it. Compiled only when the device granted shader-f16;
+// accumulation stays in f32, so only the cache storage narrows.
+const attnF16WGSL = `
+enable f16;
+
+struct APParams { seqQ: u32, seqKV: u32, dh: u32, d: u32, rows: u32, off: u32, dkv: u32, window: u32 }
+@group(0) @binding(3) var<storage, read> offs: array<vec4<u32>>;
+@group(0) @binding(10) var<uniform> ap: APParams;
+@group(0) @binding(11) var<storage, read> aq: array<f32>;
+@group(0) @binding(12) var<storage, read> akh: array<f16>;
+@group(0) @binding(13) var<storage, read> avh: array<f16>;
+@group(0) @binding(14) var<storage, read_write> aout: array<f32>;
+
+struct CVParams { n: u32, off: u32, pad0: u32, pad1: u32 }
+@group(0) @binding(20) var<uniform> cvp: CVParams;
+@group(0) @binding(21) var<storage, read> cvsrc: array<f32>;
+@group(0) @binding(22) var<storage, read_write> cvdst: array<f16>;
+
+@compute @workgroup_size(256, 1, 1)
+fn rows_to_f16(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if (gid.x < cvp.n) {
+        cvdst[cvp.off + gid.x] = f16(cvsrc[gid.x]);
+    }
+}
+
+const AT = 64u;
+var<workgroup> qrow_h: array<f32, 2048>;
+var<workgroup> sc_h: array<f32, 512>;
+var<workgroup> red_h: array<f32, 512>;
+
+@compute @workgroup_size(64, 1, 1)
+fn attn_causal_gh(@builtin(workgroup_id) wid: vec3<u32>,
+                  @builtin(num_workgroups) nwg: vec3<u32>,
+                  @builtin(local_invocation_id) lid: vec3<u32>) {
+    let row = wid.y * nwg.x + wid.x;
+    if (row >= ap.rows) {
+        return;
+    }
+    let grp = ap.d / ap.dkv;
+    let bh = row / ap.seqQ;
+    let qi = row % ap.seqQ;
+    let offQ = offs[bh].x;
+    let offKV = offs[bh].y;
+    let offO = offs[bh].z;
+    let t = lid.x;
+    for (var c = t; c < grp * ap.dh; c = c + 64u) {
+        qrow_h[c] = aq[offQ + qi * ap.d + c];
+    }
+    workgroupBarrier();
+    let limit = qi + ap.off + 1u;
+    var start = 0u;
+    if (ap.window > 0u && limit > ap.window) {
+        start = limit - ap.window;
+    }
+    let scale = inverseSqrt(f32(ap.dh));
+    var m: array<f32, 8>;
+    var l: array<f32, 8>;
+    var acc: array<vec4<f32>, 8>;
+    for (var h = 0u; h < 8u; h = h + 1u) {
+        m[h] = -3.40282e38;
+    }
+    let tiles = (limit + AT - 1u) / AT;
+    for (var tt = start / AT; tt < tiles; tt = tt + 1u) {
+        let j = tt * AT + t;
+        let valid = j >= start && j < limit;
+        var dot: array<f32, 8>;
+        for (var h = 0u; h < 8u; h = h + 1u) {
+            dot[h] = 0.0;
+        }
+        if (valid) {
+            for (var c = 0u; c < ap.dh; c = c + 1u) {
+                let kv = f32(akh[offKV + j * ap.dkv + c]);
+                for (var h = 0u; h < 8u; h = h + 1u) {
+                    if (h < grp) {
+                        dot[h] = dot[h] + qrow_h[h * ap.dh + c] * kv;
+                    }
+                }
+            }
+        }
+        for (var h = 0u; h < 8u; h = h + 1u) {
+            if (h < grp) {
+                var sv = -3.40282e38;
+                if (valid) {
+                    sv = dot[h] * scale;
+                }
+                dot[h] = sv;
+                red_h[h * 64u + t] = sv;
+            }
+        }
+        workgroupBarrier();
+        for (var r = 32u; r > 0u; r = r >> 1u) {
+            if (t < r) {
+                for (var h = 0u; h < 8u; h = h + 1u) {
+                    if (h < grp) {
+                        red_h[h * 64u + t] = max(red_h[h * 64u + t], red_h[h * 64u + t + r]);
+                    }
+                }
+            }
+            workgroupBarrier();
+        }
+        var mNew: array<f32, 8>;
+        var p: array<f32, 8>;
+        for (var h = 0u; h < 8u; h = h + 1u) {
+            p[h] = 0.0;
+            if (h < grp) {
+                mNew[h] = max(m[h], red_h[h * 64u]);
+                if (valid) {
+                    p[h] = exp(dot[h] - mNew[h]);
+                }
+            }
+        }
+        workgroupBarrier();
+        for (var h = 0u; h < 8u; h = h + 1u) {
+            if (h < grp) {
+                sc_h[h * 64u + t] = p[h];
+                red_h[h * 64u + t] = p[h];
+            }
+        }
+        workgroupBarrier();
+        for (var r = 32u; r > 0u; r = r >> 1u) {
+            if (t < r) {
+                for (var h = 0u; h < 8u; h = h + 1u) {
+                    if (h < grp) {
+                        red_h[h * 64u + t] = red_h[h * 64u + t] + red_h[h * 64u + t + r];
+                    }
+                }
+            }
+            workgroupBarrier();
+        }
+        for (var h = 0u; h < 8u; h = h + 1u) {
+            if (h < grp) {
+                // exp underflows to zero on the first tile, where m is -inf-like.
+                let rescale = exp(m[h] - mNew[h]);
+                l[h] = l[h] * rescale + red_h[h * 64u];
+                m[h] = mNew[h];
+                acc[h] = acc[h] * rescale;
+            }
+        }
+        let jEnd = min(limit, tt * AT + AT);
+        for (var jj = max(start, tt * AT); jj < jEnd; jj = jj + 1u) {
+            var vv = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+            if (t < ap.dh) {
+                vv.x = f32(avh[offKV + jj * ap.dkv + t]);
+            }
+            if (64u + t < ap.dh) {
+                vv.y = f32(avh[offKV + jj * ap.dkv + 64u + t]);
+            }
+            if (128u + t < ap.dh) {
+                vv.z = f32(avh[offKV + jj * ap.dkv + 128u + t]);
+            }
+            if (192u + t < ap.dh) {
+                vv.w = f32(avh[offKV + jj * ap.dkv + 192u + t]);
+            }
+            for (var h = 0u; h < 8u; h = h + 1u) {
+                if (h < grp) {
+                    acc[h] = acc[h] + sc_h[h * 64u + jj - tt * AT] * vv;
+                }
+            }
+        }
+        workgroupBarrier();
+    }
+    for (var h = 0u; h < 8u; h = h + 1u) {
+        if (h < grp) {
+            let o = offO + qi * ap.d + h * ap.dh;
+            if (t < ap.dh) {
+                aout[o + t] = acc[h].x / l[h];
+            }
+            if (64u + t < ap.dh) {
+                aout[o + 64u + t] = acc[h].y / l[h];
+            }
+            if (128u + t < ap.dh) {
+                aout[o + 128u + t] = acc[h].z / l[h];
+            }
+            if (192u + t < ap.dh) {
+                aout[o + 192u + t] = acc[h].w / l[h];
+            }
+        }
+    }
+}
+`
+
 // IntDot reports whether the optional integer-dot GEMM module compiled
 // on this device; without it large batches use the f32 tiled kernel.
 func (g *GPU) IntDot() bool { return g.hasIntDot }
@@ -1211,12 +1394,13 @@ type gpuPipelines struct {
 	scale, softmax, attn, qmatmul                  uintptr
 	rmsnorm, rope, addIP, siluMulIP, q4matmul      uintptr
 	geluMulIP, qmatmulB, attnG, qmatmulT           uintptr
-	qacts, qmatmulI                                uintptr
+	qacts, qmatmulI, attnF16, rowsToF16            uintptr
 	layMatmul, layMatmulT, layMatmulS, layMatmulTS uintptr
 	layScale, laySoftmax, layAttn, layQmatmul      uintptr
 	layRmsnorm, layRope, layAddIP, laySiluMulIP    uintptr
 	layQ4matmul, layGeluMulIP, layQmatmulB         uintptr
 	layAttnG, layQmatmulT, layQacts, layQmatmulI   uintptr
+	layAttnF16, layRowsToF16                       uintptr
 }
 
 // initPipelines compiles every kernel from g.module; the caller holds
@@ -1272,6 +1456,31 @@ func (g *GPU) initPipelines() error {
 		g.hasIntDot = ok
 	}
 	uncapturedCB = ""
+	// The f16 module needs the shader-f16 device feature; failure to
+	// compile just leaves the f32 cache path.
+	if g.hasF16 {
+		ok := false
+		g.module3 = g.makeModuleFrom(attnF16WGSL)
+		if g.module3 != 0 && uncapturedCB == "" {
+			ok = true
+			for _, x := range []struct {
+				pipe, lay *uintptr
+				entry     string
+			}{
+				{&g.pipes.attnF16, &g.pipes.layAttnF16, "attn_causal_gh"},
+				{&g.pipes.rowsToF16, &g.pipes.layRowsToF16, "rows_to_f16"},
+			} {
+				*x.pipe = g.makePipelineIn(g.module3, x.entry)
+				if *x.pipe == 0 || uncapturedCB != "" {
+					ok = false
+					break
+				}
+				*x.lay = fnPipelineGetLayout(*x.pipe, 0)
+			}
+		}
+		g.hasF16 = ok
+		uncapturedCB = ""
+	}
 	return nil
 }
 
@@ -1285,6 +1494,7 @@ func (g *GPU) releasePipelines() {
 		g.pipes.layAddIP, g.pipes.laySiluMulIP, g.pipes.layQ4matmul,
 		g.pipes.layGeluMulIP, g.pipes.layQmatmulB, g.pipes.layAttnG,
 		g.pipes.layQmatmulT, g.pipes.layQacts, g.pipes.layQmatmulI,
+		g.pipes.layAttnF16, g.pipes.layRowsToF16,
 	} {
 		if h != 0 {
 			fnLayoutRelease(h)
@@ -1297,6 +1507,7 @@ func (g *GPU) releasePipelines() {
 		g.pipes.addIP, g.pipes.siluMulIP, g.pipes.q4matmul,
 		g.pipes.geluMulIP, g.pipes.qmatmulB, g.pipes.attnG,
 		g.pipes.qmatmulT, g.pipes.qacts, g.pipes.qmatmulI,
+		g.pipes.attnF16, g.pipes.rowsToF16,
 	} {
 		if h != 0 {
 			fnPipelineRelease(h)
@@ -1611,6 +1822,49 @@ type GPUTensor struct {
 	buf   uintptr
 	shape []int
 	freed bool
+	f16   bool // half-precision storage (KV caches); most kernels want f32
+}
+
+// byteLen is the tensor's buffer size, which the pool keys on.
+func (t *GPUTensor) byteLen() uint64 {
+	if t.f16 {
+		return (uint64(t.Size())*2 + 3) &^ 3
+	}
+	return uint64(t.Size()) * 4
+}
+
+// HasF16 reports whether the device granted shader-f16 and the f16
+// kernels compiled: NewF16Tensor and the half-precision KV cache path
+// are usable only then.
+func (g *GPU) HasF16() bool { return g.hasF16 }
+
+// NewF16Tensor allocates a zeroed half-precision GPU tensor. Only the
+// attention cache kernels read and write f16 tensors: fill it with
+// CopyRowsInto, feed it to GroupedCausalAttention.
+func (g *GPU) NewF16Tensor(shape ...int) (*GPUTensor, error) {
+	if !g.hasF16 {
+		return nil, errors.New("tensai: device has no shader-f16 support")
+	}
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	if n <= 0 {
+		return nil, errors.New("tensai: empty f16 tensor")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	t := &GPUTensor{g: g, shape: append([]int(nil), shape...), f16: true}
+	t.buf = g.newBuffer(gpuTensorUsage, t.byteLen())
+	if t.buf == 0 {
+		return nil, errors.New("tensai: gpu buffer allocation failed")
+	}
+	return t, nil
 }
 
 // Every GPUTensor buffer is storage-usable (kernel input and output),
@@ -1813,7 +2067,7 @@ func (t *GPUTensor) Free() {
 		return
 	}
 	t.freed = true
-	t.g.putBuffer(gpuTensorUsage, uint64(t.Size())*4, t.buf)
+	t.g.putBuffer(gpuTensorUsage, t.byteLen(), t.buf)
 }
 
 // MatMul multiplies two GPU-resident tensors with the same shape and
@@ -2765,6 +3019,29 @@ func (t *GPUTensor) CopyRowsInto(dst *GPUTensor, off int) error {
 		return errors.New("tensai: gpu is closed")
 	}
 	uncapturedCB = ""
+	if dst.f16 {
+		// A half-precision destination converts through a kernel; the
+		// pass batches it like any other dispatch, no copy involved.
+		n := t.Size()
+		params := [4]uint32{uint32(n), uint32(off)}
+		bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+		defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
+		fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+		entries := [3]wgpuBindGroupEntry{
+			{binding: 20, buffer: bufParams, size: 16},
+			{binding: 21, buffer: t.buf, size: uint64(n) * 4},
+			{binding: 22, buffer: dst.buf, size: dst.byteLen()},
+		}
+		bindGroup := g.cachedBindGroup(g.pipes.layRowsToF16, entries[:])
+		runtime.KeepAlive(&entries)
+		if err := g.dispatch(g.pipes.rowsToF16, bindGroup, uint32((n+255)/256), 1, 1); err != nil {
+			return err
+		}
+		if uncapturedCB != "" {
+			return fmt.Errorf("tensai: gpu f16 copy failed: %s", uncapturedCB)
+		}
+		return nil
+	}
 	if g.batchEnc != 0 {
 		g.endBatchPass()
 		fnEncoderCopyBuffer(g.batchEnc, t.buf, 0, dst.buf, uint64(off)*4, uint64(t.Size())*4)
@@ -2822,6 +3099,12 @@ func (q *GPUTensor) GroupedCausalAttention(k, v *GPUTensor, heads, kvHeads, seqK
 	// group; other shapes keep the per-head kernel.
 	group := heads / kvHeads
 	grouped := group > 1 && group <= 8 && dh <= 256
+	if k.f16 != v.f16 {
+		return nil, errors.New("tensai: k and v caches must share a precision")
+	}
+	if k.f16 && !grouped {
+		return nil, fmt.Errorf("tensai: the f16 cache path needs a query-head group of 2..8, got %d", group)
+	}
 	nwg := heads
 	if grouped {
 		nwg = kvHeads
@@ -2867,13 +3150,16 @@ func (q *GPUTensor) GroupedCausalAttention(k, v *GPUTensor, heads, kvHeads, seqK
 		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
 		{binding: 10, buffer: bufParams, size: 32},
 		{binding: 11, buffer: q.buf, size: uint64(q.Size()) * 4},
-		{binding: 12, buffer: k.buf, size: uint64(k.Size()) * 4},
-		{binding: 13, buffer: v.buf, size: uint64(v.Size()) * 4},
+		{binding: 12, buffer: k.buf, size: k.byteLen()},
+		{binding: 13, buffer: v.buf, size: v.byteLen()},
 		{binding: 14, buffer: bufOut, size: outBytes},
 	}
 	pipe, lay := g.pipes.attn, g.pipes.layAttn
 	if grouped {
 		pipe, lay = g.pipes.attnG, g.pipes.layAttnG
+		if k.f16 {
+			pipe, lay = g.pipes.attnF16, g.pipes.layAttnF16
+		}
 	}
 	bindGroup := g.cachedBindGroup(lay, entries[:])
 	runtime.KeepAlive(&entries)


### PR DESCRIPTION
The device requests the shader-f16 feature when the adapter offers it (dropping it if the device still refuses), and a separately compiled f16 module carries a grouped attention kernel reading a half-precision cache plus the conversion kernel that appends f32 rows into it. Accumulation stays f32, only the cache storage narrows, and devices without the feature keep the f32 path. NewF16Tensor allocates the cache, CopyRowsInto converts into it, and GroupedCausalAttention picks the f16 kernel off the tensor. On dozen (Radeon 680M) a 551-token Q8 GPU prefill of Qwen2.5-0.5B drops from 0.74s to 0.63s (~880 tok/s) and decode rises from 33.9 to 36.8 tok/s; a 1.5B model's cache upload drops from 10s to 6.6s with decode unchanged. The Qwen-shaped attention test gains an f16-path variant checked against an f16-rounded reference.