### PR TITLE
Add a bench subcommand comparing CPU and GPU speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ GOEXPERIMENT=simd go install ./cmd/tensai
 tensai run -q8 "What is the capital of France?"
 tensai chat -q8 -gguf model.gguf
 tensai serve -q8 -addr :8080                      # OpenAI-compatible API
+GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8   # CPU vs GPU
 go run -tags wgpu ./_example/wgpu          # needs wgpu-native, see above
 go run -tags wgpu ./_example/wgpu -sweep  # GPU vs CPU across sizes
 go test ./...

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -9,15 +9,19 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime/pprof"
 	"strings"
 	"time"
 
+	"github.com/mattn/tensai/gpu"
 	"github.com/mattn/tensai/internal/llm"
 )
 
@@ -32,6 +36,7 @@ commands:
   run      generate a completion for a prompt
   chat     interactive multi-turn chat on stdin
   serve    OpenAI-compatible /v1/chat/completions server
+  bench    compare CPU and GPU prefill and decode speed
   models   list cached models; "models rm <name>" deletes one
   version  print the version
 
@@ -166,6 +171,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case "bench":
+		fs := flag.NewFlagSet("tensai bench", flag.ExitOnError)
+		o, finish := modelFlags(fs)
+		p := fs.Int("p", 512, "approximate prompt tokens to prefill")
+		n := fs.Int("n", 32, "tokens to decode")
+		fs.Parse(args)
+		finish()
+		if o.Bits == 0 {
+			// The GPU path needs quantized weights; bench both sides
+			// the same way.
+			o.Bits = 8
+		}
+		benchCmd(o, *p, *n)
 	case "models":
 		if err := modelsCmd(args); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -179,6 +197,118 @@ func main() {
 		fmt.Fprintf(os.Stderr, "tensai: unknown command %q\n\n%s\n", cmd, usage)
 		os.Exit(2)
 	}
+}
+
+// benchCmd compares prefill and decode speed on the CPU and the GPU.
+// Each side runs in its own child process so the second measurement never
+// pays for the first one's heap: a freed model keeps its pages resident
+// long enough to distort a back-to-back run in one process.
+func benchCmd(o *llm.Options, p, n int) {
+	if side := os.Getenv("TENSAI_BENCH_CHILD"); side != "" {
+		benchChild(side)
+		return
+	}
+	var sb strings.Builder
+	for sb.Len() < p*4 {
+		sb.WriteString("The quick brown fox jumps over the lazy dog while considering cache coherency protocols and memory hierarchies in modern processors. ")
+	}
+	cfg := benchConfig{Opts: *o, Prompt: sb.String(), N: n}
+	cfg.Opts.Log = nil
+	blob, err := json.Marshal(&cfg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	run := func(side string) (benchResult, error) {
+		cmd := exec.Command(exe, "bench")
+		cmd.Env = append(os.Environ(), "TENSAI_BENCH_CHILD="+side, "TENSAI_BENCH_CONFIG="+string(blob))
+		cmd.Stderr = os.Stderr
+		out, err := cmd.Output()
+		if err != nil {
+			return benchResult{}, err
+		}
+		var r benchResult
+		if err := json.Unmarshal(out, &r); err != nil {
+			return benchResult{}, err
+		}
+		if r.Err != "" {
+			return benchResult{}, errors.New(r.Err)
+		}
+		return r, nil
+	}
+	cpu, err := run("cpu")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "cpu:", err)
+		os.Exit(1)
+	}
+	dev, gpuErr := run("gpu")
+
+	fmt.Printf("prefill %d tokens, decode %d tokens, int%d weights\n", cpu.Tokens, n, o.Bits)
+	// The two binding generations reach different adapters and differ in
+	// speed on the same one, so the table names which build measured.
+	tag := gpu.Backend()
+	if tag == "" {
+		tag = "no gpu build tag"
+	}
+	if gpuErr == nil && dev.Adapter != "" {
+		fmt.Printf("gpu: %s via -tags %s\n", dev.Adapter, tag)
+	} else {
+		fmt.Printf("gpu build: %s\n", tag)
+	}
+	fmt.Printf("\n%-9s %12s %12s\n", "", "prefill", "decode")
+	fmt.Printf("%-9s %10.1f %s %10.1f %s\n", "cpu", cpu.Prefill, "t/s", cpu.Decode, "t/s")
+	if gpuErr != nil {
+		fmt.Printf("%-9s unavailable: %v\n", "gpu", gpuErr)
+		return
+	}
+	fmt.Printf("%-9s %10.1f %s %10.1f %s\n", "gpu", dev.Prefill, "t/s", dev.Decode, "t/s")
+	fmt.Printf("%-9s %11.2fx %12.2fx\n", "gpu/cpu", dev.Prefill/cpu.Prefill, dev.Decode/cpu.Decode)
+}
+
+type benchConfig struct {
+	Opts   llm.Options
+	Prompt string
+	N      int
+}
+
+type benchResult struct {
+	Tokens  int
+	Prefill float64
+	Decode  float64
+	Adapter string `json:",omitempty"`
+	Err     string `json:",omitempty"`
+}
+
+// benchChild measures one side and prints the result as one JSON line.
+func benchChild(side string) {
+	var cfg benchConfig
+	if err := json.Unmarshal([]byte(os.Getenv("TENSAI_BENCH_CONFIG")), &cfg); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	cfg.Opts.Log = os.Stderr
+	cfg.Opts.GPU = side == "gpu"
+	var r benchResult
+	e, err := llm.Open(cfg.Opts)
+	if err != nil {
+		r.Err = err.Error()
+	} else {
+		defer e.Close()
+		res := e.Generate(io.Discard, cfg.Prompt, true, cfg.N)
+		r = benchResult{
+			Tokens:  res.PromptTokens,
+			Prefill: float64(res.PromptTokens) / res.Prefill.Seconds(),
+			Decode:  float64(res.CompletionTokens) / (res.Total - res.Prefill).Seconds(),
+			Adapter: e.GPUName(),
+		}
+	}
+	out, _ := json.Marshal(&r)
+	fmt.Println(string(out))
 }
 
 // modelsCmd lists the model cache, or deletes entries with

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -66,6 +66,7 @@ commands:
   run      generate a completion for a prompt
   chat     interactive multi-turn chat on stdin
   serve    OpenAI-compatible /v1/chat/completions server
