### PR TITLE
Give tensai run a JSON output mode

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+	"strings"
 	"time"
 
 	"github.com/mattn/tensai/internal/llm"
@@ -105,6 +106,7 @@ func main() {
 		o, finish := modelFlags(fs)
 		prompt := fs.String("prompt", "", "user message (or raw prompt with -raw); positional arguments join into one")
 		raw := fs.Bool("raw", false, "skip the chat template, complete the prompt as-is")
+		jsonOut := fs.Bool("json", false, "print one JSON object with the completion and usage instead of streaming text")
 		n := fs.Int("n", 256, "max tokens to generate")
 		cpuprofile := fs.String("cpuprofile", "", "write a CPU profile of generation to this file")
 		fs.Parse(args)
@@ -124,7 +126,22 @@ func main() {
 		defer e.Close()
 		stop := profileTo(*cpuprofile)
 		defer stop()
-		e.Generate(os.Stdout, text, *raw, *n)
+		if *jsonOut {
+			var sb strings.Builder
+			res := e.Generate(&sb, text, *raw, *n)
+			out, _ := json.Marshal(map[string]any{
+				"content":           strings.TrimSuffix(sb.String(), "\n"),
+				"finish":            res.Finish,
+				"prompt_tokens":     res.PromptTokens,
+				"completion_tokens": res.CompletionTokens,
+				"prefill_ms":        res.Prefill.Milliseconds(),
+				"total_ms":          res.Total.Milliseconds(),
+				"tok_per_sec":       float64(res.CompletionTokens) / (res.Total - res.Prefill).Seconds(),
+			})
+			fmt.Println(string(out))
+		} else {
+			e.Generate(os.Stdout, text, *raw, *n)
+		}
 	case "chat":
 		fs := flag.NewFlagSet("tensai chat", flag.ExitOnError)
 		o, finish := modelFlags(fs)

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -274,13 +274,15 @@ func (e *Engine) feed(ids []int) {
 }
 
 // generate emits up to limit sampled tokens to w, speculatively when a
-// draft model is loaded, and reports throughput to the Log writer.
-func (e *Engine) generate(w io.Writer, limit int) {
+// draft model is loaded, and reports throughput to the Log writer. It
+// returns the token count and why generation ended.
+func (e *Engine) generate(w io.Writer, limit int) (int, string) {
 	start := time.Now()
 	gen := 0
 	if e.draft != nil {
 		var stats specStats
-		e.logits, e.steps, _, stats = generateSpeculative(e.model, e.draft, e.logits, e.steps,
+		var finish string
+		e.logits, e.steps, finish, stats = generateSpeculative(e.model, e.draft, e.logits, e.steps,
 			limit, e.nCtx, e.opts.SpecK, e.opts.Temp, e.opts.TopP, func(id int) bool {
 				return id == e.imEnd || id == e.eot
 			}, e.rng, func(id int) bool {
@@ -291,12 +293,14 @@ func (e *Engine) generate(w io.Writer, limit int) {
 		fmt.Fprintln(w)
 		fmt.Fprintf(e.opts.Log, "(%d tokens, %.1f tok/s, %d/%d drafts accepted)\n",
 			gen, float64(gen)/time.Since(start).Seconds(), stats.accepted, stats.proposed)
-		return
+		return gen, finish
 	}
+	finish := "length"
 	for ; gen < limit && e.steps < e.nCtx-1; gen++ {
 		next := sample(e.logits, e.opts.Temp, e.opts.TopP, e.rng)
 		if next == e.imEnd || next == e.eot {
 			e.feed([]int{next})
+			finish = "stop"
 			break
 		}
 		fmt.Fprint(w, e.tok.Decode([]int{next}))
@@ -305,11 +309,21 @@ func (e *Engine) generate(w io.Writer, limit int) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(e.opts.Log, "(%d tokens, %.1f tok/s)\n",
 		gen, float64(gen)/time.Since(start).Seconds())
+	return gen, finish
+}
+
+// RunResult reports what one Generate call did.
+type RunResult struct {
+	PromptTokens     int
+	CompletionTokens int
+	Finish           string // "stop" or "length"
+	Prefill          time.Duration
+	Total            time.Duration
 }
 
 // Generate runs one completion: the prompt goes through the model's chat
 // template (or verbatim when raw), and up to n sampled tokens stream to w.
-func (e *Engine) Generate(w io.Writer, prompt string, raw bool, n int) {
+func (e *Engine) Generate(w io.Writer, prompt string, raw bool, n int) RunResult {
 	text := prompt
 	if !raw {
 		if e.tm.foldSystem {
@@ -323,10 +337,15 @@ func (e *Engine) Generate(w io.Writer, prompt string, raw bool, n int) {
 	fmt.Fprintf(e.opts.Log, "prompt: %d tokens\n", len(ids))
 	start := time.Now()
 	e.feed(ids)
-	fmt.Fprintf(e.opts.Log, "prefill: %v\n", time.Since(start).Round(time.Millisecond))
-	e.generate(w, n)
+	prefill := time.Since(start)
+	fmt.Fprintf(e.opts.Log, "prefill: %v\n", prefill.Round(time.Millisecond))
+	gen, finish := e.generate(w, n)
 	fmt.Fprintf(e.opts.Log, "%d tokens total in %v\n",
 		e.steps, time.Since(start).Round(time.Millisecond))
+	return RunResult{
+		PromptTokens: len(ids), CompletionTokens: gen, Finish: finish,
+		Prefill: prefill, Total: time.Since(start),
+	}
 }
 
 // Chat runs an interactive multi-turn loop: one line of in per turn, the


### PR DESCRIPTION
Generate now returns a RunResult (token counts, finish reason, and timings), and run -json prints one JSON object — content, finish, usage, and throughput — on stdout with the progress chatter still on stderr, so the output pipes straight into jq.