### PR TITLE
Share the user-cache model directory across entry points

### DIFF
--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	o := llm.Options{Log: os.Stderr}
-	flag.StringVar(&o.Data, "data", "_example/qwen/data", "directory for the downloaded model files")
+	flag.StringVar(&o.Data, "data", "", "directory for the downloaded model files (default: the per-repo directory under the user cache)")
 	flag.StringVar(&o.Repo, "repo", llm.DefaultRepo, "Hugging Face repo to download missing model files from")
 	prompt := flag.String("prompt", "What is the capital of France?", "user message (or raw prompt with -raw)")
 	flag.StringVar(&o.System, "system", llm.DefaultSystem, "system message for the chat template (Qwen's branding swaps for a neutral one on other models)")
@@ -49,6 +49,9 @@ func main() {
 	}
 	if *q4 {
 		o.Bits = 4
+	}
+	if o.Data == "" && o.GGUF == "" {
+		o.Data = llm.DefaultDataDir(o.Repo)
 	}
 
 	e, err := llm.Open(o)

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -11,8 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
-	"path/filepath"
 	"runtime/debug"
 	"runtime/pprof"
 
@@ -57,11 +55,7 @@ func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 			o.Bits = 4
 		}
 		if o.Data == "" && o.GGUF == "" {
-			if dir, err := os.UserCacheDir(); err == nil {
-				o.Data = filepath.Join(dir, "tensai", path.Base(o.Repo))
-			} else {
-				o.Data = filepath.Join("tensai-data", path.Base(o.Repo))
-			}
+			o.Data = llm.DefaultDataDir(o.Repo)
 		}
 	}
 	return o, finish

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -31,6 +32,19 @@ const DefaultRepo = "Qwen/Qwen2.5-0.5B-Instruct"
 // families swap it for a neutral one (see Open), exactly when the caller
 // left it at this default.
 const DefaultSystem = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+
+// DefaultDataDir is where a repo's files live when Options.Data is
+// empty: a per-repo directory under the user cache (~/.cache/tensai/...
+// on Linux).
+func DefaultDataDir(repo string) string {
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, "tensai", path.Base(repo))
+	}
+	return filepath.Join("tensai-data", path.Base(repo))
+}
 
 // Options selects and configures a model. The zero value is not runnable:
 // fill Data or GGUF, and usually Bits.


### PR DESCRIPTION
DefaultDataDir moves the per-repo cache-directory rule into internal/llm, and the qwen example adopts it in place of its old _example/qwen/data default, so both entry points read and populate the same ~/.cache/tensai/<repo> tree instead of downloading separate copies.