### PR TITLE
Serve a demo page, take an API key, and bind loopback by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /tensai /tensai
 ENV XDG_CACHE_HOME=/cache
+# serve binds loopback by default; inside a container it must answer on
+# the bridge for -p to work.
+ENV TENSAI_ADDR=:8080
 VOLUME /cache
 ENTRYPOINT ["/tensai"]
 CMD ["chat"]

--- a/_example/qwen/main.go
+++ b/_example/qwen/main.go
@@ -62,7 +62,7 @@ func main() {
 	defer e.Close()
 
 	if *serveAddr != "" {
-		if err := e.Serve(*serveAddr); err != nil {
+		if err := e.Serve(*serveAddr, ""); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -153,11 +153,16 @@ func main() {
 	case "serve":
 		fs := flag.NewFlagSet("tensai serve", flag.ExitOnError)
 		o, finish := modelFlags(fs)
-		addr := fs.String("addr", ":8080", "address to listen on")
+		defAddr := os.Getenv("TENSAI_ADDR")
+		if defAddr == "" {
+			defAddr = "127.0.0.1:8080"
+		}
+		addr := fs.String("addr", defAddr, "address to listen on (or $TENSAI_ADDR); loopback only unless widened")
+		apiKey := fs.String("api-key", os.Getenv("TENSAI_API_KEY"), "require this bearer token on the /v1 API (or $TENSAI_API_KEY)")
 		fs.Parse(args)
 		e := openEngine(o, finish)
 		defer e.Close()
-		if err := e.Serve(*addr); err != nil {
+		if err := e.Serve(*addr, *apiKey); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -381,10 +381,13 @@ func (e *Engine) Chat(in io.Reader, w io.Writer, n int) {
 	}
 }
 
-// Serve blocks on an OpenAI-compatible /v1/chat/completions server.
-func (e *Engine) Serve(addr string) error {
+// Serve blocks on an OpenAI-compatible /v1/chat/completions server,
+// with a demo page on GET /. A non-empty apiKey guards the /v1 routes
+// behind an Authorization: Bearer header.
+func (e *Engine) Serve(addr, apiKey string) error {
 	s := &server{
-		model: e.model, tok: e.tok, system: e.system, nCtx: e.nCtx,
+		apiKey: apiKey,
+		model:  e.model, tok: e.tok, system: e.system, nCtx: e.nCtx,
 		temp: e.opts.Temp, topP: e.opts.TopP, imEnd: e.imEnd, eot: e.eot,
 		tm: e.tm, prefill: e.prefill, step: e.step, reset: e.reset,
 		draft: e.draft, specK: e.opts.SpecK,

--- a/internal/llm/serve.go
+++ b/internal/llm/serve.go
@@ -9,6 +9,8 @@ package llm
 // address works against a pure-Go model.
 
 import (
+	"crypto/subtle"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -76,6 +78,7 @@ func render(tm tmpl, msgs []chatMessage, defaultSystem string) string {
 
 type server struct {
 	mu      sync.Mutex // one request drives the model at a time
+	apiKey  string     // "" leaves /v1 open
 	model   *qwen
 	draft   *qwen
 	specK   int
@@ -98,16 +101,50 @@ type tokenizerIface interface {
 	Decode([]int) string
 }
 
+// auth wraps a /v1 handler with the bearer check. The demo page stays
+// open — static HTML holds no secrets and a browser cannot attach a
+// bearer header to plain navigation anyway — while every API route
+// answers 401 until the right key arrives.
+func (s *server) auth(h http.HandlerFunc) http.HandlerFunc {
+	if s.apiKey == "" {
+		return h
+	}
+	want := []byte("Bearer " + s.apiKey)
+	return func(w http.ResponseWriter, r *http.Request) {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(got, want) == 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "invalid api key", "type": "invalid_request_error"},
+			})
+			return
+		}
+		h(w, r)
+	}
+}
+
+//go:embed webui.html
+var webUI []byte
+
 func (s *server) listen(addr string) error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/chat/completions", s.chatCompletions)
-	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/chat/completions", s.auth(s.chatCompletions))
+	mux.HandleFunc("/v1/models", s.auth(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{
 			"object": "list",
 			"data": []map[string]any{{
 				"id": "tensai", "object": "model", "owned_by": "tensai",
 			}},
 		})
+	}))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(webUI)
 	})
 	fmt.Printf("listening on %s (POST /v1/chat/completions)\n", addr)
 	return http.ListenAndServe(addr, mux)

--- a/internal/llm/webui.html
+++ b/internal/llm/webui.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tensai</title>
+<style>
+:root { color-scheme: light dark; }
+body { font-family: system-ui, sans-serif; max-width: 46rem; margin: 2rem auto; padding: 0 1rem; }
+h1 { font-size: 1.2rem; } h1 small { font-weight: normal; opacity: .6; }
+textarea { width: 100%; box-sizing: border-box; min-height: 5rem; font: inherit; padding: .5rem; }
+#out { white-space: pre-wrap; border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+       border-radius: 6px; padding: .75rem; min-height: 6rem; margin-top: 1rem; }
+.row { display: flex; gap: 1rem; align-items: center; margin: .5rem 0; flex-wrap: wrap; }
+#key-row { display: none; }
+button { font: inherit; padding: .3rem 1.2rem; }
+input[type=password] { font: inherit; }
+.err { color: #c33; }
+</style>
+</head>
+<body>
+<h1>tensai <small id="model"></small></h1>
+<textarea id="prompt" placeholder="Ask something..."></textarea>
+<div class="row">
+  <button id="send">Send</button>
+  <label>temp <input id="temp" type="range" min="0" max="1.5" step="0.1" value="0.7">
+  <span id="tempv">0.7</span></label>
+</div>
+<div class="row" id="key-row">
+  <label>API key <input id="key" type="password"></label>
+  <button id="savekey">Save</button>
+</div>
+<div id="out"></div>
+<script>
+const $ = id => document.getElementById(id);
+const headers = () => {
+  const h = { "Content-Type": "application/json" };
+  let k = "";
+  try { k = localStorage.getItem("tensai-api-key") || ""; } catch {}
+  if (k) h["Authorization"] = "Bearer " + k;
+  return h;
+};
+const needKey = () => { $("key-row").style.display = "flex"; };
+$("savekey").onclick = () => {
+  try { localStorage.setItem("tensai-api-key", $("key").value); } catch {}
+  $("key-row").style.display = "none";
+  load();
+};
+$("temp").oninput = () => $("tempv").textContent = $("temp").value;
+
+async function load() {
+  try {
+    const r = await fetch("v1/models", { headers: headers() });
+    if (r.status === 401) return needKey();
+    const d = await r.json();
+    $("model").textContent = d.data?.[0]?.id || "";
+  } catch {}
+}
+load();
+
+$("send").onclick = async () => {
+  const out = $("out");
+  out.textContent = "";
+  out.classList.remove("err");
+  $("send").disabled = true;
+  try {
+    const r = await fetch("v1/chat/completions", {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        model: "tensai",
+        messages: [{ role: "user", content: $("prompt").value }],
+        temperature: parseFloat($("temp").value),
+        max_tokens: 1024,
+        stream: true,
+      }),
+    });
+    if (r.status === 401) { needKey(); out.textContent = "unauthorized: enter the API key"; out.classList.add("err"); return; }
+    if (!r.ok) { out.textContent = r.status + " " + await r.text(); out.classList.add("err"); return; }
+    const rd = r.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { done, value } = await rd.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let i;
+      while ((i = buf.indexOf("\n\n")) >= 0) {
+        const line = buf.slice(0, i).trim();
+        buf = buf.slice(i + 2);
+        if (!line.startsWith("data: ") || line === "data: [DONE]") continue;
+        try {
+          const c = JSON.parse(line.slice(6));
+          out.textContent += c.choices?.[0]?.delta?.content || "";
+        } catch {}
+      }
+    }
+  } catch (e) {
+    out.textContent = String(e);
+    out.classList.add("err");
+  } finally {
+    $("send").disabled = false;
+  }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
GET / answers with an embedded single-file page — a prompt box that streams the completion, no framework, no build step — which doubles as the quickest is-it-working check. serve gains -api-key (or TENSAI_API_KEY): every /v1 route then wants Authorization: Bearer, compared in constant time, while the page stays open (static HTML holds no secrets and browser navigation cannot carry a bearer header) and asks for the key itself on a 401, keeping it in localStorage. The default address narrows to 127.0.0.1:8080 (TENSAI_ADDR or -addr widens it); the container keeps answering through -p via TENSAI_ADDR in the image. Verified: page serves from the bare binary and from the container, /v1 returns 401 without or with a wrong key and 200 with the right one, streaming works with the key, and other paths 404.