### PR TITLE
Say what the wgpu24 tag actually buys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ _example/dataset/dataset
 /.codex/
 _example/mnist/data/
 _example/gpt2/data/
-_example/qwen/data*/
 /charrnn.json
 /graph.png
 /graph.svg
@@ -24,3 +23,4 @@ tokenizer/testdata/
 *.gguf.tensai-*.cache
 run-codeserver.sh
 test-wgpu24.sh
+/PERF-INVESTIGATION.md

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# wgpu24 binds the v29 wgpu-native C API, which can see non-conformant
+# Vulkan drivers. That is what reaches the real GPU through dozen inside
+# WSL2; a plain wgpu build falls back to a software rasterizer there.
+# See docs/guide/gpu.md.
 BIN := tensai
 VERSION := $$(make -s show-version)
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)

--- a/docs/guide/gpu.ja.md
+++ b/docs/guide/gpu.ja.md
@@ -100,4 +100,12 @@ TENSAI_WGPU_LIB=$PWD/wgpu29/lib/libwgpu_native.so \
     go run -tags wgpu24 ./_example/wgpu   # adapter: Microsoft Direct3D12 (AMD Radeon(TM) Graphics)
 ```
 
-両方のタグを付けると `wgpu24` が勝ちます。新しい方が速いわけではないことに注意: Radeon 780M の `32x512x512@512x512` で、同じシェーダが v22 ライブラリでは 85ms、v29 では 165ms です。`wgpu24` は速度のためではなく、届くアダプタのために使ってください。
+両方のタグを付けると `wgpu24` が勝ちます。そしてこのような環境では、その選択がすべてを決めます — どのアダプタに届くかが決まるからです。WSL2 内の dozen 越しに Radeon 780M で測ると、v22 ビルドは llvmpipe に落ちます:
+
+| | `-tags wgpu` (v22) | `-tags wgpu24` (v29) |
+|---|---|---|
+| 到達したアダプタ | llvmpipe (ソフトウェア) | Microsoft Direct3D12 (Radeon 780M) |
+| f32 `32x512x512@512x512`、入力常駐 | 461.7ms | 69.5ms |
+| int8 プレフィル / デコード | 27.0 / 6.0 t/s | 1801 / 27.1 t/s |
+
+`Makefile` が `wgpu24` でビルドするのはこのためです。この差はどちらのビルドがどのハードウェアに届くかであって、同じアダプタ上で 2 つのライブラリを比較した結果ではありません — 準拠ドライバが両方から見える環境なら、どちらでも構いません。

--- a/docs/guide/gpu.md
+++ b/docs/guide/gpu.md
@@ -100,4 +100,12 @@ TENSAI_WGPU_LIB=$PWD/wgpu29/lib/libwgpu_native.so \
     go run -tags wgpu24 ./_example/wgpu   # adapter: Microsoft Direct3D12 (AMD Radeon(TM) Graphics)
 ```
 
-When both tags are set, `wgpu24` wins. Note that new does not mean faster: on a Radeon 780M at `32x512x512@512x512` the v22 library runs the same shader in 85ms and the v29 one in 165ms. Use `wgpu24` for the adapters it reaches, not for speed.
+When both tags are set, `wgpu24` wins, and on a machine like this one that choice decides everything, because it decides which adapter you get. Measured on the Radeon 780M through dozen inside WSL2, where the v22 build falls back to llvmpipe:
+
+| | `-tags wgpu` (v22) | `-tags wgpu24` (v29) |
+|---|---|---|
+| adapter reached | llvmpipe (software) | Microsoft Direct3D12 (Radeon 780M) |
+| f32 `32x512x512@512x512`, resident inputs | 461.7ms | 69.5ms |
+| int8 prefill / decode | 27.0 / 6.0 t/s | 1801 / 27.1 t/s |
+
+This is why the `Makefile` builds with `wgpu24`. The gap is which hardware each build reaches, not a comparison of the two libraries on the same adapter — where a conformant driver is visible to both, pick either.


### PR DESCRIPTION
The GPU guide told readers to use wgpu24 for the adapters it reaches and not for speed, citing the same shader at 85ms on the v22 library against 165ms on v29. That comparison does not reproduce, and it points the wrong way. Re-measured on the Radeon 780M through dozen inside WSL2, the tag decides which adapter the build gets at all: the v22 build never sees dozen and lands on llvmpipe, where the f32 product takes 461.7ms against 69.5ms on the D3D12 adapter, and int8 inference runs at 27.0 t/s prefill and 6.0 t/s decode against 1801 and 27.1. The section now carries those numbers in both languages and says the gap is which hardware each build reaches rather than the two libraries measured on one adapter. The Makefile gained the missing sentence explaining why it builds with the tag. Also drops the qwen example's ignore rule, and moves the local performance notes from .git/info/exclude into .gitignore.