### PR TITLE
Replace the optimizer index protocol with per-parameter updaters

### DIFF
--- a/autograd/autograd.go
+++ b/autograd/autograd.go
@@ -369,17 +369,18 @@ func (n *Node) Scalar() tensai.Float {
 //		trainer.Step(loss)
 //	}
 type Trainer struct {
-	opt    optim.Optimizer
+	ups    []optim.Updater
 	params []*Node
 }
 
-// NewTrainer registers the parameters with the optimizer and returns a
+// NewTrainer gives each parameter its own optimizer state and returns a
 // Trainer that updates them.
 func NewTrainer(opt optim.Optimizer, params ...*Node) *Trainer {
-	for range params {
-		opt.NewLayer()
+	ups := make([]optim.Updater, len(params))
+	for i := range ups {
+		ups[i] = opt.New()
 	}
-	return &Trainer{opt: opt, params: params}
+	return &Trainer{ups: ups, params: params}
 }
 
 // Step runs backward from the scalar loss, applies one optimizer update to
@@ -388,10 +389,10 @@ func (t *Trainer) Step(loss *Node) tensai.Float {
 	loss.Backward()
 	for i, p := range t.params {
 		if p.Grad == nil {
-			// Parameter unused in this graph; keep its optimizer slot aligned.
+			// Parameter unused in this graph; its state simply sits out.
 			continue
 		}
-		t.opt.Step(i, p.Value, p.Grad, nil, nil)
+		t.ups[i].Step(p.Value, p.Grad, nil, nil)
 	}
 	ZeroGrads(t.params...)
 	return loss.Scalar()

--- a/docs/guide/layers.ja.md
+++ b/docs/guide/layers.ja.md
@@ -31,7 +31,7 @@ type Layer interface {
 
 `Conv2D` と `MaxPool2D` は各行をチャンネル優先の画像として扱います: `index = (channel*height + y)*width + x`。`Dropout` と `BatchNorm` は `Fit`/`FitStep` 内では学習時の挙動、`Predict` 内では推論時の挙動へ自動的に切り替わります。
 
-`Embedding` は行列のみの API を保っています。各入力行はトークン ID の列で、レイヤーは引いた埋め込みベクトルを列方向に連結します。たとえば `Compile(4, ...)` と `NewEmbedding(vocab, 8)` の組み合わせは、`Mx4` のトークン ID 行列を `LayerNorm`, `GELU`, `Dense` に食わせられる `Mx32` の密な特徴行列に変えます。
+`Embedding` は行列のみの API を保っています。各入力行はトークン ID の列で (`tensai.NewMatrixFromInts` を使うと各 ID が float32 変換で正確に保たれることを検証しながら安全に作れます)、レイヤーは引いた埋め込みベクトルを列方向に連結します。たとえば `Compile(4, ...)` と `NewEmbedding(vocab, 8)` の組み合わせは、`Mx4` のトークン ID 行列を `LayerNorm`, `GELU`, `Dense` に食わせられる `Mx32` の密な特徴行列に変えます。
 
 ## 活性化関数
 
@@ -64,7 +64,7 @@ softmax は `SoftmaxCrossEntropy` の*内部*で適用されます (数値安定
 | Adam | `optim.NewAdam(lr)` |
 | AdamW | `optim.NewAdamW(lr, weightDecay)` — decoupled weight decay |
 
-Adam/AdamW のパラメータ更新は SIMD ビルドで AVX2 ベクトル化されるカーネルの 1 つです。
+`Optimizer` は更新則の設定そのものです。モデルはパラメータ対ごとに `optim.Updater` を 1 つ受け取り、Updater がその対の状態 (モーメンタムバッファ、Adam のモーメント、ステップ数) を持ちます。カスタムオプティマイザは `New() Updater` と Updater の `Step` の 2 つを実装するだけです。Adam/AdamW と SGD の更新は SIMD ビルドで AVX2 ベクトル化されます。
 
 ## k-NN ベースライン
 

--- a/docs/guide/layers.md
+++ b/docs/guide/layers.md
@@ -31,7 +31,7 @@ type Layer interface {
 
 `Conv2D` and `MaxPool2D` treat each row as a channel-major image: `index = (channel*height + y)*width + x`. `Dropout` and `BatchNorm` switch automatically between training behavior (inside `Fit`/`FitStep`) and inference behavior (inside `Predict`).
 
-`Embedding` keeps the matrix-only API: each input row is a token-id sequence, and the layer concatenates the looked-up embedding vectors across columns. For example, `Compile(4, ...)` plus `NewEmbedding(vocab, 8)` turns an `Mx4` token-id matrix into an `Mx32` dense feature matrix that can feed `LayerNorm`, `GELU`, and `Dense`.
+`Embedding` keeps the matrix-only API: each input row is a token-id sequence (build it safely with `tensai.NewMatrixFromInts`, which verifies every id survives the float32 conversion exactly), and the layer concatenates the looked-up embedding vectors across columns. For example, `Compile(4, ...)` plus `NewEmbedding(vocab, 8)` turns an `Mx4` token-id matrix into an `Mx32` dense feature matrix that can feed `LayerNorm`, `GELU`, and `Dense`.
 
 ## Activations
 
@@ -64,7 +64,7 @@ Softmax is applied *inside* `SoftmaxCrossEntropy` (with the row maximum subtract
 | Adam | `optim.NewAdam(lr)` |
 | AdamW | `optim.NewAdamW(lr, weightDecay)` — decoupled weight decay |
 
-The Adam/AdamW parameter update is one of the AVX2-vectorized kernels in the SIMD build.
+An `Optimizer` is just the rule's configuration: the model asks it for one `optim.Updater` per parameter pair, and the updater carries that pair's state (momentum buffers, Adam moments, step count). A custom optimizer therefore implements two small methods, `New() Updater` and the updater's `Step`. The Adam/AdamW and SGD parameter updates are AVX2-vectorized kernels in the SIMD build.
 
 ## k-NN baseline
 

--- a/model/model.go
+++ b/model/model.go
@@ -19,6 +19,7 @@ type Model interface {
 type Sequential struct {
 	layers    []layer.Layer
 	optimizer optim.Optimizer
+	updaters  []optim.Updater
 	loss      loss.Loss
 	lossName  string
 	rng       *rand.Rand
@@ -74,6 +75,7 @@ func (s *Sequential) compile(inputCols int, img layer.Image, loss loss.Loss, opt
 	s.loss = loss
 	s.lossName = loss.Name()
 	s.optimizer = optimizer
+	s.updaters = s.updaters[:0]
 
 	currentCols := inputCols
 	for i, l := range s.layers {
@@ -99,9 +101,9 @@ func (s *Sequential) compile(inputCols int, img layer.Image, loss loss.Loss, opt
 				img = layer.Image{}
 			}
 		}
-		// Layers that expose parameters register with the optimizer.
+		// Layers that expose parameters get their own optimizer state.
 		if w, _ := l.Params(); w != nil {
-			_ = optimizer.NewLayer()
+			s.updaters = append(s.updaters, optimizer.New())
 		}
 		if out <= 0 {
 			return fmt.Errorf("tensai: layer %d produced non-positive output cols: %d", i, out)
@@ -137,7 +139,7 @@ func (s *Sequential) backward(grad *tensai.Matrix) error {
 	return nil
 }
 
-// applyGrads updates each parameterized layer via the optimizer.
+// applyGrads updates each parameterized layer via its optimizer state.
 func (s *Sequential) applyGrads() {
 	idx := 0
 	for _, l := range s.layers {
@@ -146,7 +148,7 @@ func (s *Sequential) applyGrads() {
 			continue
 		}
 		gradW, gradB := l.Grads()
-		s.optimizer.Step(idx, weights, gradW, bias, gradB)
+		s.updaters[idx].Step(weights, gradW, bias, gradB)
 		idx++
 	}
 }

--- a/optim/optim.go
+++ b/optim/optim.go
@@ -7,25 +7,27 @@ import (
 	"github.com/mattn/tensai/internal/kernels"
 )
 
-// Optimizer updates a set of (weights, bias) parameter pairs using their
-// gradients. One Optimizer instance is shared by the model; each
-// parameterized layer gets its own state buffer inside the optimizer.
+// Optimizer is an update-rule configuration (learning rate, momentum, ...).
+// New hands out an Updater with fresh state for one parameter pair; the
+// model keeps one Updater per parameterized layer, so there is no index
+// bookkeeping between the model and the optimizer.
 type Optimizer interface {
-	// Step applies one update to the given parameters using their gradients.
-	// It is called once per parameterized layer.
-	Step(idx int, weights, gradW *tensai.Matrix, bias, gradB []tensai.Float)
-	// NewLayer registers a new parameterized layer and returns its index.
-	NewLayer() int
+	// New returns an Updater holding fresh per-parameter state.
+	New() Updater
 	// Name returns a short identifier.
 	Name() string
+}
+
+// Updater applies the optimizer rule to one (weights, bias) parameter pair,
+// carrying that pair's state (momentum buffers, Adam moments, step count).
+type Updater interface {
+	Step(weights, gradW *tensai.Matrix, bias, gradB []tensai.Float)
 }
 
 // SGD is stochastic gradient descent with optional momentum.
 type SGD struct {
 	LR       tensai.Float
 	Momentum tensai.Float
-	velW     []*tensai.Matrix
-	velB     [][]tensai.Float
 }
 
 // NewSGD returns an SGD optimizer. Momentum of 0 disables momentum.
@@ -36,24 +38,23 @@ func NewSGD(lr, momentum tensai.Float) *SGD {
 // Name returns "sgd".
 func (s *SGD) Name() string { return "sgd" }
 
-// NewLayer registers a layer and returns its index.
-func (s *SGD) NewLayer() int {
-	idx := len(s.velW)
-	s.velW = append(s.velW, nil)
-	s.velB = append(s.velB, nil)
-	return idx
+// New returns an updater with fresh velocity buffers.
+func (s *SGD) New() Updater { return &sgdUpdater{cfg: s} }
+
+type sgdUpdater struct {
+	cfg  *SGD
+	velW *tensai.Matrix
+	velB []tensai.Float
 }
 
 // Step updates parameters with standard (momentum) SGD.
-func (s *SGD) Step(idx int, weights, gradW *tensai.Matrix, bias, gradB []tensai.Float) {
-	if s.velW[idx] == nil {
-		s.velW[idx] = tensai.NewMatrix(weights.Rows, weights.Cols)
+func (u *sgdUpdater) Step(weights, gradW *tensai.Matrix, bias, gradB []tensai.Float) {
+	if u.velW == nil {
+		u.velW = tensai.NewMatrix(weights.Rows, weights.Cols)
+		u.velB = make([]tensai.Float, len(bias))
 	}
-	if s.velB[idx] == nil {
-		s.velB[idx] = make([]tensai.Float, len(bias))
-	}
-	kernels.SGDStep(weights.Data, gradW.Data, s.velW[idx].Data, s.Momentum, s.LR)
-	kernels.SGDStep(bias, gradB, s.velB[idx], s.Momentum, s.LR)
+	kernels.SGDStep(weights.Data, gradW.Data, u.velW.Data, u.cfg.Momentum, u.cfg.LR)
+	kernels.SGDStep(bias, gradB, u.velB, u.cfg.Momentum, u.cfg.LR)
 }
 
 // Adam optimizer. With WeightDecay > 0 it becomes AdamW: decay is decoupled
@@ -64,11 +65,6 @@ type Adam struct {
 	Beta2       tensai.Float
 	Eps         tensai.Float
 	WeightDecay tensai.Float
-	t           int
-	mW          []*tensai.Matrix
-	vW          []*tensai.Matrix
-	mB          [][]tensai.Float
-	vB          [][]tensai.Float
 }
 
 // NewAdam returns an Adam optimizer with standard defaults.
@@ -86,36 +82,39 @@ func NewAdamW(lr, weightDecay tensai.Float) *Adam {
 // Name returns "adam".
 func (a *Adam) Name() string { return "adam" }
 
-// NewLayer registers a layer and returns its index.
-func (a *Adam) NewLayer() int {
-	idx := len(a.mW)
-	a.mW = append(a.mW, nil)
-	a.vW = append(a.vW, nil)
-	a.mB = append(a.mB, nil)
-	a.vB = append(a.vB, nil)
-	return idx
+// New returns an updater with fresh moment buffers and step count.
+func (a *Adam) New() Updater { return &adamUpdater{cfg: a} }
+
+type adamUpdater struct {
+	cfg *Adam
+	t   int
+	mW  *tensai.Matrix
+	vW  *tensai.Matrix
+	mB  []tensai.Float
+	vB  []tensai.Float
 }
 
-// Step updates parameters with the Adam rule.
-func (a *Adam) Step(idx int, weights, gradW *tensai.Matrix, bias, gradB []tensai.Float) {
-	if a.mW[idx] == nil {
-		a.mW[idx] = tensai.NewMatrix(weights.Rows, weights.Cols)
-		a.vW[idx] = tensai.NewMatrix(weights.Rows, weights.Cols)
-		a.mB[idx] = make([]tensai.Float, len(bias))
-		a.vB[idx] = make([]tensai.Float, len(bias))
+// Step updates parameters with the Adam rule. The bias-correction step
+// count is per parameter, so a parameter that skips a step (an unused
+// autograd node) keeps its correction exact.
+func (u *adamUpdater) Step(weights, gradW *tensai.Matrix, bias, gradB []tensai.Float) {
+	if u.mW == nil {
+		u.mW = tensai.NewMatrix(weights.Rows, weights.Cols)
+		u.vW = tensai.NewMatrix(weights.Rows, weights.Cols)
+		u.mB = make([]tensai.Float, len(bias))
+		u.vB = make([]tensai.Float, len(bias))
 	}
-	a.t++
-	mW, vW := a.mW[idx], a.vW[idx]
-	mB, vB := a.mB[idx], a.vB[idx]
+	u.t++
+	a := u.cfg
 
 	// Bias corrections depend only on t, so hoist them out of the loops.
-	rc1 := 1 / (1 - kernels.PowF(a.Beta1, tensai.Float(a.t)))
-	rc2 := 1 / (1 - kernels.PowF(a.Beta2, tensai.Float(a.t)))
+	rc1 := 1 / (1 - kernels.PowF(a.Beta1, tensai.Float(u.t)))
+	rc2 := 1 / (1 - kernels.PowF(a.Beta2, tensai.Float(u.t)))
 
-	kernels.AdamStep(weights.Data, gradW.Data, mW.Data, vW.Data,
+	kernels.AdamStep(weights.Data, gradW.Data, u.mW.Data, u.vW.Data,
 		a.Beta1, a.Beta2, rc1, rc2, a.LR, a.Eps, a.WeightDecay)
 	// Decoupled weight decay is never applied to biases.
-	kernels.AdamStep(bias, gradB, mB, vB, a.Beta1, a.Beta2, rc1, rc2, a.LR, a.Eps, 0)
+	kernels.AdamStep(bias, gradB, u.mB, u.vB, a.Beta1, a.Beta2, rc1, rc2, a.LR, a.Eps, 0)
 }
 
 // Assert Optimizer implementations conform to the interface at compile time.

--- a/optim/optim_test.go
+++ b/optim/optim_test.go
@@ -7,15 +7,14 @@ import (
 )
 
 func TestAdamWDecaysWeights(t *testing.T) {
-	adam := NewAdamW(0.1, 0.5)
-	adam.NewLayer()
+	adam := NewAdamW(0.1, 0.5).New()
 	weights := tensai.NewMatrix(1, 2)
 	weights.Data[0] = 1
 	weights.Data[1] = -2
 	bias := []tensai.Float{3}
 	// Zero gradients: plain Adam would leave parameters unchanged; AdamW
 	// must still shrink weights (but never biases).
-	adam.Step(0, weights, tensai.NewMatrix(1, 2), bias, []tensai.Float{0})
+	adam.Step(weights, tensai.NewMatrix(1, 2), bias, []tensai.Float{0})
 	if weights.Data[0] >= 1 || weights.Data[1] <= -2 {
 		t.Errorf("weights not decayed: %v", weights.Data)
 	}

--- a/tensai_test.go
+++ b/tensai_test.go
@@ -104,3 +104,20 @@ func TestDotVecAxpy(t *testing.T) {
 	}()
 	DotVec(make([]Float, 3), make([]Float, 4))
 }
+
+func TestNewMatrixFromInts(t *testing.T) {
+	m, err := NewMatrixFromInts(2, 2, []int{0, 1, 65535, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.At(1, 0) != 65535 {
+		t.Fatalf("got %g", m.At(1, 0))
+	}
+	// 1<<25 + 1 is the first odd integer float32 cannot represent.
+	if _, err := NewMatrixFromInts(1, 1, []int{1<<25 + 1}); err == nil {
+		t.Fatal("expected exactness error")
+	}
+	if _, err := NewMatrixFromInts(2, 2, []int{1}); err == nil {
+		t.Fatal("expected length error")
+	}
+}

--- a/tensor.go
+++ b/tensor.go
@@ -36,6 +36,24 @@ func NewMatrixFromSlice(rows, cols int, data []Float) (*Matrix, error) {
 	return m, nil
 }
 
+// NewMatrixFromInts builds a matrix from integer values, verifying each one
+// survives the float32 conversion exactly. This is the safe way to build
+// token-id inputs for an Embedding layer, whose ids travel as Float.
+func NewMatrixFromInts(rows, cols int, data []int) (*Matrix, error) {
+	if len(data) != rows*cols {
+		return nil, fmt.Errorf("tensai: data length %d != %dx%d", len(data), rows, cols)
+	}
+	m := NewMatrix(rows, cols)
+	for i, v := range data {
+		f := Float(v)
+		if int(f) != v {
+			return nil, fmt.Errorf("tensai: value %d at index %d does not fit float32 exactly", v, i)
+		}
+		m.Data[i] = f
+	}
+	return m, nil
+}
+
 // At returns the element at (r, c).
 func (m *Matrix) At(r, c int) Float {
 	return m.Data[r*m.Cols+c]


### PR DESCRIPTION
Second follow-up from the API review. The Optimizer interface's NewLayer/Step(idx, ...) protocol leaked the model's registration bookkeeping into every implementation, and it hid a real bug: Adam advanced its shared timestep once per Step call rather than per training step, so with several parameterized layers the bias correction decayed several times too fast and differed between layers. Optimizer is now just the rule's configuration with New() handing out an optim.Updater per parameter pair; the updater owns that pair's state, including a per-parameter Adam step count that stays exact even when a Trainer parameter sits out a step. Also adds tensai.NewMatrixFromInts, a validated constructor for the integer token-id matrices Embedding consumes. Constructor names and everything the examples use are unchanged.