### PR TITLE
Thread the spatial shape through Sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,18 @@ for epoch := 0; epoch < epochs; epoch++ {
 
 ```go
 net := model.NewSequential()
-net.Add(layer.NewConv2D(28, 28, 1, 8, 3, 1, 1)) // inH, inW, inC, outC, kernel, stride, pad
+net.Add(layer.NewConv2D(8, 3, 1, 1)) // outC, kernel, stride, pad
 net.Add(&layer.ReLU{})
-net.Add(layer.NewMaxPool2D(28, 28, 8, 2))
+net.Add(layer.NewMaxPool2D(2))
 net.Add(layer.NewDense(64))
 net.Add(layer.NewBatchNorm())
 net.Add(layer.NewLeakyReLU(0.01))
 net.Add(layer.NewDropout(0.3))
 net.Add(layer.NewDense(10))
 
-net.Compile(28*28, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
+// The input geometry is stated once; the spatial shape threads through
+// the stack, so the conv and pool layers pick their dimensions up from it.
+net.CompileImage(layer.Image{H: 28, W: 28, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
 net.Fit(inputs, targets, 10)
 
 net.SaveFile("model.json")

--- a/_example/mnist/main.go
+++ b/_example/mnist/main.go
@@ -276,12 +276,12 @@ func buildModel(kind string) (*model.Sequential, error) {
 		model.Add(&layer.ReLU{})
 		model.Add(layer.NewDense(classCount))
 	case "cnn":
-		model.Add(layer.NewConv2D(28, 28, 1, 8, 3, 1, 1)) // 28x28x1 -> 28x28x8
+		model.Add(layer.NewConv2D(8, 3, 1, 1)) // 28x28x1 -> 28x28x8
 		model.Add(&layer.ReLU{})
-		model.Add(layer.NewMaxPool2D(28, 28, 8, 2)) // -> 14x14x8
-		model.Add(layer.NewConv2D(14, 14, 8, 16, 3, 1, 1))
+		model.Add(layer.NewMaxPool2D(2)) // -> 14x14x8
+		model.Add(layer.NewConv2D(16, 3, 1, 1))
 		model.Add(&layer.ReLU{})
-		model.Add(layer.NewMaxPool2D(14, 14, 16, 2)) // -> 7x7x16
+		model.Add(layer.NewMaxPool2D(2)) // -> 7x7x16
 		model.Add(layer.NewDense(64))
 		model.Add(&layer.ReLU{})
 		model.Add(layer.NewDropout(0.25))
@@ -289,7 +289,15 @@ func buildModel(kind string) (*model.Sequential, error) {
 	default:
 		return nil, fmt.Errorf("unknown model kind %q (want dense or cnn)", kind)
 	}
-	if err := model.Compile(imageSize, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01)); err != nil {
+	var err error
+	if kind == "cnn" {
+		// The input geometry is stated once; Conv2D and MaxPool2D pick their
+		// dimensions up from the threaded shape.
+		err = model.CompileImage(layer.Image{H: 28, W: 28, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
+	} else {
+		err = model.Compile(imageSize, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
+	}
+	if err != nil {
 		return nil, err
 	}
 	return model, nil

--- a/docs/guide/layers.ja.md
+++ b/docs/guide/layers.ja.md
@@ -23,8 +23,8 @@ type Layer interface {
 |---|---|---|
 | Dense | `layer.NewDense(outCols)` | 全結合。Glorot/He スタイルの初期化 |
 | Embedding | `layer.NewEmbedding(vocabSize, dim)` | 入力行は `Float` に格納された整数トークン ID。引いたベクトルは行方向に連結 |
-| Conv2D | `layer.NewConv2D(inH, inW, inC, outC, kernel, stride, pad)` | im2col + `Dot` カーネル |
-| MaxPool2D | `layer.NewMaxPool2D(inH, inW, channels, size)` | |
+| Conv2D | `layer.NewConv2D(outC, kernel, stride, pad)` | im2col + `Dot` カーネル。入力形状は `CompileImage` から |
+| MaxPool2D | `layer.NewMaxPool2D(size)` | 入力形状は `CompileImage` から |
 | BatchNorm | `layer.NewBatchNorm()` | 移動統計量はモデルと一緒に保存されます |
 | LayerNorm | `layer.NewLayerNorm()` | 行ごとの正規化 |
 | Dropout | `layer.NewDropout(rate)` | 学習時のみ有効 |

--- a/docs/guide/layers.md
+++ b/docs/guide/layers.md
@@ -23,8 +23,8 @@ type Layer interface {
 |---|---|---|
 | Dense | `layer.NewDense(outCols)` | Fully connected; Glorot/He-style initialization |
 | Embedding | `layer.NewEmbedding(vocabSize, dim)` | Input rows are integer token ids stored in `Float`; looked-up vectors concatenate across the row |
-| Conv2D | `layer.NewConv2D(inH, inW, inC, outC, kernel, stride, pad)` | im2col + the `Dot` kernel |
-| MaxPool2D | `layer.NewMaxPool2D(inH, inW, channels, size)` | |
+| Conv2D | `layer.NewConv2D(outC, kernel, stride, pad)` | im2col + the `Dot` kernel; input shape comes from `CompileImage` |
+| MaxPool2D | `layer.NewMaxPool2D(size)` | Input shape comes from `CompileImage` |
 | BatchNorm | `layer.NewBatchNorm()` | Running statistics are saved with the model |
 | LayerNorm | `layer.NewLayerNorm()` | Per-row normalization |
 | Dropout | `layer.NewDropout(rate)` | Active only during training |

--- a/docs/guide/training.ja.md
+++ b/docs/guide/training.ja.md
@@ -44,16 +44,18 @@ for epoch := 0; epoch < epochs; epoch++ {
 
 ```go
 net := model.NewSequential()
-net.Add(layer.NewConv2D(28, 28, 1, 8, 3, 1, 1)) // inH, inW, inC, outC, kernel, stride, pad
+net.Add(layer.NewConv2D(8, 3, 1, 1)) // outC, kernel, stride, pad
 net.Add(&layer.ReLU{})
-net.Add(layer.NewMaxPool2D(28, 28, 8, 2))
+net.Add(layer.NewMaxPool2D(2))
 net.Add(layer.NewDense(64))
 net.Add(layer.NewBatchNorm())
 net.Add(layer.NewLeakyReLU(0.01))
 net.Add(layer.NewDropout(0.3))
 net.Add(layer.NewDense(10))
 
-net.Compile(28*28, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
+// 入力の形状は一度だけ書く。空間形状がスタックを流れるので
+// conv / pool レイヤーは自分の入力サイズをそこから受け取る
+net.CompileImage(layer.Image{H: 28, W: 28, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
 net.Fit(inputs, targets, 10)
 ```
 

--- a/docs/guide/training.md
+++ b/docs/guide/training.md
@@ -44,16 +44,18 @@ for epoch := 0; epoch < epochs; epoch++ {
 
 ```go
 net := model.NewSequential()
-net.Add(layer.NewConv2D(28, 28, 1, 8, 3, 1, 1)) // inH, inW, inC, outC, kernel, stride, pad
+net.Add(layer.NewConv2D(8, 3, 1, 1)) // outC, kernel, stride, pad
 net.Add(&layer.ReLU{})
-net.Add(layer.NewMaxPool2D(28, 28, 8, 2))
+net.Add(layer.NewMaxPool2D(2))
 net.Add(layer.NewDense(64))
 net.Add(layer.NewBatchNorm())
 net.Add(layer.NewLeakyReLU(0.01))
 net.Add(layer.NewDropout(0.3))
 net.Add(layer.NewDense(10))
 
-net.Compile(28*28, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
+// The input geometry is stated once; the spatial shape threads through
+// the stack, so the conv and pool layers pick their dimensions up from it.
+net.CompileImage(layer.Image{H: 28, W: 28, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdamW(0.001, 0.01))
 net.Fit(inputs, targets, 10)
 ```
 

--- a/encoding/onnx/marshal_test.go
+++ b/encoding/onnx/marshal_test.go
@@ -76,13 +76,13 @@ func TestMarshalMLP(t *testing.T) {
 func TestMarshalCNN(t *testing.T) {
 	rng := rand.New(rand.NewSource(2))
 	m := model.NewSequential()
-	m.Add(layer.NewConv2D(8, 8, 2, 6, 3, 1, 1))
+	m.Add(layer.NewConv2D(6, 3, 1, 1))
 	m.Add(&layer.ReLU{})
-	m.Add(layer.NewMaxPool2D(8, 8, 6, 2))
-	m.Add(layer.NewConv2D(4, 4, 6, 4, 3, 1, 0))
+	m.Add(layer.NewMaxPool2D(2))
+	m.Add(layer.NewConv2D(4, 3, 1, 0))
 	m.Add(&layer.Sigmoid{})
 	m.Add(layer.NewDense(5))
-	if err := m.Compile(8*8*2, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
+	if err := m.CompileImage(layer.Image{H: 8, W: 8, C: 2}, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
 		t.Fatal(err)
 	}
 	trainStep(t, m, 8*8*2, 5, true, rng)
@@ -114,9 +114,9 @@ func TestMarshalErrors(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(3))
 	sm := model.NewSequential()
-	sm.Add(layer.NewConv2D(4, 4, 1, 2, 3, 1, 1))
+	sm.Add(layer.NewConv2D(2, 3, 1, 1))
 	sm.Add(&layer.Softmax{})
-	if err := sm.Compile(16, loss.MeanSquaredError{}, optim.NewAdam(0.01)); err != nil {
+	if err := sm.CompileImage(layer.Image{H: 4, W: 4, C: 1}, loss.MeanSquaredError{}, optim.NewAdam(0.01)); err != nil {
 		t.Fatal(err)
 	}
 	trainStep(t, sm, 16, 32, false, rng)

--- a/encoding/tflite/marshal_test.go
+++ b/encoding/tflite/marshal_test.go
@@ -25,15 +25,15 @@ func buildMLP(t *testing.T) *model.Sequential {
 func buildCNN(t *testing.T) *model.Sequential {
 	t.Helper()
 	m := model.NewSequential()
-	m.Add(layer.NewConv2D(8, 8, 1, 4, 3, 1, 1))
+	m.Add(layer.NewConv2D(4, 3, 1, 1))
 	m.Add(&layer.ReLU{})
-	m.Add(layer.NewMaxPool2D(8, 8, 4, 2))
+	m.Add(layer.NewMaxPool2D(2))
 	m.Add(layer.NewDense(8))
 	m.Add(layer.NewBatchNorm())
 	m.Add(layer.NewLeakyReLU(0.1))
 	m.Add(layer.NewDropout(0.2))
 	m.Add(layer.NewDense(2))
-	if err := m.Compile(8*8, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
+	if err := m.CompileImage(layer.Image{H: 8, W: 8, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
 		t.Fatal(err)
 	}
 	return m
@@ -72,8 +72,8 @@ func TestMarshalRejectsUnsupported(t *testing.T) {
 	}
 
 	m = model.NewSequential()
-	m.Add(layer.NewConv2D(8, 8, 1, 4, 5, 1, 1)) // k=5, pad=1: neither VALID nor SAME
-	if err := m.Compile(8*8, loss.MeanSquaredError{}, optim.NewAdam(0.01)); err != nil {
+	m.Add(layer.NewConv2D(4, 5, 1, 1)) // k=5, pad=1: neither VALID nor SAME
+	if err := m.CompileImage(layer.Image{H: 8, W: 8, C: 1}, loss.MeanSquaredError{}, optim.NewAdam(0.01)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := Marshal(m); err == nil {

--- a/layer/conv.go
+++ b/layer/conv.go
@@ -7,6 +7,28 @@ import (
 	"github.com/mattn/tensai"
 )
 
+// Image describes the spatial shape of one flattened sample row: C
+// channels of HxW pixels in channel-major order,
+// index = (channel*H + y)*W + x.
+type Image struct {
+	H, W, C int
+}
+
+// Cols is the flattened row width of the image.
+func (im Image) Cols() int { return im.H * im.W * im.C }
+
+// ImageLayer is implemented by layers that consume a spatial input shape.
+// Sequential models thread the Image through the stack: hand the input
+// shape to CompileImage, and layers that keep the row width (activations,
+// BatchNorm, LayerNorm, Dropout) pass it along automatically, so Conv2D and
+// MaxPool2D never state their input dimensions.
+type ImageLayer interface {
+	Layer
+	// InitImage configures the layer from the incoming image shape and
+	// returns the outgoing one.
+	InitImage(in Image, rng *rand.Rand) (Image, error)
+}
+
 // Conv2D is a 2D convolution layer. Because the framework moves data as flat
 // MxN matrices, each sample row must be laid out channel-major:
 // index = (channel*height + y)*width + x. The output uses the same layout.
@@ -36,31 +58,36 @@ type Conv2D struct {
 	prod, wT, gRe, dcols, gradIn *tensai.Matrix
 }
 
-// NewConv2D returns a convolution layer for inH x inW inputs with inC
-// channels, producing outC channels with a square kernel.
-func NewConv2D(inH, inW, inC, outC, kernel, stride, pad int) *Conv2D {
-	return &Conv2D{inH: inH, inW: inW, inC: inC, outC: outC, kernel: kernel, stride: stride, pad: pad}
+// NewConv2D returns a convolution layer producing outC channels with a
+// square kernel. The input dimensions come from the model: compile with
+// CompileImage and the spatial shape threads through the stack.
+func NewConv2D(outC, kernel, stride, pad int) *Conv2D {
+	return &Conv2D{outC: outC, kernel: kernel, stride: stride, pad: pad}
 }
 
+// Init without a spatial shape cannot configure a convolution.
 func (c *Conv2D) Init(inputCols int, rng *rand.Rand) (int, error) {
+	return 0, fmt.Errorf("tensai: conv2d needs a spatial input shape; compile the model with CompileImage")
+}
+
+// InitImage configures the convolution from the incoming image shape.
+func (c *Conv2D) InitImage(in Image, rng *rand.Rand) (Image, error) {
+	c.inH, c.inW, c.inC = in.H, in.W, in.C
 	if c.inH <= 0 || c.inW <= 0 || c.inC <= 0 || c.outC <= 0 || c.kernel <= 0 || c.stride <= 0 || c.pad < 0 {
-		return 0, fmt.Errorf("tensai: conv2d invalid config: in=%dx%dx%d out=%d kernel=%d stride=%d pad=%d",
+		return Image{}, fmt.Errorf("tensai: conv2d invalid config: in=%dx%dx%d out=%d kernel=%d stride=%d pad=%d",
 			c.inH, c.inW, c.inC, c.outC, c.kernel, c.stride, c.pad)
-	}
-	if inputCols != c.inH*c.inW*c.inC {
-		return 0, fmt.Errorf("tensai: conv2d input cols %d != %dx%dx%d", inputCols, c.inH, c.inW, c.inC)
 	}
 	c.outH = (c.inH+2*c.pad-c.kernel)/c.stride + 1
 	c.outW = (c.inW+2*c.pad-c.kernel)/c.stride + 1
 	if c.outH <= 0 || c.outW <= 0 {
-		return 0, fmt.Errorf("tensai: conv2d kernel %d does not fit input %dx%d (pad %d)",
+		return Image{}, fmt.Errorf("tensai: conv2d kernel %d does not fit input %dx%d (pad %d)",
 			c.kernel, c.inH, c.inW, c.pad)
 	}
 	c.weights = tensai.RandomMatrix(c.inC*c.kernel*c.kernel, c.outC, rng)
 	c.bias = make([]tensai.Float, c.outC)
 	c.gradW = tensai.NewMatrix(c.weights.Rows, c.weights.Cols)
 	c.gradB = make([]tensai.Float, c.outC)
-	return c.outH * c.outW * c.outC, nil
+	return Image{H: c.outH, W: c.outW, C: c.outC}, nil
 }
 
 // im2col expands the input batch into patch rows: one row per output pixel,
@@ -218,26 +245,32 @@ type MaxPool2D struct {
 	inCols     int
 }
 
-// NewMaxPool2D returns a max-pooling layer with stride equal to size.
-func NewMaxPool2D(inH, inW, channels, size int) *MaxPool2D {
-	return &MaxPool2D{inH: inH, inW: inW, channels: channels, size: size}
+// NewMaxPool2D returns a max-pooling layer with stride equal to size. The
+// input dimensions come from the model: compile with CompileImage and the
+// spatial shape threads through the stack.
+func NewMaxPool2D(size int) *MaxPool2D {
+	return &MaxPool2D{size: size}
 }
 
+// Init without a spatial shape cannot configure a pooling layer.
 func (p *MaxPool2D) Init(inputCols int, _ *rand.Rand) (int, error) {
+	return 0, fmt.Errorf("tensai: maxpool2d needs a spatial input shape; compile the model with CompileImage")
+}
+
+// InitImage configures the pooling layer from the incoming image shape.
+func (p *MaxPool2D) InitImage(in Image, _ *rand.Rand) (Image, error) {
+	p.inH, p.inW, p.channels = in.H, in.W, in.C
 	if p.inH <= 0 || p.inW <= 0 || p.channels <= 0 || p.size <= 0 {
-		return 0, fmt.Errorf("tensai: maxpool2d invalid config: in=%dx%dx%d size=%d",
+		return Image{}, fmt.Errorf("tensai: maxpool2d invalid config: in=%dx%dx%d size=%d",
 			p.inH, p.inW, p.channels, p.size)
-	}
-	if inputCols != p.inH*p.inW*p.channels {
-		return 0, fmt.Errorf("tensai: maxpool2d input cols %d != %dx%dx%d", inputCols, p.inH, p.inW, p.channels)
 	}
 	p.outH = p.inH / p.size
 	p.outW = p.inW / p.size
 	if p.outH == 0 || p.outW == 0 {
-		return 0, fmt.Errorf("tensai: maxpool2d size %d larger than input %dx%d", p.size, p.inH, p.inW)
+		return Image{}, fmt.Errorf("tensai: maxpool2d size %d larger than input %dx%d", p.size, p.inH, p.inW)
 	}
-	p.inCols = inputCols
-	return p.outH * p.outW * p.channels, nil
+	p.inCols = in.Cols()
+	return Image{H: p.outH, W: p.outW, C: p.channels}, nil
 }
 
 func (p *MaxPool2D) Forward(input *tensai.Matrix) (*tensai.Matrix, error) {

--- a/layer/features_test.go
+++ b/layer/features_test.go
@@ -197,13 +197,13 @@ func TestBatchNormEvalUsesRunningStats(t *testing.T) {
 
 func TestConv2DGradient(t *testing.T) {
 	rng := rand.New(rand.NewSource(7))
-	conv := NewConv2D(5, 5, 2, 3, 3, 1, 1)
-	outCols, err := conv.Init(5*5*2, rng)
+	conv := NewConv2D(3, 3, 1, 1)
+	outImg, err := conv.InitImage(Image{H: 5, W: 5, C: 2}, rng)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outCols != 5*5*3 {
-		t.Fatalf("expected out cols %d, got %d", 5*5*3, outCols)
+	if outImg.Cols() != 5*5*3 {
+		t.Fatalf("expected out cols %d, got %d", 5*5*3, outImg.Cols())
 	}
 	checkLayerGrad(t, conv, randomInput(2, 5*5*2, 8), 1e-2)
 
@@ -242,13 +242,13 @@ func TestConv2DGradient(t *testing.T) {
 }
 
 func TestMaxPool2DGradient(t *testing.T) {
-	pool := NewMaxPool2D(4, 4, 2, 2)
-	outCols, err := pool.Init(4*4*2, nil)
+	pool := NewMaxPool2D(2)
+	outImg, err := pool.InitImage(Image{H: 4, W: 4, C: 2}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outCols != 2*2*2 {
-		t.Fatalf("expected out cols %d, got %d", 2*2*2, outCols)
+	if outImg.Cols() != 2*2*2 {
+		t.Fatalf("expected out cols %d, got %d", 2*2*2, outImg.Cols())
 	}
 	// Distinct values avoid ties, where max is not differentiable.
 	in := tensai.NewMatrix(2, 4*4*2)

--- a/model/model.go
+++ b/model/model.go
@@ -42,8 +42,26 @@ func (s *Sequential) Add(layer layer.Layer) *Sequential {
 }
 
 // Compile wires the loss and optimizer and initializes all parameters.
-// inputCols is the number of features in a single input row.
+// inputCols is the number of features in a single input row. Models that
+// start from flattened images should use CompileImage instead, which also
+// threads the spatial shape through the stack.
 func (s *Sequential) Compile(inputCols int, loss loss.Loss, optimizer optim.Optimizer) error {
+	return s.compile(inputCols, layer.Image{}, loss, optimizer)
+}
+
+// CompileImage is Compile for models whose input rows are flattened
+// channel-major images. The spatial shape threads through the stack:
+// Conv2D and MaxPool2D take their input dimensions from it, and layers
+// that keep the row width (activations, BatchNorm, LayerNorm, Dropout)
+// pass it along, so only the model input states its geometry.
+func (s *Sequential) CompileImage(in layer.Image, loss loss.Loss, optimizer optim.Optimizer) error {
+	if in.H <= 0 || in.W <= 0 || in.C <= 0 {
+		return fmt.Errorf("tensai: CompileImage needs a positive input shape, got %dx%dx%d", in.H, in.W, in.C)
+	}
+	return s.compile(in.Cols(), in, loss, optimizer)
+}
+
+func (s *Sequential) compile(inputCols int, img layer.Image, loss loss.Loss, optimizer optim.Optimizer) error {
 	if len(s.layers) == 0 {
 		return fmt.Errorf("tensai: cannot compile a model with no layers")
 	}
@@ -59,9 +77,27 @@ func (s *Sequential) Compile(inputCols int, loss loss.Loss, optimizer optim.Opti
 
 	currentCols := inputCols
 	for i, l := range s.layers {
-		out, err := l.Init(currentCols, s.rng)
-		if err != nil {
-			return fmt.Errorf("tensai: layer %d init: %w", i, err)
+		var out int
+		if il, ok := l.(layer.ImageLayer); ok {
+			if img == (layer.Image{}) {
+				return fmt.Errorf("tensai: layer %d init: %T needs a spatial input shape; compile the model with CompileImage", i, l)
+			}
+			outImg, err := il.InitImage(img, s.rng)
+			if err != nil {
+				return fmt.Errorf("tensai: layer %d init: %w", i, err)
+			}
+			img = outImg
+			out = outImg.Cols()
+		} else {
+			var err error
+			out, err = l.Init(currentCols, s.rng)
+			if err != nil {
+				return fmt.Errorf("tensai: layer %d init: %w", i, err)
+			}
+			if out != currentCols {
+				// The layer reshaped the row; the spatial reading is gone.
+				img = layer.Image{}
+			}
 		}
 		// Layers that expose parameters register with the optimizer.
 		if w, _ := l.Params(); w != nil {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -227,11 +227,11 @@ func TestConvNetLearnsLineOrientation(t *testing.T) {
 	}
 
 	model := NewSequential()
-	model.Add(layer.NewConv2D(size, size, 1, 4, 3, 1, 1))
+	model.Add(layer.NewConv2D(4, 3, 1, 1))
 	model.Add(&layer.ReLU{})
-	model.Add(layer.NewMaxPool2D(size, size, 4, 2))
+	model.Add(layer.NewMaxPool2D(2))
 	model.Add(layer.NewDense(2))
-	if err := model.Compile(size*size, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.05)); err != nil {
+	if err := model.CompileImage(layer.Image{H: size, W: size, C: 1}, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.05)); err != nil {
 		t.Fatal(err)
 	}
 	var lossVal tensai.Float


### PR DESCRIPTION
Follow-up to #128 acting on the API review: NewConv2D's seven positional ints were the easiest place to silently misorder arguments, and every conv and pool layer restated dimensions the model already knew. Conv2D and MaxPool2D now take only their own parameters (NewConv2D(outC, kernel, stride, pad), NewMaxPool2D(size)) and get the input geometry from the model: CompileImage(layer.Image{H, W, C}, ...) states the input shape once and threads it through the stack via the new layer.ImageLayer interface, with width-preserving layers (activations, BatchNorm, LayerNorm, Dropout) passing it along and Dense dropping it. Compile is unchanged for non-spatial models. The exporters are untouched (Conv2D.Shape() still reports the resolved geometry); the mnist example, tests, README, and both documentation languages are updated.