### PR TITLE
Select a cached model by the name the listing prints

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -51,6 +51,7 @@ func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 	fs.StringVar(&o.Data, "data", "", "directory for the downloaded model files (default: a per-repo directory under the user cache)")
 	fs.StringVar(&o.Repo, "repo", llm.DefaultRepo, "Hugging Face repo to download missing model files from")
 	fs.StringVar(&o.GGUF, "gguf", "", "load model and tokenizer from a single .gguf file instead of -data/-repo")
+	model := fs.String("model", "", `cached model to run, named as "tensai models" prints it`)
 	q8 := fs.Bool("q8", false, "decode against int8-quantized weights")
 	q4 := fs.Bool("q4", false, "decode against int4-quantized weights (group-wise)")
 	fs.BoolVar(&o.GPU, "gpu", false, "decode on the GPU (requires -q8 or -q4 and a wgpu build tag)")
@@ -71,11 +72,49 @@ func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 		if *q4 {
 			o.Bits = 4
 		}
+		if *model != "" {
+			if err := useCached(o, *model); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+		}
 		if o.Data == "" && o.GGUF == "" {
 			o.Data = llm.DefaultDataDir(o.Repo)
 		}
 	}
 	return o, finish
+}
+
+// useCached points the options at a model already in the cache, named the
+// way "tensai models" prints it, so a listing can be pasted into a run
+// without spelling out a path or remembering the Hugging Face org. It
+// never downloads: a name that is not cached is an error, not a fetch.
+func useCached(o *llm.Options, name string) error {
+	if o.Data != "" || o.GGUF != "" {
+		return fmt.Errorf("-model already says which model to run; drop -data and -gguf")
+	}
+	if name != filepath.Base(name) || name == "." || name == ".." {
+		return fmt.Errorf("invalid model name %q: use the name \"tensai models\" prints, not a path", name)
+	}
+	root := llm.CacheRoot()
+	// A .gguf carries everything in one file; a directory needs the
+	// config.json that run, chat, and serve load first.
+	for _, gguf := range []string{name, name + ".gguf"} {
+		if !strings.HasSuffix(gguf, ".gguf") {
+			continue
+		}
+		p := filepath.Join(root, gguf)
+		if _, err := os.Stat(p); err == nil {
+			o.GGUF = p
+			return nil
+		}
+	}
+	dir := filepath.Join(root, name)
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); err == nil {
+		o.Data = dir
+		return nil
+	}
+	return fmt.Errorf("no cached model %q under %s (see \"tensai models\")", name, root)
 }
 
 func openEngine(o *llm.Options, finish func()) *llm.Engine {

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -71,10 +71,11 @@ commands:
   version  print the version
 ```
 
-モデルを使うコマンドは同じフラグを共有します: `-repo` (ダウンロード元の Hugging Face リポジトリ)、`-gguf` (1 つの .gguf からすべてロード)、`-q8`/`-q4`、`-gpu`、`-draft`、`-think`、`-system`、`-temp`、`-topp`、`-seed` など — 完全なリストは `tensai <command> -h` で。
+モデルを使うコマンドは同じフラグを共有します: `-model` (キャッシュ済みモデルを `tensai models` が出す名前で指定)、`-repo` (ダウンロード元の Hugging Face リポジトリ)、`-gguf` (1 つの .gguf からすべてロード)、`-q8`/`-q4`、`-gpu`、`-draft`、`-think`、`-system`、`-temp`、`-topp`、`-seed` など — 完全なリストは `tensai <command> -h` で。
 
 ```bash
 tensai run -q8 "What is the capital of France?"
+tensai run -q8 -model Qwen3-0.6B "Explain RoPE briefly"   # "tensai models" の名前をそのまま
 tensai run -q8 -json "Explain RoPE briefly"      # 補完と使用量を 1 つの JSON で
 tensai chat -q8 -gguf model.gguf                 # マルチターン。KV キャッシュが対話全体を運ぶ
 tensai models                                    # キャッシュ一覧。"models rm <name>" で削除
@@ -119,6 +120,10 @@ gpu/cpu      5.20x                   0.75x
 ```bash
 tensai serve -q8 -addr 127.0.0.1:8080
 ```
+
+`-model` には一覧の名前をそのまま渡せます — ディレクトリでも `.gguf` でも、拡張子は
+あってもなくても構いません。ダウンロードはしないので、キャッシュに無い名前はエラーに
+なります。取ってきてほしいときは `-repo` を使ってください。
 
 `models` が一覧するのは `run` / `chat` / `serve` が読めるものだけです —
 `config.json` を持つディレクトリか、`.gguf` ファイル。example はデータセットを

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -71,10 +71,11 @@ commands:
   version  print the version
 ```
 
-All model commands share the same flags: `-repo` (Hugging Face repo to download from), `-gguf` (load everything from one .gguf file), `-q8`/`-q4`, `-gpu`, `-draft`, `-think`, `-system`, `-temp`, `-topp`, `-seed`, and more — run `tensai <command> -h` for the full list.
+All model commands share the same flags: `-model` (a model already cached, named as `tensai models` prints it), `-repo` (Hugging Face repo to download from), `-gguf` (load everything from one .gguf file), `-q8`/`-q4`, `-gpu`, `-draft`, `-think`, `-system`, `-temp`, `-topp`, `-seed`, and more — run `tensai <command> -h` for the full list.
 
 ```bash
 tensai run -q8 "What is the capital of France?"
+tensai run -q8 -model Qwen3-0.6B "Explain RoPE briefly"   # a name from "tensai models"
 tensai run -q8 -json "Explain RoPE briefly"      # one JSON object with usage counts
 tensai chat -q8 -gguf model.gguf                 # multi-turn; the KV cache carries the dialogue
 tensai models                                    # list the cache; "models rm <name>" deletes
@@ -121,6 +122,10 @@ the prompt grows, since attention is quadratic, so compare at one length.
 ```bash
 tensai serve -q8 -addr 127.0.0.1:8080
 ```
+
+`-model` takes a name straight from the listing — a directory or a `.gguf`,
+with or without the extension — and never downloads: an uncached name is an
+error rather than a fetch. Use `-repo` when you do want tensai to go get it.
 
 `models` lists only what `run`, `chat`, and `serve` can load — a directory
 with a `config.json`, or a `.gguf` file. The examples cache their datasets in


### PR DESCRIPTION
tensai models prints names like Qwen3-0.6B, but nothing accepted them: running that model meant either spelling out -data ~/.cache/tensai/Qwen3-0.6B or knowing the Hugging Face org for -repo. A -model flag now takes the listed name directly — a directory or a .gguf, with or without the extension — and resolves it inside the cache root. It never downloads, so an uncached name is an error pointing back at the listing rather than a surprise fetch; -repo remains the way to ask for one. Paths are rejected, and combining it with -data or -gguf says so instead of silently picking one.