### PR TITLE
Report the kernels in use and silence the child engine logs in bench

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/mattn/tensai/gpu"
 	"github.com/mattn/tensai/internal/llm"
+	"github.com/mattn/tensai/internal/simd"
 )
 
 const version = "0.0.10"
@@ -249,6 +250,14 @@ func benchCmd(o *llm.Options, p, n int) {
 	dev, gpuErr := run("gpu")
 
 	fmt.Printf("prefill %d tokens, decode %d tokens, int%d weights\n", cpu.Tokens, n, o.Bits)
+	// A binary built without GOEXPERIMENT=simd runs the portable kernels
+	// and measures an order of magnitude slower, which is easy to mistake
+	// for a slow machine.
+	if simd.HasAVX2 {
+		fmt.Println("cpu: AVX2 kernels")
+	} else {
+		fmt.Println("cpu: portable kernels (rebuild with GOEXPERIMENT=simd on amd64 for AVX2)")
+	}
 	// The two binding generations reach different adapters and differ in
 	// speed on the same one, so the table names which build measured.
 	tag := gpu.Backend()
@@ -291,7 +300,9 @@ func benchChild(side string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	cfg.Opts.Log = os.Stderr
+	// The engine's progress lines would interleave with the parent's
+	// table; the measurement is the output here.
+	cfg.Opts.Log = io.Discard
 	cfg.Opts.GPU = side == "gpu"
 	var r benchResult
 	e, err := llm.Open(cfg.Opts)

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -85,14 +85,17 @@ tensai bench -q8                                 # CPU vs GPU のプレフィル
 
 `bench` は合成プロンプトのプレフィルと数トークンのデコードを CPU と GPU で 1
 回ずつ実行し、両方と倍率を表示します。各側は別プロセスで走るので、解放済み
-モデルのページがもう一方の測定を汚しません。ヘッダにはアダプタ名とビルドタグ
-が出ます — これが重要で、2 つのバインディング世代は届くアダプタが異なり
-(WSL2 の Mesa dozen のような非準拠ドライバが見えるのは `wgpu24` だけ)、
-タグを間違えると気付かないまま CPU Vulkan 実装にフォールバックします。
+モデルのページがもう一方の測定を汚しません。ヘッダには両側が使っているカーネルと
+アダプタが出ます — これが重要で、2 つのバインディング世代は届くアダプタが
+異なり (WSL2 の Mesa dozen のような非準拠ドライバが見えるのは `wgpu24`
+だけ)、タグを間違えると気付かないまま CPU Vulkan 実装にフォールバックします。
+また `GOEXPERIMENT=simd` なしでビルドするとポータブルカーネルを測ることに
+なり、AVX2 版より一桁遅い数値が出ます。
 
 ```
 $ GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8
 prefill 401 tokens, decode 32 tokens, int8 weights
+cpu: AVX2 kernels
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
                prefill       decode

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -86,14 +86,18 @@ tensai bench -q8                                 # CPU vs GPU, prefill and decod
 `bench` prefills a synthetic prompt and decodes a few tokens twice — once on
 the CPU, once on the GPU — and prints both with the ratio. Each side runs in
 its own child process, so a freed model's pages never distort the other
-measurement. The header names the adapter and the build tag, which matters:
+measurement. The header names the kernels and the adapter each side is using, which
+matters:
 the two binding generations reach different adapters (only `wgpu24` sees
 non-conformant drivers such as Mesa's dozen inside WSL2), so a build without
-that tag may silently fall back to a CPU Vulkan implementation.
+that tag may silently fall back to a CPU Vulkan implementation, and a binary
+built without `GOEXPERIMENT=simd` measures the portable kernels, an order of
+magnitude below the AVX2 ones.
 
 ```
 $ GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8
 prefill 401 tokens, decode 32 tokens, int8 weights
+cpu: AVX2 kernels
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
                prefill       decode

--- a/gpu/wgpu24.go
+++ b/gpu/wgpu24.go
@@ -359,9 +359,11 @@ func loadWGPU() error {
 	loadOnce.Do(func() {
 		var lib uintptr
 		var err error
+		var loaded string
 		for _, name := range libCandidates() {
 			lib, err = dlopenWGPU(name)
 			if err == nil {
+				loaded = name
 				break
 			}
 		}
@@ -371,10 +373,12 @@ func loadWGPU() error {
 		}
 		// Same symbol names, different ABI: calling a v22 library through
 		// these bindings crashes, so gate on the packed version number.
+		// Name the file that was loaded: with several versions installed
+		// the mismatch is usually TENSAI_WGPU_LIB pointing at the wrong one.
 		var fnGetVersion func() uint32
 		purego.RegisterLibFunc(&fnGetVersion, lib, "wgpuGetVersion")
 		if major := fnGetVersion() >> 24; major < 24 {
-			loadErr = fmt.Errorf("tensai: wgpu-native v%d is too old for -tags wgpu24 (needs v24+); use -tags wgpu with it", major)
+			loadErr = fmt.Errorf("tensai: %s is wgpu-native v%d, too old for -tags wgpu24 (needs v24+): point TENSAI_WGPU_LIB at a v24+ library, or build with -tags wgpu instead", loaded, major)
 			return
 		}
 		for _, f := range []struct {


### PR DESCRIPTION
Two things made a bench run hard to read. The child processes still logged the engine's own load and generation lines, which interleaved above the table, so they now go to io.Discard. And a binary built without GOEXPERIMENT=simd measured the portable kernels at around 18 t/s with nothing in the output saying so, which reads as a slow machine rather than a slow build; the header now names the CPU kernels the same way it already names the GPU adapter and binding generation.