### PR TITLE
Keep thinking out of the answer

### DIFF
--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -142,6 +142,20 @@ tensai serve -q8 -addr 127.0.0.1:8080
 
 `serve` は `/v1/chat/completions` (messages 配列、SSE ストリーミング、使用量カウント) を公開するので、OpenAI クライアントを向ければ何でも純 Go のモデルとチャットできます。組み込みのチャットデモページが `GET /` で提供されます。
 
+### 思考の分離
+
+`-think` を付けると、答える前に考えるモデルの出力は 2 つに分かれて届きます — 最初に書く思考ブロックが `reasoning_content`、返答だけが `content` で、ストリーミングでもそれぞれのデルタになります。クライアントは思考を思考として表示することも、捨てることもできます。思考がプロンプトに戻ることはありません — 履歴を再生するときは返答だけを残し、思考は落とします。モデル自身のテンプレートと同じ扱いです。
+
+```json
+"message": {
+  "role": "assistant",
+  "reasoning_content": "Okay, the user is asking for 17 multiplied by 3...",
+  "content": "17 multiplied by 3 is 51."
+}
+```
+
+`-think` なしの場合、qwen3 と smollm3 は空の思考ブロックでターンを開くので、分離するものがありません。gpt-oss は harmony チャンネルで推論する別機構で、これは対象外です。
+
 ### ツール呼び出し
 
 `tools` を渡すと、モデルは散文の代わりに `tool_calls` で答えられます。エージェントがループを回すのに必要なものです:

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -145,6 +145,20 @@ the same place, and those are counted separately rather than listed as models;
 
 `serve` exposes `/v1/chat/completions` (messages array, SSE streaming, usage counts), so any OpenAI client pointed at it chats with a pure-Go model. A built-in chat demo page is served on `GET /`.
 
+### Thinking
+
+With `-think`, a model that reasons before it answers keeps the two apart on the wire: the block it writes first arrives as `reasoning_content` and only the reply is `content`, streaming as its own deltas, so a client can show the thinking as thinking or drop it. Reasoning never goes back into the prompt — replayed history keeps the answer and loses the thinking, as the model's own template does.
+
+```json
+"message": {
+  "role": "assistant",
+  "reasoning_content": "Okay, the user is asking for 17 multiplied by 3...",
+  "content": "17 multiplied by 3 is 51."
+}
+```
+
+Without `-think` the qwen3 and smollm3 families open the turn with an empty block, so there is nothing to separate. gpt-oss reasons in harmony channels instead, which this does not cover.
+
 ### Tool calling
 
 Pass `tools` and the model can answer with `tool_calls` instead of prose, which is what an agent needs to drive a loop:

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -785,6 +785,11 @@ type tmpl struct {
 	// the system turn, calls emitted as <tool_call> JSON, and results fed
 	// back as <tool_response> inside a user turn.
 	toolCalls string
+	// reasonOpen and reasonClose bracket the block a thinking model fills
+	// before it answers, empty for families that do not think out loud.
+	// What is between them is the model reasoning, not its reply, and the
+	// API keeps the two apart.
+	reasonOpen, reasonClose string
 }
 
 func templateFor(modelType string, think bool) tmpl {
@@ -820,7 +825,9 @@ func templateFor(modelType string, think bool) tmpl {
 			bos:      "<｜begin▁of▁sentence｜>",
 			userOpen: "<｜User｜>",
 			asstOpen: "<｜Assistant｜>", asstClose: "<｜end▁of▁sentence｜>",
-			stops: []string{"<｜end▁of▁sentence｜>"},
+			stops:       []string{"<｜end▁of▁sentence｜>"},
+			reasonOpen:  "<think>",
+			reasonClose: "</think>",
 		}
 	}
 	if modelType == "phi3" {
@@ -852,8 +859,12 @@ func templateFor(modelType string, think bool) tmpl {
 	}
 	// Qwen3 and SmolLM3 disable their thinking mode by opening the
 	// assistant turn with an empty think block; -think leaves it open.
-	if (modelType == "qwen3" || modelType == "smollm3") && !think {
-		t.asstOpen += "<think>\n\n</think>\n\n"
+	if modelType == "qwen3" || modelType == "smollm3" {
+		if think {
+			t.reasonOpen, t.reasonClose = "<think>", "</think>"
+		} else {
+			t.asstOpen += "<think>\n\n</think>\n\n"
+		}
 	}
 	return t
 }

--- a/internal/llm/serve.go
+++ b/internal/llm/serve.go
@@ -156,7 +156,14 @@ func render(tm tmpl, msgs []chatMessage, defaultSystem string, tools []toolDef) 
 			}
 			first = false
 		case m.Role == "assistant":
