### PR TITLE
Point bump-force at the package holding the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 
 .PHONY: bump-force
 bump-force: $(GOBIN)/gobump
-	@gobump patch -w .
+	@gobump patch -w ./cmd/tensai
 	git commit -am "Bump up version to $(VERSION)"
 	git tag "v$(VERSION)"
 	git push origin main


### PR DESCRIPTION
bump-force asked gobump to patch the module root, where there is no version to find, so it stopped with "version not found" before doing anything. The constant lives in ./cmd/tensai, which is what the bump and show-version targets already name.