### PR TITLE
Add metrics.Evaluate and metrics.Report

### DIFF
--- a/_example/iris/main.go
+++ b/_example/iris/main.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 
 	tensai "github.com/mattn/tensai"
-	"github.com/mattn/tensai/dataset"
 	"github.com/mattn/tensai/dataset/iris"
 	"github.com/mattn/tensai/layer"
 	"github.com/mattn/tensai/loss"
@@ -22,22 +21,6 @@ const (
 	batchSize    = 32
 	seed         = 3
 )
-
-func evaluate(net *model.Sequential, ds *dataset.Dataset) (int, [][]int, error) {
-	pred, err := net.Predict(ds.Inputs)
-	if err != nil {
-		return 0, nil, err
-	}
-	correct, err := metrics.Correct(pred, ds.Targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	confusion, err := metrics.Confusion(pred, ds.Targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	return correct, confusion, nil
-}
 
 func main() {
 	ds, err := iris.Load(nil)
@@ -79,20 +62,20 @@ func main() {
 		}
 	}
 
-	trainCorrect, _, err := evaluate(net, train)
+	trainRes, err := metrics.Evaluate(net, train.Inputs, train.Targets)
 	if err != nil {
 		panic(err)
 	}
-	testCorrect, confusion, err := evaluate(net, test)
+	testRes, err := metrics.Evaluate(net, test.Inputs, test.Targets)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("\ntrain accuracy: %d/%d\n", trainCorrect, train.Len())
-	fmt.Printf("test accuracy:  %d/%d\n", testCorrect, test.Len())
+	fmt.Printf("\ntrain accuracy: %d/%d\n", trainRes.Correct, trainRes.Total)
+	fmt.Printf("test accuracy:  %d/%d\n", testRes.Correct, testRes.Total)
 	fmt.Println("\nconfusion matrix (rows = actual, columns = predicted):")
-	for r := range confusion {
+	for r := range testRes.Confusion {
 		fmt.Printf("  %-10s:", iris.ClassNames[r])
-		for _, n := range confusion[r] {
+		for _, n := range testRes.Confusion[r] {
 			fmt.Printf(" %3d", n)
 		}
 		fmt.Println()

--- a/_example/mnist/main.go
+++ b/_example/mnist/main.go
@@ -48,20 +48,12 @@ func predictChunked(model model.Model, inputs *tensai.Matrix) (*tensai.Matrix, e
 	return out, nil
 }
 
-func evaluate(model model.Model, inputs, targets *tensai.Matrix) (int, [][]int, error) {
+func evaluate(model model.Model, inputs, targets *tensai.Matrix) (*metrics.Result, error) {
 	pred, err := predictChunked(model, inputs)
 	if err != nil {
-		return 0, nil, err
+		return nil, err
 	}
-	correct, err := metrics.Correct(pred, targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	confusion, err := metrics.Confusion(pred, targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	return correct, confusion, nil
+	return metrics.Report(pred, targets)
 }
 
 // buildModel constructs either the plain MLP or a small CNN and compiles it.
@@ -130,12 +122,12 @@ func main() {
 		if err := knn.Fit(train.Inputs, train.Targets); err != nil {
 			panic(err)
 		}
-		correct, confusion, err := evaluate(knn, test.Inputs, test.Targets)
+		res, err := evaluate(knn, test.Inputs, test.Targets)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("knn (k=3) test accuracy: %d/%d\n", correct, test.Len())
-		printConfusion(confusion)
+		fmt.Printf("knn (k=3) test accuracy: %d/%d\n", res.Correct, res.Total)
+		printConfusion(res.Confusion)
 		return
 	}
 
@@ -161,17 +153,17 @@ func main() {
 		fmt.Printf("epoch %2d: loss=%.6f\n", epoch, lossSum/float32(steps))
 	}
 
-	trainCorrect, _, err := evaluate(model, train.Inputs, train.Targets)
+	trainRes, err := evaluate(model, train.Inputs, train.Targets)
 	if err != nil {
 		panic(err)
 	}
-	testCorrect, confusion, err := evaluate(model, test.Inputs, test.Targets)
+	testRes, err := evaluate(model, test.Inputs, test.Targets)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("\ntrain accuracy: %d/%d\n", trainCorrect, train.Len())
-	fmt.Printf("test accuracy:  %d/%d\n", testCorrect, test.Len())
+	fmt.Printf("\ntrain accuracy: %d/%d\n", trainRes.Correct, trainRes.Total)
+	fmt.Printf("test accuracy:  %d/%d\n", testRes.Correct, testRes.Total)
 
 	// Round-trip the trained parameters through JSON to demonstrate
 	// serialization: a freshly built model must score identically.
@@ -192,11 +184,11 @@ func main() {
 	if err := reloaded.LoadFile(modelPath); err != nil {
 		panic(err)
 	}
-	reloadedCorrect, _, err := evaluate(reloaded, test.Inputs, test.Targets)
+	reloadedRes, err := evaluate(reloaded, test.Inputs, test.Targets)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("saved to %s, reloaded accuracy: %d/%d\n", modelPath, reloadedCorrect, test.Len())
+	fmt.Printf("saved to %s, reloaded accuracy: %d/%d\n", modelPath, reloadedRes.Correct, reloadedRes.Total)
 
 	if *export != "" {
 		// MNIST is single-channel, so the flat rows already match the NHWC
@@ -207,7 +199,7 @@ func main() {
 		}
 		fmt.Printf("exported TFLite model to %s\n", *export)
 	}
-	printConfusion(confusion)
+	printConfusion(testRes.Confusion)
 }
 
 func printConfusion(confusion [][]int) {

--- a/_example/spiral/main.go
+++ b/_example/spiral/main.go
@@ -48,22 +48,6 @@ func makeSpiral() *dataset.Dataset {
 	return ds
 }
 
-func evaluate(model *model.Sequential, ds *dataset.Dataset) (int, [][]int, error) {
-	pred, err := model.Predict(ds.Inputs)
-	if err != nil {
-		return 0, nil, err
-	}
-	correct, err := metrics.Correct(pred, ds.Targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	confusion, err := metrics.Confusion(pred, ds.Targets)
-	if err != nil {
-		return 0, nil, err
-	}
-	return correct, confusion, nil
-}
-
 func main() {
 	splitRng := rand.New(rand.NewSource(trainingSeed + 2))
 	train, test, err := makeSpiral().SplitStratified(testFraction, splitRng)
@@ -99,21 +83,21 @@ func main() {
 		}
 	}
 
-	trainCorrect, _, err := evaluate(model, train)
+	trainRes, err := metrics.Evaluate(model, train.Inputs, train.Targets)
 	if err != nil {
 		panic(err)
 	}
-	testCorrect, confusion, err := evaluate(model, test)
+	testRes, err := metrics.Evaluate(model, test.Inputs, test.Targets)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("\ntrain accuracy: %d/%d\n", trainCorrect, train.Len())
-	fmt.Printf("test accuracy:  %d/%d\n", testCorrect, test.Len())
+	fmt.Printf("\ntrain accuracy: %d/%d\n", trainRes.Correct, trainRes.Total)
+	fmt.Printf("test accuracy:  %d/%d\n", testRes.Correct, testRes.Total)
 	fmt.Println("\nconfusion matrix (rows = actual, columns = predicted):")
-	for r := range confusion {
+	for r := range testRes.Confusion {
 		fmt.Printf("  class %d:", r)
-		for _, n := range confusion[r] {
+		for _, n := range testRes.Confusion[r] {
 			fmt.Printf(" %3d", n)
 		}
 		fmt.Println()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,6 +11,47 @@ import (
 	"github.com/mattn/tensai"
 )
 
+// Predictor is anything that maps input rows to one column of scores per
+// class. model.Sequential and knn.KNN satisfy it.
+type Predictor interface {
+	Predict(*tensai.Matrix) (*tensai.Matrix, error)
+}
+
+// Result summarizes a classification evaluation.
+type Result struct {
+	Correct   int
+	Total     int
+	Confusion [][]int // rows are actual classes, columns are predicted
+}
+
+// Accuracy returns the fraction of correctly classified samples.
+func (r *Result) Accuracy() float64 {
+	return float64(r.Correct) / float64(r.Total)
+}
+
+// Report builds a Result from an existing prediction matrix, for callers
+// that produce predictions themselves (e.g. in chunks).
+func Report(pred, targets *tensai.Matrix) (*Result, error) {
+	correct, err := Correct(pred, targets)
+	if err != nil {
+		return nil, err
+	}
+	confusion, err := Confusion(pred, targets)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Correct: correct, Total: pred.Rows, Confusion: confusion}, nil
+}
+
+// Evaluate runs the predictor over inputs and reports the result.
+func Evaluate(p Predictor, inputs, targets *tensai.Matrix) (*Result, error) {
+	pred, err := p.Predict(inputs)
+	if err != nil {
+		return nil, err
+	}
+	return Report(pred, targets)
+}
+
 func check(pred, targets *tensai.Matrix) error {
 	if pred == nil || targets == nil {
 		return fmt.Errorf("tensai: metrics: nil matrix")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mattn/tensai"
@@ -60,6 +61,36 @@ func TestConfusion(t *testing.T) {
 				t.Fatalf("confusion[%d][%d] = %d, want %d", r, c, confusion[r][c], want[r][c])
 			}
 		}
+	}
+}
+
+type fakePredictor struct {
+	pred *tensai.Matrix
+	err  error
+}
+
+func (f fakePredictor) Predict(*tensai.Matrix) (*tensai.Matrix, error) {
+	return f.pred, f.err
+}
+
+func TestReportAndEvaluate(t *testing.T) {
+	pred, targets := fixtures(t)
+	res, err := Evaluate(fakePredictor{pred: pred}, nil, targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Correct != 3 || res.Total != 4 {
+		t.Fatalf("Correct/Total = %d/%d, want 3/4", res.Correct, res.Total)
+	}
+	if res.Accuracy() != 0.75 {
+		t.Fatalf("Accuracy = %g, want 0.75", res.Accuracy())
+	}
+	if res.Confusion[1][2] != 1 {
+		t.Fatalf("Confusion[1][2] = %d, want 1", res.Confusion[1][2])
+	}
+	wantErr := fmt.Errorf("predict failed")
+	if _, err := Evaluate(fakePredictor{err: wantErr}, nil, targets); err != wantErr {
+		t.Fatalf("err = %v, want %v", err, wantErr)
 	}
 }
 


### PR DESCRIPTION
Every classification example carried the same Predict-then-score wrapper around `metrics.Correct` and `metrics.Confusion`. This moves it into the metrics package:

- `Result` bundles the correct count, total, and confusion matrix, with an `Accuracy()` method.
- `Report(pred, targets)` builds a `Result` from an existing prediction matrix, for callers that produce predictions themselves (e.g. the mnist example's chunked prediction).
- `Evaluate(p, inputs, targets)` runs any `Predictor` over a split and reports it. `Predictor` is declared structurally in metrics, so `model.Sequential` and `knn.KNN` satisfy it without new imports.

The iris, mnist, and spiral examples drop their local `evaluate` helpers; their output is unchanged.