### PR TITLE
Release tensai binaries from tags, algia style

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.27.x"
+        cache: false
+    - name: Cross build
+      run: make cross
+    - name: Upload
+      run: make upload
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+BIN := tensai
+VERSION := $$(make -s show-version)
+CURRENT_REVISION := $(shell git rev-parse --short HEAD)
+BUILD_LDFLAGS := "-s -w -X main.revision=$(CURRENT_REVISION)"
+GOBIN ?= $(shell go env GOPATH)/bin
+export GOEXPERIMENT=simd
+export CGO_ENABLED=0
+
+.PHONY: all
+all: clean build
+
+.PHONY: build
+build:
+	go build -tags wgpu24 -ldflags=$(BUILD_LDFLAGS) -o $(BIN) ./cmd/tensai
+
+.PHONY: install
+install:
+	go install -tags wgpu24 -ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
+
+.PHONY: show-version
+show-version: $(GOBIN)/gobump
+	gobump show -r ./cmd/tensai
+
+$(GOBIN)/gobump:
+	go install github.com/x-motemen/gobump/cmd/gobump@latest
+
+.PHONY: cross
+cross: $(GOBIN)/goxz
+	goxz -n $(BIN) -pv=v$(VERSION) -os linux,darwin,windows -arch amd64,arm64 \
+		-build-tags wgpu24 -build-ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
+
+$(GOBIN)/goxz:
+	go install github.com/Songmu/goxz/cmd/goxz@latest
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: clean
+clean:
+	rm -rf $(BIN) goxz
+	go clean
+
+.PHONY: bump
+bump: $(GOBIN)/gobump
+ifneq ($(shell git status --porcelain),)
+	$(error git workspace is dirty)
+endif
+ifneq ($(shell git rev-parse --abbrev-ref HEAD),main)
+	$(error current branch is not main)
+endif
+	@gobump up -w ./cmd/tensai
+	git commit -am "Bump up version to $(VERSION)"
+	git tag "v$(VERSION)"
+	git push origin main
+	git push origin "refs/tags/v$(VERSION)"
+
+.PHONY: upload
+upload: $(GOBIN)/ghr
+	ghr -body="" "v$(VERSION)" goxz
+
+$(GOBIN)/ghr:
+	go install github.com/tcnksm/ghr@latest

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -11,11 +11,15 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
 	"runtime/pprof"
 
 	"github.com/mattn/tensai/internal/llm"
 )
+
+const version = "0.0.2"
+
+// revision is stamped by the release build (-X main.revision=...).
+var revision = "HEAD"
 
 const usage = `usage: tensai <command> [flags]
 
@@ -136,11 +140,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "version":
-		if bi, ok := debug.ReadBuildInfo(); ok {
-			fmt.Println("tensai", bi.Main.Version)
-			return
-		}
-		fmt.Println("tensai (unknown)")
+		fmt.Printf("tensai v%s (%s)\n", version, revision)
 	case "-h", "--help", "help":
 		fmt.Println(usage)
 	default:

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattn/tensai/internal/llm"
 )
 
-const version = "0.0.2"
+const version = "0.0.1"
 
 // revision is stamped by the release build (-X main.revision=...).
 var revision = "HEAD"


### PR DESCRIPTION
A version constant in cmd/tensai (patch-only, v0.0.X) replaces the build-info guess, with the git revision stamped through ldflags. The Makefile carries algia's release flow — gobump reads and bumps the constant, goxz cross-builds the six os/arch archives with GOEXPERIMENT=simd, CGO_ENABLED=0, and the wgpu24 tag, ghr uploads them, and make bump does the bump-commit-tag-push dance — and the Release workflow runs cross and upload on every v* tag. Verified locally: make build stamps the revision, make cross produces all six archives, and the archived linux/amd64 binary reports v0.0.2 with GOEXPERIMENT=simd, CGO_ENABLED=0, and -tags=wgpu24 in its build info.