### PR TITLE
Name the model once, in -model

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The DeepSeek-R1 distills need no family of their own — they are stock qwen2/ll
 
 With `-q8`/`-q4` each weight quantizes as it loads and its float32 copy dies immediately, so the full-precision model never has to fit in memory, and the layers load in parallel with the quantizer splitting columns across CPUs. Quantized GGUF checkpoints skip the float32 detour entirely: Q8_0, Q4_0, Q5_0, the whole Q4_K/Q5_K/Q6_K K-quant family, and MXFP4 repack straight from the memory-mapped file — nibbles copy raw where the grids line up, five- and six-bit spans renormalize with integer rounding under `-q4`, everything widens onto a finer int8 grid under `-q8` — keeping llama.cpp's own quantization intact. A 1.5B Q4_K_M loads in about 3 seconds instead of 8 (`-requant` restores the float detour, trading the much slower load for about 10% more decode speed from its coarser symmetric tables); a 3B Q8_0 opens in 5 seconds instead of 32.
 
-The first `-gguf` load also writes the repacked weights to a cache file next to the model (`-nocache` opts out), and every later load just memory-maps it: the 1.5B Q4_K_M reopens in ~0.3 seconds, a Mistral 7B in well under a second, and gpt-oss-20b in under two. Beyond the instant reopen, mapped weights are clean file-backed pages the kernel can drop and re-read at will — on a machine where the model barely fits, that replaces swap thrashing with ordinary page cache behavior, which is the same structural advantage llama.cpp gets from decoding straight out of its mmap'd file.
+The first `.gguf` load also writes the repacked weights to a cache file next to the model (`-nocache` opts out), and every later load just memory-maps it: the 1.5B Q4_K_M reopens in ~0.3 seconds, a Mistral 7B in well under a second, and gpt-oss-20b in under two. Beyond the instant reopen, mapped weights are clean file-backed pages the kernel can drop and re-read at will — on a machine where the model barely fits, that replaces swap thrashing with ordinary page cache behavior, which is the same structural advantage llama.cpp gets from decoding straight out of its mmap'd file.
 
 On a 15GB machine the ladder looks like: 0.5B at ~40 tok/s with `-q8` and a 1.5B Q4_K_M at ~25 with `-q4` (the tiled integer kernels, measured on native Windows), and Qwen2.5-**7B**-Instruct — 15GB of BF16 shards, int4-quantized on the fly during a two-minute load into ~6GB resident — answering correctly at 3.5 tok/s. Prompts feed through a batched prefill: `QMatrix.MatMul` streams the weights once per block of eight token rows instead of once per token, cutting the wait before the first generated token by around 6x.
 
@@ -415,7 +415,7 @@ GOEXPERIMENT=simd go run ./_example/qwen -q8      # downloads Qwen2.5-0.5B-Instr
 # The tensai command wraps the same engine as subcommands:
 GOEXPERIMENT=simd go install ./cmd/tensai
 tensai run -q8 "What is the capital of France?"
-tensai chat -q8 -gguf model.gguf
+tensai chat -q8 -model ./model.gguf
 tensai serve -q8 -addr :8080                      # OpenAI-compatible API
 GOEXPERIMENT=simd go run -tags wgpu24 ./cmd/tensai bench -q8   # CPU vs GPU
 go run -tags wgpu ./_example/wgpu          # needs wgpu-native, see above

--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -48,22 +48,21 @@ Run "tensai <command> -h" for the command's flags.`
 // Options they fill.
 func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 	o := &llm.Options{Log: os.Stderr}
-	fs.StringVar(&o.Data, "data", "", "directory for the downloaded model files (default: a per-repo directory under the user cache)")
-	fs.StringVar(&o.Repo, "repo", llm.DefaultRepo, "Hugging Face repo to download missing model files from")
-	fs.StringVar(&o.GGUF, "gguf", "", "load model and tokenizer from a single .gguf file instead of -data/-repo")
+	model := fs.String("model", "", `which model to run: a name from "tensai models", a path to a directory or .gguf, or a Hugging Face repo to download`)
+	data := fs.String("data", "", "directory to cache a downloaded model in (default: a per-repo directory under the user cache)")
 	q8 := fs.Bool("q8", false, "decode against int8-quantized weights")
 	q4 := fs.Bool("q4", false, "decode against int4-quantized weights (group-wise)")
 	fs.BoolVar(&o.GPU, "gpu", false, "decode on the GPU (requires -q8 or -q4 and a wgpu build tag)")
 	fs.BoolVar(&o.Requant, "requant", false, "requantize gguf weights through float32 instead of repacking their stored blocks")