-			b.WriteString(tm.asstOpen + m.Content)
+			// The model's own template drops reasoning from history, so a
+			// client that echoes a whole turn back does not get to teach
+			// it that thinking belongs in the answer.
+			text := m.Content
+			if tm.reasonOpen != "" {
+				_, text = splitReasoning(text, tm.reasonOpen, tm.reasonClose)
+			}
+			b.WriteString(tm.asstOpen + text)
 			if hermes {
 				for _, c := range m.ToolCalls {
 					args := strings.TrimSpace(c.Function.Arguments)
@@ -183,6 +190,21 @@ func render(tm tmpl, msgs []chatMessage, defaultSystem string, tools []toolDef) 
 	}
 	b.WriteString(tm.asstOpen)
 	return b.String()
+}
+
+// splitReasoning takes the block a thinking model writes before its
+// answer off the front of a finished turn. A turn cut short mid-block
+// is all reasoning and no answer, which is what it is.
+func splitReasoning(s, open, close string) (reason, rest string) {
+	i := strings.Index(s, open)
+	if i < 0 {
+		return "", s
+	}
+	head, body := s[:i], s[i+len(open):]
+	if j := strings.Index(body, close); j >= 0 {
+		return strings.TrimSpace(body[:j]), strings.TrimSpace(head + body[j+len(close):])
+	}
+	return strings.TrimSpace(body), strings.TrimSpace(head)
 }
 
 // partialMarker returns how many trailing bytes of s could still grow
@@ -403,17 +425,30 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	// the marker appears; any tail that could still grow into it is held
 	// back, and once a call has started nothing more is streamed.
 	sawCall := false
