### PR TITLE
Retract v0.1.0, tagged in error before the package split

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/mattn/tensai
 go 1.21
 
 require github.com/ebitengine/purego v0.10.2
+
+retract (
+	v0.1.0 // Tagged in error before the package split; releases follow v0.0.x.
+	v0.1.1 // Contains only this retraction.
+)


### PR DESCRIPTION
The module proxy permanently cached a v0.1.0 tag that was pushed and later deleted; it points at a pre-split commit from 2026-08-20, and because the go command resolves latest from the proxy's version list, go get currently hands new users that stale API instead of v0.0.6. This retracts v0.1.0 (and the retraction-only v0.1.1 itself). After merging, tagging v0.1.1 publishes the retraction; the go command then resolves latest back to v0.0.6 and pkg.go.dev strikes both versions through.