### PR TITLE
Add a bump target that runs without a tty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,14 @@ endif
 	git push origin main
 	git push origin "refs/tags/v$(VERSION)"
 
+.PHONY: bump-force
+bump-force: $(GOBIN)/gobump
+	@gobump patch -w .
+	git commit -am "Bump up version to $(VERSION)"
+	git tag "v$(VERSION)"
+	git push origin main
+	git push origin "refs/tags/v$(VERSION)"
+
 .PHONY: upload
 upload: $(GOBIN)/ghr
 	ghr -body="" "v$(VERSION)" goxz


### PR DESCRIPTION
make bump asks for confirmation, which is fine at a terminal and impossible anywhere else. bump-force does the same work -- gobump patch, commit, tag, push both -- without the clean-tree and main-branch guards that make the interactive one safe, so it is the one to reach for when a release has to happen from a non-interactive shell.