### PR TITLE
Skip publishing when a tag does not match the embedded version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,30 @@ on:
     - 'v*'
 
 jobs:
+  # A tag that does not match the version embedded in cmd/tensai (e.g. a
+  # module-retraction tag) must not publish binaries or move the image tags.
+  check:
+    name: Check tag
+    runs-on: ubuntu-latest
+    outputs:
+      match: ${{ steps.v.outputs.match }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: v
+      run: |
+        # Mirrors "make show-version" without a Go toolchain.
+        want="v$(sed -n 's/^const version = "\(.*\)"$/\1/p' cmd/tensai/main.go)"
+        echo "tag=$GITHUB_REF_NAME embedded=$want"
+        if [ "$want" = "$GITHUB_REF_NAME" ]; then
+          echo match=true >> "$GITHUB_OUTPUT"
+        else
+          echo match=false >> "$GITHUB_OUTPUT"
+        fi
+
   release:
     name: Release
+    needs: check
+    if: needs.check.outputs.match == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,6 +50,8 @@ jobs:
 
   docker:
     name: Docker
+    needs: check
+    if: needs.check.outputs.match == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The release workflow derives the version from the constant in cmd/tensai rather than the pushed tag, so the retraction-only v0.1.1 tag tried to re-upload v0.0.6 assets (failing on already_exists) and moved the ghcr latest image tag. A check job now compares the tag against the embedded version and skips both the release and docker jobs on mismatch, so retraction or otherwise out-of-band tags publish nothing.