-	var flush func(string)
+	// send names the field a piece belongs in: what a thinking model
+	// writes before it answers is reasoning, not content, and clients
+	// that show the two differently need them apart.
+	var send func(field, piece string)
+	flush := func(piece string) {
+		if send != nil && piece != "" {
+			send("content", piece)
+		}
+	}
+	flushReason := func(piece string) {
+		if send != nil && piece != "" {
+			send("reasoning_content", piece)
+		}
+	}
 	if req.Stream {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		flusher, _ := w.(http.Flusher)
-		flush = func(piece string) {
+		send = func(field, piece string) {
 			chunk := map[string]any{
 				"id": id, "object": "chat.completion.chunk", "created": created,
 				"model": "tensai",
 				"choices": []map[string]any{{
-					"index": 0, "delta": map[string]any{"content": piece},
+					"index": 0, "delta": map[string]any{field: piece},
 				}},
 			}
 			raw, _ := json.Marshal(chunk)
@@ -426,7 +461,7 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	// held is the text accepted but not yet streamed, kept only long
 	// enough to rule out the start of a call marker.
 	var held strings.Builder
-	emit := func(piece string, final bool) {
+	answer := func(piece string, final bool) {
 		if len(tools) == 0 {
 			flush(piece)
 			return
@@ -452,6 +487,54 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		held.WriteString(text[len(text)-keep:])
 		if len(text) > keep {
 			flush(text[:len(text)-keep])
+		}
+	}
+
+	// A thinking model opens its turn with a reasoning block; what is
+	// inside goes out as reasoning and what follows is the answer. The
+	// two markers are looked for one at a time, holding back only a tail
+	// that could still grow into the one being awaited.
+	var reasonHeld strings.Builder
+	reasonState := 0 // 0 before the block, 1 inside it, 2 past it
+	emit := func(piece string, final bool) {
+		if s.tm.reasonOpen == "" || reasonState == 2 {
+			answer(piece, final)
+			return
+		}
+		reasonHeld.WriteString(piece)
+		for {
+			text := reasonHeld.String()
+			marker := s.tm.reasonOpen
+			if reasonState == 1 {
+				marker = s.tm.reasonClose
+			}
+			if i := strings.Index(text, marker); i >= 0 {
+				reasonHeld.Reset()
+				reasonHeld.WriteString(text[i+len(marker):])
+				if reasonState == 0 {
+					answer(text[:i], false)
+					reasonState = 1
+					continue
+				}
+				flushReason(text[:i])
+				reasonState = 2
+				answer(reasonHeld.String(), final)
+				reasonHeld.Reset()
+				return
+			}
+			keep := 0
+			if !final {
+				keep = partialMarker(text, marker)
+			}
+			out := text[:len(text)-keep]
+			reasonHeld.Reset()
+			reasonHeld.WriteString(text[len(text)-keep:])
+			if reasonState == 0 {
+				answer(out, final)
+			} else {
+				flushReason(out)
+			}
+			return
 		}
 	}
 
@@ -548,6 +631,10 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	content := s.tok.Decode(out)
+	reasoning := ""
+	if s.tm.reasonOpen != "" {
+		reasoning, content = splitReasoning(content, s.tm.reasonOpen, s.tm.reasonClose)
+	}
 	var calls []toolCall
 	if len(tools) > 0 {
 		content, calls = parseToolCalls(content)
@@ -590,6 +677,9 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	msg := map[string]any{"role": "assistant", "content": content}
+	if reasoning != "" {
+		msg["reasoning_content"] = reasoning
+	}
 	if len(calls) > 0 {
 		msg["tool_calls"] = calls
 	}

--- a/internal/llm/serve_reasoning_test.go
+++ b/internal/llm/serve_reasoning_test.go
@@ -1,0 +1,193 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// scriptedTok is a tokenizer over a fixed script: token i decodes to
+// piece i, and the last id is the end-of-turn the server stops on.
+type scriptedTok struct{ pieces []string }
+
+func (t scriptedTok) Encode(s string) []int { return []int{0} }
+func (t scriptedTok) Decode(ids []int) string {
+	var b strings.Builder
+	for _, id := range ids {
+		if id >= 0 && id < len(t.pieces) {
+			b.WriteString(t.pieces[id])
+		}
+	}
+	return b.String()
+}
+
+// scriptedServer replays pieces one token at a time, which is what
+// exercises the split: a marker can arrive in fragments.
+func scriptedServer(t *testing.T, tm tmpl, pieces []string) *server {
+	t.Helper()
+	tok := scriptedTok{pieces: pieces}
+	end := len(pieces)
+	next := 0
+	oneHot := func(id int) []float32 {
+		l := make([]float32, end+1)
+		l[id] = 1
+		return l
+	}
+	s := &server{
+		tok: tok, nCtx: 4096, imEnd: end, eot: end, tm: tm,
+		reset: func() { next = 0 },
+	}
+	s.prefill = func([]int, int) []float32 {
+		id := next
+		next++
+		return oneHot(id)
+	}
+	s.step = func(int, int) []float32 {
+		if next >= end {
+			return oneHot(end)
+		}
+		id := next
+		next++
+		return oneHot(id)
+	}
+	return s
+}
+
+func post(t *testing.T, s *server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.chatCompletions(w, r)
+	return w
+}
+
+func thinkingTmpl() tmpl { return templateFor("qwen3", true) }
+
+func TestReasoningSplitNonStreaming(t *testing.T) {
+	// The markers arrive split across tokens, as a byte-level BPE gives them.
+	s := scriptedServer(t, thinkingTmpl(), []string{
+		"<th", "ink>", "\n17*3", " is 51.\n", "</think", ">", "\n\nIt is ", "51.",
+	})
+	w := post(t, s, `{"messages":[{"role":"user","content":"17*3?"}]}`)
+	var got struct {
+		Choices []struct {
+			Message struct {
+				Content   string `json:"content"`
+				Reasoning string `json:"reasoning_content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("%v: %s", err, w.Body)
+	}
+	m := got.Choices[0].Message
+	if m.Reasoning != "17*3 is 51." {
+		t.Errorf("reasoning_content = %q, want the thinking only", m.Reasoning)
+	}
+	if m.Content != "It is 51." {
+		t.Errorf("content = %q, want the answer only", m.Content)
+	}
+	if strings.Contains(m.Content, "<think") {
+		t.Errorf("the marker leaked into content: %q", m.Content)
+	}
+}
+
+// Deltas must carry reasoning and answer in their own fields, and no
+// fragment of a marker may reach the client in either.
+func TestReasoningSplitStreaming(t *testing.T) {
+	s := scriptedServer(t, thinkingTmpl(), []string{
+		"<th", "ink>", "weighing", " it", "</thi", "nk>", "done", ".",
+	})
+	w := post(t, s, `{"stream":true,"messages":[{"role":"user","content":"?"}]}`)
+	var reason, content strings.Builder
+	for _, line := range strings.Split(w.Body.String(), "\n") {
+		line = strings.TrimPrefix(line, "data: ")
+		if line == "" || line == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content   string `json:"content"`
+					Reasoning string `json:"reasoning_content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			t.Fatalf("%v: %s", err, line)
+		}
+		reason.WriteString(chunk.Choices[0].Delta.Reasoning)
+		content.WriteString(chunk.Choices[0].Delta.Content)
+	}
+	if reason.String() != "weighing it" {
+		t.Errorf("streamed reasoning = %q", reason.String())
+	}
+	if content.String() != "done." {
+		t.Errorf("streamed content = %q", content.String())
+	}
+	for _, bad := range []string{"<th", "think", "</th"} {
+		if strings.Contains(content.String(), bad) || strings.Contains(reason.String(), bad) {
+			t.Errorf("a marker fragment %q leaked into the stream", bad)
+		}
+	}
+}
+
+// A model that never opens a block, or a family that does not think,
+// must stream exactly what it said.
+func TestReasoningAbsent(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		tm   tmpl
+	}{
+		{"thinking family, no block", thinkingTmpl()},
+		{"non-thinking family", templateFor("qwen2", false)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := scriptedServer(t, tt.tm, []string{"just", " an ", "answer"})
+			w := post(t, s, `{"messages":[{"role":"user","content":"?"}]}`)
+			var got map[string]any
+			json.Unmarshal(w.Body.Bytes(), &got)
+			msg := got["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+			if msg["content"] != "just an answer" {
+				t.Errorf("content = %v", msg["content"])
+			}
+			if _, ok := msg["reasoning_content"]; ok {
+				t.Errorf("a turn with no thinking grew a reasoning_content field")
+			}
+		})
+	}
+}
+
+func TestSplitReasoning(t *testing.T) {
+	for _, tt := range []struct{ in, reason, rest string }{
+		{"<think>a</think>b", "a", "b"},
+		{"no block here", "", "no block here"},
+		// Cut short mid-block: it is all reasoning, and saying so beats
+		// presenting half a thought as the answer.
+		{"<think>unfinished", "unfinished", ""},
+		{"lead <think>a</think> tail", "a", "lead  tail"},
+	} {
+		reason, rest := splitReasoning(tt.in, "<think>", "</think>")
+		if reason != tt.reason || rest != tt.rest {
+			t.Errorf("splitReasoning(%q) = (%q, %q), want (%q, %q)", tt.in, reason, rest, tt.reason, tt.rest)
+		}
+	}
+}
+
+// Reasoning never goes back into the prompt: the model's own template
+// drops it from history.
+func TestRenderDropsReasoningFromHistory(t *testing.T) {
+	got := render(thinkingTmpl(), []chatMessage{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "<think>pondering</think>hello"},
+		{Role: "user", Content: "again"},
+	}, "sys", nil)
+	if strings.Contains(got, "pondering") || strings.Contains(got, "<think>") {
+		t.Errorf("replayed history carried the thinking back in:\n%s", got)
+	}
+	if !strings.Contains(got, "hello") {
+		t.Errorf("the answer was dropped along with the thinking:\n%s", got)
+	}
+}


### PR DESCRIPTION
A model run with -think wrote its reasoning into the reply: the whole <think> block arrived as content, so a client showed the model working through the question as if that were the answer. The block now comes back as reasoning_content, streaming as deltas of its own, which is the field clients already read and what llama.cpp puts it in. Markers are matched across token boundaries, holding back only a tail that could still grow into the one being awaited, so no fragment reaches either field. A turn cut short mid-block is all reasoning rather than half a thought presented as an answer. Replayed history keeps the answer and drops the thinking, as the model's own template does, so a client echoing a whole turn back cannot teach it that reasoning belongs in the reply. Families are marked by their template: qwen3 and smollm3 under -think, and the DeepSeek distills, which open the block themselves. Tested end to end against a scripted model that splits the markers across tokens, and confirmed with Qwen3 driving the yagi agent, which now renders the thinking in its own channel.