### PR TITLE
Fix the darwin build of mmapfile's Release

### DIFF
--- a/internal/mmapfile/release_darwin.go
+++ b/internal/mmapfile/release_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package mmapfile
+
+import (
+	"syscall"
+)
+
+// Release tells the kernel the mapped range will not be needed again;
+// darwin's syscall package lacks the Madvise wrapper, so this issues
+// the raw system call with the same page-inward rounding as linux.
+func Release(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	page := syscall.Getpagesize()
+	start := 0
+	if off := int(uintptr(addrOf(b)) % uintptr(page)); off != 0 {
+		start = page - off
+	}
+	end := start + (len(b)-start)/page*page
+	if end <= start {
+		return
+	}
+	r := b[start:end]
+	syscall.Syscall(syscall.SYS_MADVISE, uintptr(addrOf(r)), uintptr(len(r)), syscall.MADV_DONTNEED)
+}

--- a/internal/mmapfile/release_linux.go
+++ b/internal/mmapfile/release_linux.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux
 
 package mmapfile
 


### PR DESCRIPTION
syscall.Madvise only exists on linux, so the darwin half of the release_unix build tag never compiled and cross-building cmd/tensai for macOS failed. Darwin now issues the raw SYS_MADVISE system call with the same page-inward rounding, and the linux file drops the dead tag. Verified: CGO_ENABLED=0 GOEXPERIMENT=simd -tags wgpu24 builds for linux/{amd64,arm64}, darwin/{amd64,arm64}, and windows/amd64 all pass.