### PR TITLE
Measure steady state in bench instead of one cold pass

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime/pprof"
+	"sort"
 	"strings"
 	"time"
 
@@ -177,6 +178,7 @@ func main() {
 		o, finish := modelFlags(fs)
 		p := fs.Int("p", 512, "approximate prompt tokens to prefill")
 		n := fs.Int("n", 32, "tokens to decode")
+		reps := fs.Int("r", 5, "timed repetitions per side, after one warm-up")
 		fs.Parse(args)
 		finish()
 		if o.Bits == 0 {
@@ -184,7 +186,7 @@ func main() {
 			// the same way.
 			o.Bits = 8
 		}
-		benchCmd(o, *p, *n)
+		benchCmd(o, *p, *n, *reps)
 	case "models":
 		if err := modelsCmd(args); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -204,7 +206,7 @@ func main() {
 // Each side runs in its own child process so the second measurement never
 // pays for the first one's heap: a freed model keeps its pages resident
 // long enough to distort a back-to-back run in one process.
-func benchCmd(o *llm.Options, p, n int) {
+func benchCmd(o *llm.Options, p, n, reps int) {
 	if side := os.Getenv("TENSAI_BENCH_CHILD"); side != "" {
 		benchChild(side)
 		return
@@ -213,7 +215,7 @@ func benchCmd(o *llm.Options, p, n int) {
 	for sb.Len() < p*4 {
 		sb.WriteString("The quick brown fox jumps over the lazy dog while considering cache coherency protocols and memory hierarchies in modern processors. ")
 	}
-	cfg := benchConfig{Opts: *o, Prompt: sb.String(), N: n}
+	cfg := benchConfig{Opts: *o, Prompt: sb.String(), N: n, Reps: reps}
 	cfg.Opts.Log = nil
 	blob, err := json.Marshal(&cfg)
 	if err != nil {
@@ -269,28 +271,54 @@ func benchCmd(o *llm.Options, p, n int) {
 	} else {
 		fmt.Printf("gpu build: %s\n", tag)
 	}
-	fmt.Printf("\n%-9s %12s %12s\n", "", "prefill", "decode")
-	fmt.Printf("%-9s %10.1f %s %10.1f %s\n", "cpu", cpu.Prefill, "t/s", cpu.Decode, "t/s")
+	row := func(name string, r benchResult) {
+		fmt.Printf("%-8s %9.1f %-14s %8.1f %s\n", name,
+			median(r.Prefill), spread(r.Prefill),
+			median(r.Decode), spread(r.Decode))
+	}
+	fmt.Printf("\nmedian of %d runs after one warm-up, tokens/sec\n\n", reps)
+	fmt.Printf("%-8s %9s %-14s %8s\n", "", "prefill", "", "decode")
+	row("cpu", cpu)
 	if gpuErr != nil {
-		fmt.Printf("%-9s unavailable: %v\n", "gpu", gpuErr)
+		fmt.Printf("%-8s unavailable: %v\n", "gpu", gpuErr)
 		return
 	}
-	fmt.Printf("%-9s %10.1f %s %10.1f %s\n", "gpu", dev.Prefill, "t/s", dev.Decode, "t/s")
-	fmt.Printf("%-9s %11.2fx %12.2fx\n", "gpu/cpu", dev.Prefill/cpu.Prefill, dev.Decode/cpu.Decode)
+	row("gpu", dev)
+	fmt.Printf("%-8s %8.2fx %-14s %7.2fx\n", "gpu/cpu",
+		median(dev.Prefill)/median(cpu.Prefill), "", median(dev.Decode)/median(cpu.Decode))
 }
 
 type benchConfig struct {
 	Opts   llm.Options
 	Prompt string
 	N      int
+	Reps   int
 }
 
 type benchResult struct {
 	Tokens  int
-	Prefill float64
-	Decode  float64
+	Prefill []float64 // one sample per repetition
+	Decode  []float64
 	Adapter string `json:",omitempty"`
 	Err     string `json:",omitempty"`
+}
+
+// median returns the middle sample; samples are sorted in place.
+func median(v []float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	sort.Float64s(v)
+	return v[len(v)/2]
+}
+
+// spread renders the low-high range of the samples.
+func spread(v []float64) string {
+	if len(v) < 2 {
+		return ""
+	}
+	sort.Float64s(v)
+	return fmt.Sprintf("(%.0f-%.0f)", v[0], v[len(v)-1])
 }
 
 // benchChild measures one side and prints the result as one JSON line.
@@ -310,12 +338,20 @@ func benchChild(side string) {
 		r.Err = err.Error()
 	} else {
 		defer e.Close()
-		res := e.Generate(io.Discard, cfg.Prompt, true, cfg.N)
-		r = benchResult{
-			Tokens:  res.PromptTokens,
-			Prefill: float64(res.PromptTokens) / res.Prefill.Seconds(),
-			Decode:  float64(res.CompletionTokens) / (res.Total - res.Prefill).Seconds(),
-			Adapter: e.GPUName(),
+		r.Adapter = e.GPUName()
+		// The model stays loaded across repetitions and the first pass is
+		// discarded, so the samples describe steady state rather than a
+		// cold cache and a ramping clock — the same thing llama-bench
+		// reports.
+		for i := 0; i <= cfg.Reps; i++ {
+			e.Reset()
+			res := e.Generate(io.Discard, cfg.Prompt, true, cfg.N)
+			if i == 0 {
+				r.Tokens = res.PromptTokens
+				continue
+			}
+			r.Prefill = append(r.Prefill, float64(res.PromptTokens)/res.Prefill.Seconds())
+			r.Decode = append(r.Decode, float64(res.CompletionTokens)/(res.Total-res.Prefill).Seconds())
 		}
 	}
 	out, _ := json.Marshal(&r)

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -98,17 +98,21 @@ prefill 401 tokens, decode 32 tokens, int8 weights
 cpu: AVX2 kernels
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
-               prefill       decode
-cpu            398.2 t/s       39.4 t/s
-gpu           2020.9 t/s       29.7 t/s
-gpu/cpu          5.08x         0.75x
+median of 5 runs after one warm-up, tokens/sec
+
+           prefill                  decode
+cpu          430.7 (357-446)          38.3 (38-39)
+gpu         2241.5 (1663-2295)        28.7 (25-29)
+gpu/cpu      5.20x                   0.75x
 ```
 
-`-p` でプロンプトのおおよそのトークン数、`-n` でデコードするトークン数を指定
-します。GPU ビルドタグなしの場合は、GPU 行に理由が表示されます。 プレフィルの t/s はプロンプトが
-長くなるほど下がり (attention が二次)、変換レイヤー越しでは実行ごとに数 %
-ぶれます。長さをまたいだ単発の数値ではなく、同じ長さで数回の中央値を比べて
-ください。
+`-p` でプロンプトのおおよそのトークン数、`-n` でデコードするトークン数、`-r`
+で計測の反復回数を指定します。GPU ビルドタグなしの場合は、GPU 行に理由が
+表示されます。反復の間モデルは常駐したままで、最初の 1 回は捨てられるので、
+サンプルは定常状態を表します — この経路ではコールドのプレフィルが 3 割ほど
+低く出ることがあり、定常状態を報告するツールと比べるとそれが不公平になり
+ます。プレフィルの t/s は attention が二次なのでプロンプトが長いほど下がり
+ます。比較は同じ長さで行ってください。
 
 ### OpenAI 互換 API の提供
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -100,17 +100,21 @@ prefill 401 tokens, decode 32 tokens, int8 weights
 cpu: AVX2 kernels
 gpu: Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (integrated) via -tags wgpu24
 
-               prefill       decode
-cpu            398.2 t/s       39.4 t/s
-gpu           2020.9 t/s       29.7 t/s
-gpu/cpu          5.08x         0.75x
+median of 5 runs after one warm-up, tokens/sec
+
+           prefill                  decode
+cpu          430.7 (357-446)          38.3 (38-39)
+gpu         2241.5 (1663-2295)        28.7 (25-29)
+gpu/cpu      5.20x                   0.75x
 ```
 
-`-p` sets the approximate prompt length and `-n` the tokens to decode. Without
-a GPU build tag the GPU row reports why it is unavailable. Prefill throughput falls as the prompt
-grows (attention is quadratic) and varies a few percent run to run through a
-translation layer, so compare medians of a few runs at one length rather than
-single numbers across lengths.
+`-p` sets the approximate prompt length, `-n` the tokens to decode, and `-r`
+the timed repetitions. Without a GPU build tag the GPU row reports why it is
+unavailable. The model stays loaded across repetitions and the first pass is
+discarded, so the samples describe steady state — a cold prefill on this path
+can read 30% low, which is what makes an unwarmed number unfair to compare
+against a tool that reports steady state. Prefill throughput still falls as
+the prompt grows, since attention is quadratic, so compare at one length.
 
 ### Serving an OpenAI-compatible API
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -245,6 +245,18 @@ func Open(o Options) (*Engine, error) {
 	return e, nil
 }
 
+// Reset drops the KV cache and rewinds the position counter, so the next
+// Generate starts from an empty context instead of continuing the last
+// one. Benchmarks use it to repeat the same prompt.
+func (e *Engine) Reset() {
+	e.reset()
+	if e.draft != nil {
+		e.draft.reset()
+	}
+	e.steps = 0
+	e.logits = nil
+}
+
 // GPUName reports the adapter the engine is running on, empty when
 // decoding on the CPU. Backend names the binding generation the binary
 // was built with.


### PR DESCRIPTION
bench loaded the model and timed a single prefill per side, so every sample carried a cold cache and a ramping clock — comparing that against a tool like llama-bench, which keeps the model resident and averages many repetitions, understated tensai by about 30% on the GPU path and made the spread far wider than the hardware's. Each side now warms up once and then runs -r timed repetitions with the model still loaded, reporting the median and the low-high range. Adds Engine.Reset, which drops the KV cache and rewinds the position counter between repetitions; repeated generations produce identical output. On the Radeon 780M through dozen the GPU prefill median goes from 1605 to 2242 t/s and the range narrows from 1287-2182 to 1663-2295.