+  bench    compare CPU and GPU prefill and decode speed
   models   list cached models; "models rm <name>" deletes one
   version  print the version
 ```
@@ -77,7 +78,31 @@ tensai run -q8 "What is the capital of France?"
 tensai run -q8 -json "Explain RoPE briefly"      # 補完と使用量を 1 つの JSON で
 tensai chat -q8 -gguf model.gguf                 # マルチターン。KV キャッシュが対話全体を運ぶ
 tensai models                                    # キャッシュ一覧。"models rm <name>" で削除
+tensai bench -q8                                 # CPU vs GPU のプレフィル/デコード比較
 ```
+
+### CPU と GPU の比較
+
+`bench` は合成プロンプトのプレフィルと数トークンのデコードを CPU と GPU で 1
+回ずつ実行し、両方と倍率を表示します。各側は別プロセスで走るので、解放済み
+モデルのページがもう一方の測定を汚しません。ヘッダにはアダプタ名とビルドタグ
+が出ます — これが重要で、2 つのバインディング世代は届くアダプタが異なり
+(WSL2 の Mesa dozen のような非準拠ドライバが見えるのは `wgpu24` だけ)、
+タグを間違えると気付かないまま CPU Vulkan 実装にフォールバックします。
+
+```
+$ GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8
+prefill 401 tokens, decode 32 tokens, int8 weights
+gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
+
+               prefill       decode
+cpu            397.5 t/s       40.1 t/s
+gpu           2113.1 t/s       30.1 t/s
+gpu/cpu          5.32x         0.75x
+```
+
+`-p` でプロンプトのおおよそのトークン数、`-n` でデコードするトークン数を指定
+します。GPU ビルドタグなしの場合は、GPU 行に理由が表示されます。
 
 ### OpenAI 互換 API の提供
 

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -96,13 +96,16 @@ prefill 401 tokens, decode 32 tokens, int8 weights
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
                prefill       decode
-cpu            397.5 t/s       40.1 t/s
-gpu           2113.1 t/s       30.1 t/s
-gpu/cpu          5.32x         0.75x
+cpu            398.2 t/s       39.4 t/s
+gpu           2020.9 t/s       29.7 t/s
+gpu/cpu          5.08x         0.75x
 ```
 
 `-p` でプロンプトのおおよそのトークン数、`-n` でデコードするトークン数を指定
-します。GPU ビルドタグなしの場合は、GPU 行に理由が表示されます。
+します。GPU ビルドタグなしの場合は、GPU 行に理由が表示されます。 プレフィルの t/s はプロンプトが
+長くなるほど下がり (attention が二次)、変換レイヤー越しでは実行ごとに数 %
+ぶれます。長さをまたいだ単発の数値ではなく、同じ長さで数回の中央値を比べて
+ください。
 
 ### OpenAI 互換 API の提供
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -66,6 +66,7 @@ commands:
   run      generate a completion for a prompt
   chat     interactive multi-turn chat on stdin
   serve    OpenAI-compatible /v1/chat/completions server
+  bench    compare CPU and GPU prefill and decode speed
   models   list cached models; "models rm <name>" deletes one
   version  print the version
 ```
