### PR TITLE
Extend speculative decoding to sampling and the serve API

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -411,7 +411,7 @@ func main() {
 	ggufPath := flag.String("gguf", "", "load model and tokenizer from a single .gguf file instead of -data/-repo")
 	serveAddr := flag.String("serve", "", "serve an OpenAI-compatible /v1/chat/completions API on this address (e.g. :8080)")
 	think := flag.Bool("think", false, "let Qwen3 models reason in a <think> block before answering")
-	draftDir := flag.String("draft", "", "data directory of a smaller draft model: speculative decoding (greedy only)")
+	draftDir := flag.String("draft", "", "data directory of a smaller draft model for speculative decoding")
 	specK := flag.Int("spec", 3, "draft tokens proposed per speculative step (3 fills one 4-row verification block)")
 	requant := flag.Bool("requant", false, "requantize gguf weights through float32 instead of repacking their stored blocks (slower load, but coarser scale tables decode faster)")
 	nocache := flag.Bool("nocache", false, "neither write nor reuse the repack cache file the first -gguf load leaves next to the model")
@@ -468,11 +468,11 @@ func main() {
 		model.cfg.ModelType, model.cfg.Layers, model.cfg.HiddenSize, how, time.Since(start).Round(time.Millisecond))
 
 	// The draft model shares the tokenizer, so it must come from the same
-	// family (0.5B drafting for 7B, say). Speculation verifies greedily.
+	// family (0.5B drafting for 7B, say).
 	var draftM *qwen
 	if *draftDir != "" {
-		if *temp > 0 || *gpu || *serveAddr != "" {
-			fmt.Fprintln(os.Stderr, "-draft requires greedy CPU decoding (-temp 0, no -gpu/-serve)")
+		if *gpu {
+			fmt.Fprintln(os.Stderr, "-draft requires CPU decoding (no -gpu)")
 			os.Exit(1)
 		}
 		dw, err := fetchWeights(*draftDir)
@@ -597,6 +597,7 @@ func main() {
 			model: model, tok: tok, system: *system, nCtx: nCtx,
 			temp: *temp, topP: *topP, imEnd: imEnd, eot: eot,
 			tm: tm, prefill: prefillFn, step: stepFn, reset: reset,
+			draft: draftM, specK: *specK,
 		}
 		if err := s.listen(*serveAddr); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -624,57 +625,21 @@ func main() {
 			steps++
 		}
 	}
-	// generateSpec emits tokens speculatively: the target's pending logits
-	// pick a token, the draft greedily proposes specK continuations, and
-	// one batched target pass scores them all — every agreed position is
-	// accepted, the first disagreement's row supplies the corrected next
-	// pick, and both KV caches roll back to the accepted length.
 	generateSpec := func(limit int) {
 		start := time.Now()
-		gen, accepted, proposed := 0, 0, 0
-		for gen < limit && steps < nCtx-2-*specK {
-			c0 := sample(logits, 0, 1, rng)
-			if c0 == imEnd || c0 == eot {
-				feed([]int{c0})
-				break
-			}
-			fmt.Print(tok.Decode([]int{c0}))
-			gen++
-			props := make([]int, 0, *specK)
-			dl := draftM.step(c0, steps)
-			for i := 0; i < *specK; i++ {
-				d := sample(dl, 0, 1, rng)
-				props = append(props, d)
-				dl = draftM.step(d, steps+1+i)
-			}
-			lm := model.prefillLogits(append([]int{c0}, props...), steps)
-			j, stop := 0, false
-			for ; j < len(props); j++ {
-				row := lm.Data[j*lm.Cols : (j+1)*lm.Cols]
-				if sample(row, 0, 1, rng) != props[j] {
-					break
-				}
-				if props[j] == imEnd || props[j] == eot {
-					j++
-					stop = true
-					break
-				}
-				fmt.Print(tok.Decode([]int{props[j]}))
+		gen := 0
+		var stats specStats
+		logits, steps, _, stats = generateSpeculative(model, draftM, logits, steps,
+			limit, nCtx, *specK, *temp, *topP, func(id int) bool {
+				return id == imEnd || id == eot
+			}, rng, func(id int) bool {
+				fmt.Print(tok.Decode([]int{id}))
 				gen++
-			}
-			accepted += j
-			proposed += len(props)
-			model.truncate(steps + 1 + j)
-			draftM.truncate(steps + 1 + j)
-			steps += 1 + j
-			logits = lm.Data[j*lm.Cols : (j+1)*lm.Cols]
-			if stop {
-				break
-			}
-		}
+				return true
+			})
 		fmt.Println()
 		fmt.Fprintf(os.Stderr, "(%d tokens, %.1f tok/s, %d/%d drafts accepted)\n",
-			gen, float64(gen)/time.Since(start).Seconds(), accepted, proposed)
+			gen, float64(gen)/time.Since(start).Seconds(), stats.accepted, stats.proposed)
 	}
 
 	generate := func(limit int) {

--- a/_example/qwen/main_test.go
+++ b/_example/qwen/main_test.go
@@ -1,9 +1,36 @@
 package main
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 )
+
+func TestSampleDistribution(t *testing.T) {
+	logits := []float32{0, 1, 2, -1}
+	p := sampleDistribution(logits, 0.8, 1)
+	var sum float64
+	for _, v := range p {
+		sum += v
+	}
+	if math.Abs(sum-1) > 1e-12 {
+		t.Fatalf("distribution sums to %g", sum)
+	}
+	if !(p[2] > p[1] && p[1] > p[0] && p[0] > p[3]) {
+		t.Fatalf("probabilities do not follow logits: %v", p)
+	}
+
+	p = sampleDistribution(logits, 1, 0.5)
+	nonzero := 0
+	for _, v := range p {
+		if v != 0 {
+			nonzero++
+		}
+	}
+	if nonzero != 1 || p[2] != 1 {
+		t.Fatalf("top-p nucleus = %v, want only token 2", p)
+	}
+}
 
 func BenchmarkPrefill(b *testing.B) {
 	m, _, err := loadGGUF("../../qwen2.5-0.5b-instruct-q8_0.gguf", 8, true, true)

--- a/_example/qwen/serve.go
+++ b/_example/qwen/serve.go
@@ -77,6 +77,8 @@ func render(tm tmpl, msgs []chatMessage, defaultSystem string) string {
 type server struct {
 	mu      sync.Mutex // one request drives the model at a time
 	model   *qwen
+	draft   *qwen
+	specK   int
 	tok     tokenizerIface
 	system  string
 	nCtx    int
@@ -165,6 +167,9 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.reset()
+	if s.draft != nil {
+		s.draft.reset()
+	}
 
 	id := fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano())
 	created := time.Now().Unix()
@@ -229,31 +234,53 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logits := s.prefill(ids, 0)
+	if s.draft != nil {
+		s.draft.prefill(ids, 0)
+	}
 	steps := len(ids)
 	var out []int
 	finish := "length"
 	ctx := r.Context()
-	for len(out) < limit && steps < s.nCtx-1 {
-		// A disconnected client stops the generation instead of holding
-		// the model for tokens nobody will read.
-		select {
-		case <-ctx.Done():
-			finish = "abort"
-			steps = s.nCtx // fall out below
-			continue
-		default:
+	if s.draft != nil {
+		emit := func(next int) bool {
+			select {
+			case <-ctx.Done():
+				return false
+			default:
+			}
+			out = append(out, next)
+			if flush != nil {
+				push(s.tok.Decode([]int{next}), false)
+			}
+			return true
 		}
-		next := sample(logits, temp, topP, rng)
-		if next == s.imEnd || next == s.eot {
-			finish = "stop"
-			break
+		_, _, finish, _ = generateSpeculative(s.model, s.draft, logits, steps, limit,
+			s.nCtx, s.specK, temp, topP, func(id int) bool {
+				return id == s.imEnd || id == s.eot
+			}, rng, emit)
+	} else {
+		for len(out) < limit && steps < s.nCtx-1 {
+			// A disconnected client stops the generation instead of holding
+			// the model for tokens nobody will read.
+			select {
+			case <-ctx.Done():
+				finish = "abort"
+				steps = s.nCtx // fall out below
+				continue
+			default:
+			}
+			next := sample(logits, temp, topP, rng)
+			if next == s.imEnd || next == s.eot {
+				finish = "stop"
+				break
+			}
+			out = append(out, next)
+			if flush != nil {
+				push(s.tok.Decode([]int{next}), false)
+			}
+			logits = s.step(next, steps)
+			steps++
 		}
-		out = append(out, next)
-		if flush != nil {
-			push(s.tok.Decode([]int{next}), false)
-		}
-		logits = s.step(next, steps)
-		steps++
 	}
 	if finish == "abort" {
 		return

--- a/_example/qwen/speculative.go
+++ b/_example/qwen/speculative.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+type specStats struct {
+	accepted int
+	proposed int
+}
+
+// sampleDistribution returns the exact temperature/top-p distribution used by
+// speculative rejection sampling. Keeping the zeroed tail is intentional: it
+// makes max(0, p-q) cheap on a rejected proposal.
+func sampleDistribution(logits []float32, temp, topP float64) []float64 {
+	p := make([]float64, len(logits))
+	buckets := make([]uint16, len(logits))
+	maxl := logits[0]
+	for _, v := range logits[1:] {
+		if v > maxl {
+			maxl = v
+		}
+	}
+	var sum float64
+	const nb = 1100
+	var bsum [nb]float64
+	for i, v := range logits {
+		p[i] = math.Exp(float64(v-maxl) / temp)
+		sum += p[i]
+		if topP < 1 && p[i] > 0 {
+			b := -math.Ilogb(p[i])
+			if b < 0 {
+				b = 0
+			} else if b >= nb {
+				b = nb - 1
+			}
+			buckets[i] = uint16(b)
+			bsum[b] += p[i]
+		}
+	}
+	if topP < 1 {
+		target := topP * sum
+		var mass float64
+		cut := 0
+		for cut < nb-1 && mass+bsum[cut] < target {
+			mass += bsum[cut]
+			cut++
+		}
+		ids := make([]int, 0, len(p)/100)
+		for i, b := range buckets {
+			if int(b) <= cut && p[i] > 0 {
+				ids = append(ids, i)
+			}
+		}
+		sort.Slice(ids, func(i, j int) bool { return p[ids[i]] > p[ids[j]] })
+		mass = 0
+		n := 0
+		for n < len(ids) && (n == 0 || mass < target) {
+			mass += p[ids[n]]
+			n++
+		}
+		for i := range p {
+			p[i] = 0
+		}
+		for _, id := range ids[:n] {
+			p[id] = math.Exp(float64(logits[id]-maxl) / temp)
+		}
+		sum = mass
+	}
+	for i := range p {
+		p[i] /= sum
+	}
+	return p
+}
+
+func drawDistribution(p []float64, rng *rand.Rand) int {
+	r := rng.Float64()
+	for i, v := range p {
+		r -= v
+		if r <= 0 {
+			return i
+		}
+	}
+	return len(p) - 1
+}
+
+// generateSpeculative implements greedy verification at temp <= 0 and the
+// standard exact speculative-sampling rejection rule otherwise. emit returns
+// false to abort (for example when an HTTP client disconnects).
+func generateSpeculative(target, draft *qwen, logits []float32, steps, limit, nCtx, specK int,
+	temp, topP float64, stop func(int) bool, rng *rand.Rand, emit func(int) bool,
+) ([]float32, int, string, specStats) {
+	stats := specStats{}
+	generated := 0
+	for generated < limit && steps < nCtx-1 {
+		if specK < 1 || steps >= nCtx-1-specK {
+			next := sample(logits, temp, topP, rng)
+			if stop(next) {
+				return logits, steps, "stop", stats
+			}
+			if !emit(next) {
+				return logits, steps, "abort", stats
+			}
+			logits = target.step(next, steps)
+			draft.step(next, steps)
+			steps++
+			generated++
+			continue
+		}
+
+		first := sample(logits, temp, topP, rng)
+		if stop(first) {
+			return logits, steps, "stop", stats
+		}
+		if !emit(first) {
+			return logits, steps, "abort", stats
+		}
+		generated++
+		props := make([]int, 0, specK)
+		qdists := make([][]float64, 0, specK)
+		dl := draft.step(first, steps)
+		for i := 0; i < specK; i++ {
+			if temp <= 0 {
+				props = append(props, sample(dl, 0, 1, rng))
+			} else {
+				q := sampleDistribution(dl, temp, topP)
+				qdists = append(qdists, q)
+				props = append(props, drawDistribution(q, rng))
+			}
+			dl = draft.step(props[i], steps+1+i)
+		}
+		lm := target.prefillLogits(append([]int{first}, props...), steps)
+		accepted := 0
+		for accepted < len(props) && generated < limit {
+			row := lm.Data[accepted*lm.Cols : (accepted+1)*lm.Cols]
+			if temp <= 0 {
+				if sample(row, 0, 1, rng) != props[accepted] {
+					break
+				}
+			} else {
+				p := sampleDistribution(row, temp, topP)
+				q := qdists[accepted]
+				ratio := 1.0
+				if q[props[accepted]] > 0 {
+					ratio = p[props[accepted]] / q[props[accepted]]
+				}
+				if rng.Float64() > math.Min(1, ratio) {
+					for i := range p {
+						p[i] = math.Max(0, p[i]-q[i])
+					}
+					var mass float64
+					for _, v := range p {
+						mass += v
+					}
+					for i := range p {
+						p[i] /= mass
+					}
+					correction := drawDistribution(p, rng)
+					target.truncate(steps + 1 + accepted)
+					draft.truncate(steps + 1 + accepted)
+					steps += 1 + accepted
+					stats.accepted += accepted
+					stats.proposed += len(props)
+					if stop(correction) {
+						return logits, steps, "stop", stats
+					}
+					if !emit(correction) {
+						return logits, steps, "abort", stats
+					}
+					generated++
+					logits = target.step(correction, steps)
+					draft.step(correction, steps)
+					steps++
+					accepted = -1
+					break
+				}
+			}
+			if stop(props[accepted]) {
+				accepted++
+				target.truncate(steps + 1 + accepted)
+				draft.truncate(steps + 1 + accepted)
+				steps += 1 + accepted
+				stats.accepted += accepted
+				stats.proposed += len(props)
+				return logits, steps, "stop", stats
+			}
+			if !emit(props[accepted]) {
+				return logits, steps, "abort", stats
+			}
+			generated++
+			accepted++
+		}
+		if accepted < 0 {
+			continue
+		}
+		stats.accepted += accepted
+		stats.proposed += len(props)
+		target.truncate(steps + 1 + accepted)
+		draft.truncate(steps + 1 + accepted)
+		steps += 1 + accepted
+		logits = lm.Data[accepted*lm.Cols : (accepted+1)*lm.Cols]
+	}
+	return logits, steps, "length", stats
+}


### PR DESCRIPTION
The -draft path was CLI-only and greedy. generateSpeculative now carries both modes: greedy verification compares argmaxes as before, and temperature sampling applies the standard rejection rule (accept with probability min(1, p/q), resample max(0, p-q) on rejection), so the output distribution matches non-speculative sampling. The serve API takes a draft model through the same flags and resets both caches per request. Verified end to end on Qwen2.5 pairs (0.5B drafting 1.5B and 7B), greedy and temp 0.7, CLI and serve. Measured acceptance sits at 33-45% and the verify batch pads 4 rows to the 8-row Q8 kernel, so these CPU pairs do not net a speedup yet; a 4-row verify kernel like the Q4 path's q4matmulCols4 is the follow-up that would change that.