-	fs.BoolVar(&o.NoCache, "nocache", false, "neither write nor reuse the repack cache file the first -gguf load leaves next to the model")
-	fs.StringVar(&o.Draft, "draft", "", "data directory of a smaller draft model for speculative decoding")
+	fs.BoolVar(&o.NoCache, "nocache", false, "neither write nor reuse the repack cache file the first .gguf load leaves next to the model")
+	draft := fs.String("draft", "", "a smaller same-family model for speculative decoding, named the way -model is")
 	fs.IntVar(&o.SpecK, "spec", 3, "draft tokens proposed per speculative step")
 	fs.BoolVar(&o.Think, "think", false, "let Qwen3 models reason in a <think> block before answering")
 	fs.StringVar(&o.System, "system", llm.DefaultSystem, "system message for the chat template")
 	fs.Float64Var(&o.Temp, "temp", 0, "sampling temperature; 0 = greedy")
 	fs.Float64Var(&o.TopP, "topp", 0.9, "nucleus sampling: keep the smallest set of tokens with this much probability mass (1 disables)")
 	fs.Int64Var(&o.Seed, "seed", 1, "sampling seed for -temp > 0")
-	// Bits and the default data directory resolve only after Parse.
+	// Bits and the model reference resolve only after Parse.
 	finish := func() {
 		if *q8 {
 			o.Bits = 8
@@ -71,11 +70,103 @@ func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 		if *q4 {
 			o.Bits = 4
 		}
-		if o.Data == "" && o.GGUF == "" {
-			o.Data = llm.DefaultDataDir(o.Repo)
+		if err := resolveModel(o, *model, *data); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		if *draft != "" {
+			d := &llm.Options{}
+			if err := resolveModel(d, *draft, ""); err != nil || d.GGUF != "" {
+				fmt.Fprintf(os.Stderr, "-draft wants a model directory or a cached name, not %q\n", *draft)
+				os.Exit(2)
+			}
+			o.Draft = d.Data
 		}
 	}
 	return o, finish
+}
+
+// resolveModel turns the one thing a caller says about a model into the
+// three the loader wants. A reference is, in order: empty for the default
+// checkpoint; an existing path, to a .gguf or to a directory; a bare name
+// in the cache, exactly as "tensai models" prints it; or, failing all of
+// those, a Hugging Face repo to download. dataDir overrides where a
+// download is cached and is meaningless for the local forms.
+func resolveModel(o *llm.Options, ref, dataDir string) error {
+	if ref == "" {
+		o.Repo = llm.DefaultRepo
+		o.Data = dataDir
+		if o.Data == "" {
+			o.Data = llm.DefaultDataDir(o.Repo)
+		}
+		return nil
+	}
+	local := func(p string) error {
+		info, err := os.Stat(p)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// The same test the listing uses: a model directory is one
+			// the loader can read a config.json out of, which keeps a
+			// dataset directory from being mistaken for a checkpoint.
+			if _, err := os.Stat(filepath.Join(p, "config.json")); err != nil {
+				return fmt.Errorf("%s has no config.json, so it is not a model directory", p)
+			}
+			o.Data = p
+			return nil
+		}
+		if !strings.HasSuffix(p, ".gguf") {
+			return fmt.Errorf("%s is not a model directory or a .gguf file", p)
+		}
+		o.GGUF = p
+		return nil
+	}
+	// A path the user spelled out wins, so a directory named like a repo
+	// still resolves to the directory in front of them. Something that
+	// exists but is not a model is an error: falling through would send
+	// a typo to the network as if it were a repo.
+	if strings.ContainsAny(ref, `/\`) || ref == "." || ref == ".." {
+		if _, err := os.Stat(ref); err == nil {
+			if err := local(ref); err != nil {
+				return err
+			}
+			return dataUnused(dataDir, ref)
+		}
+	}
+	root := llm.CacheRoot()
+	if ref == filepath.Base(ref) {
+		for _, cand := range []string{ref, ref + ".gguf"} {
+			p := filepath.Join(root, cand)
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+			if err := local(p); err != nil {
+				return err
+			}
+			return dataUnused(dataDir, ref)
+		}
+	}
+	// Nothing local: the last reading that can still work is a repo, and
+	// a repo has an org, so a bare name here is simply not found.
+	if !strings.Contains(ref, "/") {
+		return fmt.Errorf("no cached model %q under %s (see \"tensai models\", or give an org/name to download)", ref, root)
+	}
+	o.Repo = ref
+	o.Data = dataDir
+	if o.Data == "" {
+		o.Data = llm.DefaultDataDir(ref)
+	}
+	return nil
+}
+
+// dataUnused rejects -data alongside a model that is already on disk,
+// where there is no download for it to place.
+func dataUnused(dataDir, ref string) error {
+	if dataDir != "" {
+		return fmt.Errorf("-data says where to cache a download, but %q is already local", ref)
+	}
+	return nil
 }
 
 func openEngine(o *llm.Options, finish func()) *llm.Engine {

--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -43,7 +43,7 @@ The capital of France is Paris.
 
 `-q8`/`-q4` では各重みがロードと同時に量子化され、float32 コピーは即座に破棄されます。フル精度のモデルがメモリに収まる必要はありません。量子化済み GGUF チェックポイントは float32 の回り道を完全にスキップします: Q8_0, Q4_0, Q5_0, Q4_K/Q5_K/Q6_K の K-quant 系、MXFP4 がメモリマップしたファイルから直接リパックされ、llama.cpp 自身の量子化がそのまま保たれます。1.5B の Q4_K_M は約 8 秒が約 3 秒に、3B の Q8_0 は 32 秒が 5 秒で開きます (`-requant` は float 経由に戻し、ずっと遅いロードと引き換えにデコードが約 10% 速くなります)。
 
-最初の `-gguf` ロードはリパック済みの重みをモデルの隣のキャッシュファイルに書き (`-nocache` でオプトアウト)、以後のロードはそれをメモリマップするだけです: 1.5B Q4_K_M は約 0.3 秒で、Mistral 7B は 1 秒未満で、gpt-oss-20b は 2 秒未満で再オープンします。マップされた重みはカーネルがいつでも破棄・再読込できるクリーンなファイルバックのページなので、モデルがぎりぎり収まるマシンではスワップのスラッシングが普通のページキャッシュの挙動に置き換わります。
+最初の `.gguf` ロードはリパック済みの重みをモデルの隣のキャッシュファイルに書き (`-nocache` でオプトアウト)、以後のロードはそれをメモリマップするだけです: 1.5B Q4_K_M は約 0.3 秒で、Mistral 7B は 1 秒未満で、gpt-oss-20b は 2 秒未満で再オープンします。マップされた重みはカーネルがいつでも破棄・再読込できるクリーンなファイルバックのページなので、モデルがぎりぎり収まるマシンではスワップのスラッシングが普通のページキャッシュの挙動に置き換わります。
 
 15GB のマシンでの階段はこうなります: 0.5B が `-q8` で約 40 tok/s、1.5B Q4_K_M が `-q4` で約 25 tok/s (タイル化整数カーネル、ネイティブ Windows)、そして Qwen2.5-**7B**-Instruct — 15GB の BF16 シャードを 2 分のロード中にオンザフライで int4 量子化して常駐約 6GB に — が 3.5 tok/s で正しく答えます。
 
@@ -71,12 +71,26 @@ commands:
   version  print the version
 ```
 
-モデルを使うコマンドは同じフラグを共有します: `-repo` (ダウンロード元の Hugging Face リポジトリ)、`-gguf` (1 つの .gguf からすべてロード)、`-q8`/`-q4`、`-gpu`、`-draft`、`-think`、`-system`、`-temp`、`-topp`、`-seed` など — 完全なリストは `tensai <command> -h` で。
+モデルを使うコマンドは同じフラグを共有します: `-model` (どのモデルを実行するか)、`-data` (ダウンロードのキャッシュ先)、`-q8`/`-q4`、`-gpu`、`-draft`、`-think`、`-system`、`-temp`、`-topp`、`-seed` など — 完全なリストは `tensai <command> -h` で。
+
+どのモデルを実行するかを言うのは `-model` だけで、次の順に解釈します:
+
+| 形式 | 例 |
+|---|---|
+| `tensai models` が出す名前 | `-model Qwen3-0.6B`、`-model qwen2.5-0.5b-instruct-q8_0` |
+| ディレクトリまたは `.gguf` のパス | `-model ./model.gguf`、`-model /srv/checkpoints/qwen` |
+| Hugging Face リポジトリ (初回にダウンロード) | `-model Qwen/Qwen3-4B-Instruct-2507` |
+
+省略すると既定のチェックポイントです。ローカル指定が勝手にダウンロードすることは
+ありません — キャッシュに無く、取得元の組織名も無い名前はエラーになり、一覧を案内
+します。`-data` はダウンロードのキャッシュ先を上書きするもので、モデルが既にローカル
+にある場合は黙って無視せずその旨を伝えます。`-draft` も同じ形式を受けます (`.gguf` を除く)。
 
 ```bash
 tensai run -q8 "What is the capital of France?"
+tensai run -q8 -model Qwen3-0.6B "Explain RoPE briefly"   # "tensai models" の名前をそのまま
 tensai run -q8 -json "Explain RoPE briefly"      # 補完と使用量を 1 つの JSON で
-tensai chat -q8 -gguf model.gguf                 # マルチターン。KV キャッシュが対話全体を運ぶ
+tensai chat -q8 -model ./model.gguf              # マルチターン。KV キャッシュが対話全体を運ぶ
 tensai models                                    # キャッシュ一覧。"models rm <name>" で削除
 tensai bench -q8                                 # CPU vs GPU のプレフィル/デコード比較
 ```

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -43,7 +43,7 @@ The capital of France is Paris.
 
 With `-q8`/`-q4` each weight quantizes as it loads and its float32 copy dies immediately, so the full-precision model never has to fit in memory. Quantized GGUF checkpoints skip the float32 detour entirely: Q8_0, Q4_0, Q5_0, the Q4_K/Q5_K/Q6_K K-quant family, and MXFP4 repack straight from the memory-mapped file, keeping llama.cpp's own quantization intact. A 1.5B Q4_K_M loads in about 3 seconds instead of 8; a 3B Q8_0 opens in 5 seconds instead of 32 (`-requant` restores the float detour, trading a much slower load for about 10% more decode speed).
 
-The first `-gguf` load also writes the repacked weights to a cache file next to the model (`-nocache` opts out), and every later load just memory-maps it: the 1.5B Q4_K_M reopens in ~0.3 seconds, a Mistral 7B in well under a second, and gpt-oss-20b in under two. Mapped weights are clean file-backed pages the kernel can drop and re-read at will — on a machine where the model barely fits, that replaces swap thrashing with ordinary page cache behavior.
+The first `.gguf` load also writes the repacked weights to a cache file next to the model (`-nocache` opts out), and every later load just memory-maps it: the 1.5B Q4_K_M reopens in ~0.3 seconds, a Mistral 7B in well under a second, and gpt-oss-20b in under two. Mapped weights are clean file-backed pages the kernel can drop and re-read at will — on a machine where the model barely fits, that replaces swap thrashing with ordinary page cache behavior.
 
 On a 15GB machine the ladder looks like: a 0.5B at ~40 tok/s with `-q8`, a 1.5B Q4_K_M at ~25 tok/s with `-q4` (tiled integer kernels, native Windows), and Qwen2.5-**7B**-Instruct — 15GB of BF16 shards, int4-quantized on the fly during a two-minute load into ~6GB resident — answering correctly at 3.5 tok/s.
 
@@ -71,12 +71,28 @@ commands:
   version  print the version
 ```
 
-All model commands share the same flags: `-repo` (Hugging Face repo to download from), `-gguf` (load everything from one .gguf file), `-q8`/`-q4`, `-gpu`, `-draft`, `-think`, `-system`, `-temp`, `-topp`, `-seed`, and more — run `tensai <command> -h` for the full list.
+All model commands share the same flags: `-model` (which model to run), `-data` (where to cache a download), `-q8`/`-q4`, `-gpu`, `-draft`, `-think`, `-system`, `-temp`, `-topp`, `-seed`, and more — run `tensai <command> -h` for the full list.
+
+`-model` is the only thing that says which model to run, and it reads whichever
+form you hand it, in this order:
+
+| Form | Example |
+|---|---|
+| a name from `tensai models` | `-model Qwen3-0.6B`, `-model qwen2.5-0.5b-instruct-q8_0` |
+| a path to a directory or `.gguf` | `-model ./model.gguf`, `-model /srv/checkpoints/qwen` |
+| a Hugging Face repo, downloaded on first use | `-model Qwen/Qwen3-4B-Instruct-2507` |
+
+Omit it for the default checkpoint. A local reference never downloads: a name
+that is not cached, and carries no org to fetch it from, is an error pointing
+back at the listing. `-data` overrides where a download is cached, and says so
+rather than being ignored when the model is already local. `-draft` takes the
+same forms, minus `.gguf`.
 
 ```bash
 tensai run -q8 "What is the capital of France?"
+tensai run -q8 -model Qwen3-0.6B "Explain RoPE briefly"   # a name from "tensai models"
 tensai run -q8 -json "Explain RoPE briefly"      # one JSON object with usage counts
-tensai chat -q8 -gguf model.gguf                 # multi-turn; the KV cache carries the dialogue
+tensai chat -q8 -model ./model.gguf              # multi-turn; the KV cache carries the dialogue
 tensai models                                    # list the cache; "models rm <name>" deletes
 tensai bench -q8                                 # CPU vs GPU, prefill and decode
 ```


### PR DESCRIPTION
Saying which model to run took three flags that did not compose: -data for a directory, -repo for a Hugging Face repo, -gguf for a file, and nothing accepted the names tensai models prints. They collapse into -model, which reads whichever form it is handed — a cached name, a path to a directory or .gguf, or an org/name to download — resolved in that order, with the empty value still meaning the default checkpoint. -data keeps only its other job, saying where a download is cached, and now reports rather than ignores itself when the model is already local. -draft takes the same forms. An existing path that is not a model is an error instead of being retried as a repo name, and a directory must carry a config.json, the same test the listing applies. README and both documentation languages are updated; _example/qwen keeps its own flags.