@@ -77,7 +78,32 @@ tensai run -q8 "What is the capital of France?"
 tensai run -q8 -json "Explain RoPE briefly"      # one JSON object with usage counts
 tensai chat -q8 -gguf model.gguf                 # multi-turn; the KV cache carries the dialogue
 tensai models                                    # list the cache; "models rm <name>" deletes
+tensai bench -q8                                 # CPU vs GPU, prefill and decode
 ```
+
+### Measuring CPU against GPU
+
+`bench` prefills a synthetic prompt and decodes a few tokens twice — once on
+the CPU, once on the GPU — and prints both with the ratio. Each side runs in
+its own child process, so a freed model's pages never distort the other
+measurement. The header names the adapter and the build tag, which matters:
+the two binding generations reach different adapters (only `wgpu24` sees
+non-conformant drivers such as Mesa's dozen inside WSL2), so a build without
+that tag may silently fall back to a CPU Vulkan implementation.
+
+```
+$ GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8
+prefill 401 tokens, decode 32 tokens, int8 weights
+gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
+
+               prefill       decode
+cpu            397.5 t/s       40.1 t/s
+gpu           2113.1 t/s       30.1 t/s
+gpu/cpu          5.32x         0.75x
+```
+
+`-p` sets the approximate prompt length and `-n` the tokens to decode. Without
+a GPU build tag the GPU row reports why it is unavailable.
 
 ### Serving an OpenAI-compatible API
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -97,13 +97,16 @@ prefill 401 tokens, decode 32 tokens, int8 weights
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
                prefill       decode
-cpu            397.5 t/s       40.1 t/s
-gpu           2113.1 t/s       30.1 t/s
-gpu/cpu          5.32x         0.75x
+cpu            398.2 t/s       39.4 t/s
+gpu           2020.9 t/s       29.7 t/s
+gpu/cpu          5.08x         0.75x
 ```
 
 `-p` sets the approximate prompt length and `-n` the tokens to decode. Without
-a GPU build tag the GPU row reports why it is unavailable.
+a GPU build tag the GPU row reports why it is unavailable. Prefill throughput falls as the prompt
+grows (attention is quadratic) and varies a few percent run to run through a
+translation layer, so compare medians of a few runs at one length rather than
+single numbers across lengths.
 
 ### Serving an OpenAI-compatible API
 

--- a/gpu/wgpu.go
+++ b/gpu/wgpu.go
@@ -523,6 +523,10 @@ func (g *Device) makePipeline(entry string) uintptr {
 	return p
 }
 
+// Backend names the wgpu-native C API these bindings target, for builds
+// that report which GPU path they were compiled with.
+func Backend() string { return "wgpu" }
+
 // Name reports the adapter wgpu selected, e.g. "AMD Radeon 780M
 // (integrated)" — handy for checking which Device a power preference landed
 // on.

--- a/gpu/wgpu24.go
+++ b/gpu/wgpu24.go
@@ -620,6 +620,10 @@ func (g *Device) makePipeline(entry string) uintptr {
 	return p
 }
 
+// Backend names the wgpu-native C API these bindings target, for builds
+// that report which GPU path they were compiled with.
+func Backend() string { return "wgpu24" }
+
 // Name reports the adapter wgpu selected, e.g. "Microsoft Direct3D12 (AMD
 // Radeon(TM) Graphics) (integrated)" — handy for checking which Device a power
 // preference landed on.

--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -29,6 +29,9 @@ var errNoWGPU = errors.New("tensai: built without wgpu support (rebuild with -ta
 // Open always fails in builds without the wgpu tag.
 func Open(power ...Power) (*Device, error) { return nil, errNoWGPU }
 
+// Backend returns the empty string: this build has no GPU support.
+func Backend() string { return "" }
+
 // Name always returns "" in builds without the wgpu tag.
 func (g *Device) Name() string { return "" }
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -245,6 +245,16 @@ func Open(o Options) (*Engine, error) {
 	return e, nil
 }
 
+// GPUName reports the adapter the engine is running on, empty when
+// decoding on the CPU. Backend names the binding generation the binary
+// was built with.
+func (e *Engine) GPUName() string {
+	if e.g == nil {
+		return ""
+	}
+	return e.g.Name()
+}
+
 // Close releases the GPU residency, if any.
 func (e *Engine) Close() {
 	if e.g != nil {


### PR DESCRIPTION
There was no standing way to see what the GPU is worth on real inference: the wgpu example sweeps f32 MatMul, which the quantized decode path never touches, and the kernel benchmarks measure one shader each. `tensai bench` prefills a synthetic prompt and decodes a few tokens on the CPU and on the GPU, printing both with the ratio. Each side runs in its own child process so a freed model's pages cannot distort the other. The header names the adapter and the build tag, which turns out to matter: only the wgpu24 bindings see non-conformant drivers such as Mesa's dozen, so a wgpu build silently measures a CPU Vulkan fallback instead. Adds gpu.Backend() and Engine.GPUName() for that header, and documents the command in the README and both documentation languages.