### PR TITLE
Publish a scratch container image from tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+goxz
+tensai
+*.gguf
+*.gguf.tensai-*.cache
+_example/charrnn/charrnn
+_example/dataset/dataset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,34 @@ jobs:
       run: make upload
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to ghcr.io
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          REVISION=${{ github.sha }}
+        tags: |
+          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# A scratch image around the static tensai binary:
+#
+#	docker run -it --rm ghcr.io/mattn/tensai chat -q8
+#
+# Models download into /cache (XDG_CACHE_HOME), so mount a volume — or
+# the host's own cache — to keep them across runs:
+#
+#	docker run -it --rm -v tensai-cache:/cache ghcr.io/mattn/tensai chat -q8
+FROM golang:1.27 AS build
+ARG TARGETARCH
+ARG REVISION=docker
+WORKDIR /src
+COPY . .
+# No wgpu tag: purego's dlopen layer needs a dynamic libc, and scratch
+# has neither that nor Vulkan — the container is the CPU path, and the
+# untagged build is truly static.
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GOEXPERIMENT=simd \
+    go build -ldflags "-s -w -X main.revision=$REVISION" \
+    -o /tensai ./cmd/tensai
+
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /tensai /tensai
+ENV XDG_CACHE_HOME=/cache
+VOLUME /cache
+ENTRYPOINT ["/tensai"]
+CMD ["chat"]


### PR DESCRIPTION
A two-stage Dockerfile puts the static CPU binary and the CA bundle into scratch — the wgpu tag stays out, since purego's dlopen layer wants a dynamic libc and scratch has neither that nor Vulkan — with models cached under the /cache volume via XDG_CACHE_HOME and chat as the default command. The release workflow gains a docker job pushing linux/amd64 and arm64 images to ghcr.io as :latest and :vX.Y.Z on every tag. Verified locally: the image runs version and chat against a mounted host cache at full SIMD speed (42.6 tok/s in-container vs 42.0 on the host), and a fresh volume downloads the default model over TLS from scratch.