### PR TITLE
Fuse the QKV projection behind a tensor view

### DIFF
--- a/gpu/slicecols_test.go
+++ b/gpu/slicecols_test.go
@@ -1,0 +1,53 @@
+//go:build (wgpu && !wgpu24 && (linux || darwin || windows)) || (wgpu24 && (linux || darwin || windows))
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/mattn/tensai"
+)
+
+// SliceCols must lift exactly the window asked for out of every row, and
+// refuse the shapes it cannot describe.
+func TestSliceCols(t *testing.T) {
+	g := openTestGPU(t)
+	rows, stride := 5, 12
+	data := make([]float32, rows*stride)
+	for i := range data {
+		data[i] = float32(i)
+	}
+	src, err := g.Upload(&tensai.Tensor{Shape: []int{rows, stride}, Data: data})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Free()
+
+	for _, tt := range []struct{ off, cols int }{{0, 4}, {4, 3}, {7, 5}, {0, 12}, {11, 1}} {
+		got, err := src.SliceCols(tt.off, tt.cols)
+		if err != nil {
+			t.Fatalf("SliceCols(%d,%d): %v", tt.off, tt.cols, err)
+		}
+		out, err := got.Download()
+		got.Free()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s := out.Shape; len(s) != 2 || s[0] != rows || s[1] != tt.cols {
+			t.Fatalf("SliceCols(%d,%d) shape %v", tt.off, tt.cols, s)
+		}
+		for r := 0; r < rows; r++ {
+			for c := 0; c < tt.cols; c++ {
+				want := float32(r*stride + tt.off + c)
+				if v := out.Data[r*tt.cols+c]; v != want {
+					t.Fatalf("SliceCols(%d,%d)[%d,%d] = %v, want %v", tt.off, tt.cols, r, c, v, want)
+				}
+			}
+		}
+	}
+	for _, tt := range []struct{ off, cols int }{{0, 13}, {10, 3}, {-1, 2}, {0, 0}} {
+		if _, err := src.SliceCols(tt.off, tt.cols); err == nil {
+			t.Errorf("SliceCols(%d,%d) was accepted", tt.off, tt.cols)
+		}
+	}
+}

--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -85,6 +85,9 @@ func (t *Tensor) Download() (*tensai.Tensor, error) { return nil, errNoWGPU }
 // Free is a no-op in builds without the wgpu tag.
 func (t *Tensor) Free() {}
 
+// View always fails in builds without the wgpu tag.
+func (t *Tensor) View(off int, shape ...int) (*Tensor, error) { return nil, errNoWGPU }
+
 // Shape returns nil in builds without the wgpu tag.
 func (t *Tensor) Shape() []int { return nil }
 

--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -88,6 +88,9 @@ func (t *Tensor) Free() {}
 // View always fails in builds without the wgpu tag.
 func (t *Tensor) View(off int, shape ...int) (*Tensor, error) { return nil, errNoWGPU }
 
+// SliceCols fails without a GPU build.
+func (t *Tensor) SliceCols(off, cols int) (*Tensor, error) { return nil, errNoWGPU }
+
 // Shape returns nil in builds without the wgpu tag.
 func (t *Tensor) Shape() []int { return nil }
 

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -1795,6 +1795,7 @@ type bgKey struct {
 	e      [8]struct {
 		binding uint32
 		buf     uintptr
+		off     uint64
 		size    uint64
 	}
 }
@@ -1813,6 +1814,7 @@ func (g *Device) cachedBindGroup(layout uintptr, entries []wgpuBindGroupEntry) u
 	for i, e := range entries {
 		key.e[i].binding = e.binding
 		key.e[i].buf = e.buffer
+		key.e[i].off = e.offset
 		key.e[i].size = e.size
 	}
 	if bg, ok := g.bgCache[key]; ok {
@@ -1857,6 +1859,53 @@ type Tensor struct {
 	shape []int
 	freed bool
 	f16   bool // half-precision storage (KV caches); most kernels want f32
+	// off is a byte offset into buf. Non-zero only for a View, which
+	// borrows a window of another tensor's buffer rather than owning one;
+	// every kernel reaches its operand through bind/bindN, so the offset
+	// applies uniformly and no call site can forget it.
+	off  uint64
+	view bool
+}
+
+// bind builds a bind-group entry covering the whole of t, and bindN one
+// covering the first n bytes. Every kernel binds its tensor operands
+// through these two so a View's offset is applied in one place instead of
+// at two dozen call sites.
+func bind(binding uint32, t *Tensor) wgpuBindGroupEntry {
+	return bindN(binding, t, t.byteLen())
+}
+
+func bindN(binding uint32, t *Tensor, bytes uint64) wgpuBindGroupEntry {
+	return wgpuBindGroupEntry{binding: binding, buffer: t.buf, offset: t.off, size: bytes}
+}
+
+// View borrows a window of t's buffer as a tensor of its own: the fused
+// QKV projection lands in one buffer and q, k, and v are read back out of
+// it without a copy. The offset must be 256-byte aligned, which every
+// WebGPU device accepts as a storage-buffer binding offset. A view does
+// not own the buffer -- Free on it is a no-op, and it must not outlive
+// the tensor it borrows from.
+func (t *Tensor) View(off int, shape ...int) (*Tensor, error) {
+	if t.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if t.f16 {
+		return nil, errors.New("tensai: cannot view a half-precision tensor")
+	}
+	n := dims.Prod(shape)
+	if off < 0 || n <= 0 || off+n > t.Size() {
+		return nil, fmt.Errorf("tensai: view of %d elements at %d overflows %d", n, off, t.Size())
+	}
+	if (uint64(off)*4)%256 != 0 {
+		return nil, fmt.Errorf("tensai: view offset %d is not 256-byte aligned", off)
+	}
+	return &Tensor{
+		g:     t.g,
+		buf:   t.buf,
+		shape: append([]int(nil), shape...),
+		off:   t.off + uint64(off)*4,
+		view:  true,
+	}, nil
 }
 
 // byteLen is the tensor's buffer size, which the pool keys on.
@@ -2023,7 +2072,7 @@ func (t *Tensor) Download() (*tensai.Tensor, error) {
 	}()
 
 	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
-	fnEncoderCopyBuffer(encoder, t.buf, 0, staging, 0, bytes)
+	fnEncoderCopyBuffer(encoder, t.buf, t.off, staging, 0, bytes)
 	cmd := fnEncoderFinish(encoder, nil)
 	fnCmdEncoderRelease(encoder)
 	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
@@ -2076,7 +2125,7 @@ func (t *Tensor) DownloadRange(off, n int) (*tensai.Tensor, error) {
 		}
 	}()
 	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
-	fnEncoderCopyBuffer(encoder, t.buf, uint64(off)*4, staging, 0, bytes)
+	fnEncoderCopyBuffer(encoder, t.buf, t.off+uint64(off)*4, staging, 0, bytes)
 	cmd := fnEncoderFinish(encoder, nil)
 	fnCmdEncoderRelease(encoder)
 	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
@@ -2101,6 +2150,9 @@ func (t *Tensor) Free() {
 		return
 	}
 	t.freed = true
+	if t.view { // borrowed, not owned: the owner still holds the buffer
+		return
+	}
 	t.g.putBuffer(gpuTensorUsage, t.byteLen(), t.buf)
 }
 
@@ -2231,8 +2283,8 @@ func (g *Device) stridedMatMul(a, b *Tensor, outShape []int, transB bool, m, k, 
 	}
 	entries := [5]wgpuBindGroupEntry{
 		{binding: 0, buffer: bufParams, size: 32},
-		{binding: 1, buffer: a.buf, size: uint64(a.Size()) * 4},
-		{binding: 2, buffer: b.buf, size: uint64(b.Size()) * 4},
+		bind(1, a),
+		bind(2, b),
 		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
 		{binding: 4, buffer: bufOut, size: outBytes},
 	}
@@ -2281,7 +2333,7 @@ func (t *Tensor) Scale(s tensai.Float) error {
 
 	entries := [2]wgpuBindGroupEntry{
 		{binding: 5, buffer: bufParams, size: 16},
-		{binding: 6, buffer: t.buf, size: uint64(count) * 4},
+		bindN(6, t, uint64(count)*4),
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.layScale, entries[:])
 	runtime.KeepAlive(&entries)
@@ -2327,7 +2379,7 @@ func (t *Tensor) softmax(qmod, off int) (*Tensor, error) {
 
 	entries := [3]wgpuBindGroupEntry{
 		{binding: 7, buffer: bufParams, size: 16},
-		{binding: 8, buffer: t.buf, size: bytes},
+		bindN(8, t, bytes),
 		{binding: 9, buffer: bufOut, size: bytes},
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.laySoftmax, entries[:])
@@ -2528,9 +2580,9 @@ func (q *Tensor) fusedCausalMHA(k, v *Tensor, heads, batch, seq, seqKV, d, dh, b
 	entries := [6]wgpuBindGroupEntry{
 		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
 		{binding: 10, buffer: bufParams, size: 32},
-		{binding: 11, buffer: q.buf, size: uint64(q.Size()) * 4},
-		{binding: 12, buffer: k.buf, size: uint64(k.Size()) * 4},
-		{binding: 13, buffer: v.buf, size: uint64(v.Size()) * 4},
+		bind(11, q),
+		bind(12, k),
+		bind(13, v),
 		{binding: 14, buffer: bufOut, size: outBytes},
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.layAttn, entries[:])
@@ -2718,7 +2770,7 @@ func (q *QMatrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) {
 		{binding: 15, buffer: bufParams, size: 32},
 		{binding: 16, buffer: q.buf, size: uint64(q.rows*q.words) * 4},
 		{binding: 17, buffer: q.scales, size: uint64(q.words*4) * 4},
-		{binding: 18, buffer: x.buf, size: uint64(x.Size()) * 4},
+		bind(18, x),
 		{binding: 19, buffer: bufOut, size: outBytes},
 		{binding: 34, buffer: biasBuf, size: biasSize},
 	}
@@ -2795,7 +2847,7 @@ func (q *QMatrix) matmulIntDot(x, bias, dst *Tensor, m int, outShape []int) (*Te
 
 	qe := [4]wgpuBindGroupEntry{
 		{binding: 0, buffer: bufParams, size: 32},
-		{binding: 1, buffer: x.buf, size: uint64(x.Size()) * 4},
+		bind(1, x),
 		{binding: 2, buffer: bufPA, size: paBytes},
 		{binding: 3, buffer: bufAS, size: uint64(m) * 4},
 	}
@@ -2864,8 +2916,8 @@ func (t *Tensor) RMSNorm(w *Tensor, eps float64) (*Tensor, error) {
 
 	entries := [4]wgpuBindGroupEntry{
 		{binding: 20, buffer: bufParams, size: 16},
-		{binding: 21, buffer: t.buf, size: uint64(t.Size()) * 4},
-		{binding: 22, buffer: w.buf, size: uint64(w.Size()) * 4},
+		bind(21, t),
+		bind(22, w),
 		{binding: 23, buffer: bufOut, size: uint64(t.Size()) * 4},
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.layRmsnorm, entries[:])
@@ -2910,8 +2962,8 @@ func (t *Tensor) RMSNormEach(w *Tensor, eps float64) (*Tensor, error) {
 
 	entries := [4]wgpuBindGroupEntry{
 		{binding: 20, buffer: bufParams, size: 16},
-		{binding: 21, buffer: t.buf, size: uint64(t.Size()) * 4},
-		{binding: 22, buffer: w.buf, size: uint64(n) * 4},
+		bind(21, t),
+		bindN(22, w, uint64(n)*4),
 		{binding: 23, buffer: bufOut, size: uint64(t.Size()) * 4},
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.layRmsnorm, entries[:])
@@ -2964,7 +3016,7 @@ func (t *Tensor) RoPE(headSz, pos0 int, theta float64) error {
 
 	entries := [2]wgpuBindGroupEntry{
 		{binding: 24, buffer: bufParams, size: 32},
-		{binding: 25, buffer: t.buf, size: uint64(t.Size()) * 4},
+		bind(25, t),
 	}
 	bindGroup := g.cachedBindGroup(g.pipes.layRope, entries[:])
 	runtime.KeepAlive(&entries)
@@ -3003,8 +3055,8 @@ func (t *Tensor) eltwiseIP(pipe, lay uintptr, o *Tensor) error {
 
 	entries := [3]wgpuBindGroupEntry{
 		{binding: 26, buffer: bufParams, size: 16},
-		{binding: 27, buffer: t.buf, size: uint64(t.Size()) * 4},
-		{binding: 28, buffer: o.buf, size: uint64(o.Size()) * 4},
+		bind(27, t),
+		bind(28, o),
 	}
 	bindGroup := g.cachedBindGroup(lay, entries[:])
 	runtime.KeepAlive(&entries)
@@ -3063,8 +3115,8 @@ func (t *Tensor) CopyRowsInto(dst *Tensor, off int) error {
 		fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
 		entries := [3]wgpuBindGroupEntry{
 			{binding: 20, buffer: bufParams, size: 16},
-			{binding: 21, buffer: t.buf, size: uint64(n) * 4},
-			{binding: 22, buffer: dst.buf, size: dst.byteLen()},
+			bindN(21, t, uint64(n)*4),
+			bind(22, dst),
 		}
 		bindGroup := g.cachedBindGroup(g.pipes.layRowsToF16, entries[:])
 		runtime.KeepAlive(&entries)
@@ -3078,11 +3130,11 @@ func (t *Tensor) CopyRowsInto(dst *Tensor, off int) error {
 	}
 	if g.batchEnc != 0 {
 		g.endBatchPass()
-		fnEncoderCopyBuffer(g.batchEnc, t.buf, 0, dst.buf, uint64(off)*4, uint64(t.Size())*4)
+		fnEncoderCopyBuffer(g.batchEnc, t.buf, t.off, dst.buf, dst.off+uint64(off)*4, uint64(t.Size())*4)
 		return nil
 	}
 	encoder := fnDeviceCreateCmdEncoder(g.device, nil)
-	fnEncoderCopyBuffer(encoder, t.buf, 0, dst.buf, uint64(off)*4, uint64(t.Size())*4)
+	fnEncoderCopyBuffer(encoder, t.buf, t.off, dst.buf, dst.off+uint64(off)*4, uint64(t.Size())*4)
 	cmd := fnEncoderFinish(encoder, nil)
 	fnCmdEncoderRelease(encoder)
 	fnQueueSubmit(g.queue, 1, unsafe.Pointer(&cmd))
@@ -3183,9 +3235,9 @@ func (q *Tensor) GroupedCausalAttention(k, v *Tensor, heads, kvHeads, seqKV, win
 	entries := [6]wgpuBindGroupEntry{
 		{binding: 3, buffer: bufOffs, size: uint64(len(offs)) * 4},
 		{binding: 10, buffer: bufParams, size: 32},
-		{binding: 11, buffer: q.buf, size: uint64(q.Size()) * 4},
-		{binding: 12, buffer: k.buf, size: k.byteLen()},
-		{binding: 13, buffer: v.buf, size: v.byteLen()},
+		bind(11, q),
+		bind(12, k),
+		bind(13, v),
 		{binding: 14, buffer: bufOut, size: outBytes},
 	}
 	pipe, lay := g.pipes.attn, g.pipes.layAttn
@@ -3372,7 +3424,7 @@ func (q *Q4Matrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) {
 		{binding: 29, buffer: bufParams, size: 32},
 		{binding: 30, buffer: q.buf, size: uint64(pairs*q.words) * 4},
 		{binding: 31, buffer: q.scales, size: uint64(groups*q.words*4) * 4},
-		{binding: 32, buffer: x.buf, size: uint64(x.Size()) * 4},
+		bind(32, x),
 		{binding: 33, buffer: bufOut, size: outBytes},
 		{binding: 35, buffer: biasBuf, size: biasSize},
 	}

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -946,6 +946,27 @@ fn silu_mul_ip(@builtin(workgroup_id) wg: vec3<u32>,
     }
 }
 
+// slice_cols lifts a column window out of every row. The fused QKV
+// projection lands in one buffer and prefill wants q, k, and v as
+// tensors of their own; a bind offset cannot express that, because the
+// window repeats once per row rather than sitting at one place in the
+// buffer.
+struct SliceParams { rows: u32, cols: u32, stride: u32, off: u32 }
+@group(0) @binding(36) var<uniform> slp: SliceParams;
+@group(0) @binding(37) var<storage, read> slsrc: array<f32>;
+@group(0) @binding(38) var<storage, read_write> sldst: array<f32>;
+
+@compute @workgroup_size(256, 1, 1)
+fn slice_cols(@builtin(workgroup_id) wg: vec3<u32>,
+              @builtin(num_workgroups) nwg: vec3<u32>,
+              @builtin(local_invocation_id) lid: vec3<u32>) {
+    let idx = (wg.y * nwg.x + wg.x) * 256u + lid.x;
+    if (idx < slp.rows * slp.cols) {
+        let r = idx / slp.cols;
+        sldst[idx] = slsrc[r * slp.stride + slp.off + (idx - r * slp.cols)];
+    }
+}
+
 // gelu_mul_ip: dst = gelu_tanh(dst) * src — Gemma's gate.
 @compute @workgroup_size(256, 1, 1)
 fn gelu_mul_ip(@builtin(workgroup_id) wg: vec3<u32>,
@@ -1429,6 +1450,7 @@ type gpuPipelines struct {
 	rmsnorm, rope, addIP, siluMulIP, q4matmul      uintptr
 	geluMulIP, qmatmulB, attnG, qmatmulT           uintptr
 	qacts, qmatmulI, attnF16, rowsToF16            uintptr
+	sliceCols, laySliceCols                        uintptr
 	layMatmul, layMatmulT, layMatmulS, layMatmulTS uintptr
 	layScale, laySoftmax, layAttn, layQmatmul      uintptr
 	layRmsnorm, layRope, layAddIP, laySiluMulIP    uintptr
@@ -1461,6 +1483,7 @@ func (g *Device) initPipelines() error {
 		{&g.pipes.qmatmulB, &g.pipes.layQmatmulB, "qmatmul_b"},
 		{&g.pipes.attnG, &g.pipes.layAttnG, "attn_causal_g"},
 		{&g.pipes.qmatmulT, &g.pipes.layQmatmulT, "qmatmul_t"},
+		{&g.pipes.sliceCols, &g.pipes.laySliceCols, "slice_cols"},
 	} {
 		*x.pipe = g.makePipeline(x.entry)
 		if *x.pipe == 0 || uncapturedCB != "" {
@@ -1540,7 +1563,7 @@ func (g *Device) releasePipelines() {
 		g.pipes.qmatmul, g.pipes.rmsnorm, g.pipes.rope,
 		g.pipes.addIP, g.pipes.siluMulIP, g.pipes.q4matmul,
 		g.pipes.geluMulIP, g.pipes.qmatmulB, g.pipes.attnG,
-		g.pipes.qmatmulT, g.pipes.qacts, g.pipes.qmatmulI,
+		g.pipes.qmatmulT, g.pipes.sliceCols, g.pipes.qacts, g.pipes.qmatmulI,
 		g.pipes.attnF16, g.pipes.rowsToF16,
 	} {
 		if h != 0 {
@@ -1906,6 +1929,64 @@ func (t *Tensor) View(off int, shape ...int) (*Tensor, error) {
 		off:   t.off + uint64(off)*4,
 		view:  true,
 	}, nil
+}
+
+// SliceCols lifts a column window out of every row into a tensor of its
+// own: t is [rows, stride] and the result [rows, cols] holding columns
+// [off, off+cols). View covers the case where the window is one
+// contiguous run of the buffer; this is the case where it repeats per
+// row, which no binding offset can describe, so it costs a copy.
+func (t *Tensor) SliceCols(off, cols int) (*Tensor, error) {
+	if t.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	n := len(t.shape)
+	if n < 2 {
+		return nil, errors.New("tensai: gpu slice needs at least 2 axes")
+	}
+	stride := t.shape[n-1]
+	if off < 0 || cols <= 0 || off+cols > stride {
+		return nil, fmt.Errorf("tensai: slice of %d columns at %d overflows %d", cols, off, stride)
+	}
+	if t.f16 {
+		return nil, errors.New("tensai: cannot slice a half-precision tensor")
+	}
+	rows := t.Size() / stride
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	outBytes := uint64(rows*cols) * 4
+	if err := g.checkSize(outBytes); err != nil {
+		return nil, err
+	}
+	params := [4]uint32{uint32(rows), uint32(cols), uint32(stride), uint32(off)}
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+	bufOut := g.takeOutBuffer(outBytes)
+
+	entries := [3]wgpuBindGroupEntry{
+		{binding: 36, buffer: bufParams, size: 16},
+		bind(37, t),
+		{binding: 38, buffer: bufOut, size: outBytes},
+	}
+	bindGroup := g.cachedBindGroup(g.pipes.laySliceCols, entries[:])
+	runtime.KeepAlive(&entries)
+
+	x, y := split2D((rows*cols + 255) / 256)
+	if err := g.dispatch(g.pipes.sliceCols, bindGroup, x, y, 1); err != nil {
+		g.dropBuffer(bufOut)
+		return nil, err
+	}
+	shape := append(append([]int(nil), t.shape[:n-1]...), cols)
+	return &Tensor{g: g, buf: bufOut, shape: shape}, nil
 }
 
 // byteLen is the tensor's buffer size, which the pool keys on.

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -200,8 +200,7 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 		if fuseQKV {
 			l.qQKV = up(b.qQKV)
 			l.bQKV = vec(b.bQKV)
-		}
-		{
+		} else {
 			l.bq = vec(vecRange(b.bQKV, 0, hs))
 			l.bk = vec(vecRange(b.bQKV, hs, hs+kvDim))
 			l.bv = vec(vecRange(b.bQKV, hs+kvDim, hs+2*kvDim))
@@ -267,6 +266,26 @@ func (gq *gpuQwen) qkv(l *gpuLayer, a *gpu.Tensor) (q, k, v, owner *gpu.Tensor) 
 		must(f.View(hs+kvDim, 1, kvDim)), f
 }
 
+// qkvRows is qkv for a batch of token rows. The fused result is
+// [rows, hs+2*kvDim] with q, k, and v side by side inside every row, so
+// no contiguous view covers one of them and each is copied out instead.
+// That copy is what lets the fused weight serve prefill as well, which
+// is what keeps the split weights off the device entirely.
+func (gq *gpuQwen) qkvRows(l *gpuLayer, a *gpu.Tensor) (q, k, v *gpu.Tensor) {
+	if l.qQKV == nil {
+		return must(l.qq.MatMulOpts(a, l.bq, nil)),
+			must(l.qk.MatMulOpts(a, l.bk, nil)),
+			must(l.qv.MatMulOpts(a, l.bv, nil))
+	}
+	hs := gq.m.cfg.Heads * gq.m.headSz
+	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
+	f := must(l.qQKV.MatMulOpts(a, l.bQKV, nil))
+	defer f.Free()
+	return must(f.SliceCols(0, hs)),
+		must(f.SliceCols(hs, kvDim)),
+		must(f.SliceCols(hs+kvDim, kvDim))
+}
+
 // prefill feeds a batch of tokens through the GPU-resident blocks — the
 // batched twins of every decode op (row-batched RMSNorm and RoPE, the
 // multi-row quantized matmuls, causal attention with the queries aligned
@@ -319,9 +338,7 @@ func (gq *gpuQwen) prefillChunk(tokens []int, startPos int) []float32 {
 	for i := range gq.layers {
 		l := &gq.layers[i]
 		a := must(x.RMSNorm(l.ln1, cfg.RMSEps))
-		q := must(l.qq.MatMulOpts(a, l.bq, nil))
-		k := must(l.qk.MatMulOpts(a, l.bk, nil))
-		v := must(l.qv.MatMulOpts(a, l.bv, nil))
+		q, k, v := gq.qkvRows(l, a)
 		a.Free()
 		if l.qNorm != nil {
 			nq := must(q.RMSNormEach(l.qNorm, cfg.RMSEps))

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -36,6 +36,8 @@ type gpuLayer struct {
 	ropeTheta                         float64
 	geglu                             bool
 	bq, bk, bv                        *gpu.Tensor
+	bQKV                              *gpu.Tensor // fused q|k|v bias, when the split aligns
+	qQKV                              gpuMat      // fused q|k|v projection; nil when split
 	qq, qk, qv, qo, qGate, qUp, qDown gpuMat
 	kc, vc                            *gpu.Tensor // [nCtx, kvDim]
 }
@@ -158,6 +160,9 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 	// has shader-f16 and the model's head grouping fits the f16 kernel.
 	group := m.cfg.Heads / m.cfg.KVHeads
 	useF16 := g.HasF16() && group > 1 && group <= 8 && m.headSz <= 256
+	// A view onto the fused result needs a 256-byte aligned offset, so
+	// both the q and the q|k boundary have to sit on 64 floats.
+	fuseQKV := hs%64 == 0 && kvDim%64 == 0
 	// upSlice uploads a column range of a fused weight in whichever width
 	// it was quantized to; up uploads a whole one.
 	upSlice := func(q *qmat, lo, hi int) gpuMat {
@@ -185,12 +190,25 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 		l.ln1, l.ln2 = vec(b.ln1), vec(b.ln2)
 		l.qNorm, l.kNorm = vec(b.qNorm), vec(b.kNorm)
 		l.postAttn, l.postFFN = vec(b.postAttn), vec(b.postFFN)
-		l.bq = vec(vecRange(b.bQKV, 0, hs))
-		l.bk = vec(vecRange(b.bQKV, hs, hs+kvDim))
-		l.bv = vec(vecRange(b.bQKV, hs+kvDim, hs+2*kvDim))
-		l.qq = upSlice(b.qQKV, 0, hs)
-		l.qk = upSlice(b.qQKV, hs, hs+kvDim)
-		l.qv = upSlice(b.qQKV, hs+kvDim, hs+2*kvDim)
+		// q, k, and v come out of one weight the loader already fused.
+		// Splitting it costs two extra dispatches over matrices narrow
+		// enough to leave the GPU idle -- measured on a Radeon 780M, the
+		// three-way split runs the projection at 24.3 GB/s against 37.4
+		// for the single fused dispatch. Keep it whole where the views
+		// that carve q, k, and v back out of the result are legal, and
+		// fall back to the split when they are not.
+		if fuseQKV {
+			l.qQKV = up(b.qQKV)
+			l.bQKV = vec(b.bQKV)
+		}
+		{
+			l.bq = vec(vecRange(b.bQKV, 0, hs))
+			l.bk = vec(vecRange(b.bQKV, hs, hs+kvDim))
+			l.bv = vec(vecRange(b.bQKV, hs+kvDim, hs+2*kvDim))
+			l.qq = upSlice(b.qQKV, 0, hs)
+			l.qk = upSlice(b.qQKV, hs, hs+kvDim)
+			l.qv = upSlice(b.qQKV, hs+kvDim, hs+2*kvDim)
+		}
 		l.qo = up(b.qo)
 		l.qGate = upSlice(b.qGU, 0, inter)
 		l.qUp = upSlice(b.qGU, inter, 2*inter)
@@ -227,6 +245,26 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 	gq.step(0, 37)
 	gq.gpuLen = 0
 	return gq, nil
+}
+
+// qkv projects one row into q, k, and v. The fused weight does it in a
+// single dispatch and hands back three views onto the result, so the
+// caller frees the returned owner once and the views not at all; without
+// it the three split weights each produce their own tensor and owner is
+// nil. Only decode can take the fused path: a multi-row result interleaves
+// q, k, and v per row, and no contiguous view covers that.
+func (gq *gpuQwen) qkv(l *gpuLayer, a *gpu.Tensor) (q, k, v, owner *gpu.Tensor) {
+	if l.qQKV == nil {
+		return must(l.qq.MatMulOpts(a, l.bq, nil)),
+			must(l.qk.MatMulOpts(a, l.bk, nil)),
+			must(l.qv.MatMulOpts(a, l.bv, nil)), nil
+	}
+	hs := gq.m.cfg.Heads * gq.m.headSz
+	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
+	f := must(l.qQKV.MatMulOpts(a, l.bQKV, nil))
+	return must(f.View(0, 1, hs)),
+		must(f.View(hs, 1, kvDim)),
+		must(f.View(hs+kvDim, 1, kvDim)), f
 }
 
 // prefill feeds a batch of tokens through the GPU-resident blocks — the
@@ -387,9 +425,7 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 	for i := range gq.layers {
 		l := &gq.layers[i]
 		a := must(x.RMSNorm(l.ln1, cfg.RMSEps))
-		q := must(l.qq.MatMulOpts(a, l.bq, nil))
-		k := must(l.qk.MatMulOpts(a, l.bk, nil))
-		v := must(l.qv.MatMulOpts(a, l.bv, nil))
+		q, k, v, qkvOwner := gq.qkv(l, a)
 		a.Free()
 		if l.qNorm != nil {
 			nq := must(q.RMSNormEach(l.qNorm, cfg.RMSEps))
@@ -424,6 +460,9 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 		}
 		attn := must(q.GroupedCausalAttention(l.kc, l.vc, cfg.Heads, cfg.KVHeads, pos+1, l.window))
 		q.Free()
+		if qkvOwner != nil { // the buffer q, k, and v were views onto
+			qkvOwner.Free()
+		}
 		// The residual add rides the projection's epilogue unless a
 		// sandwich norm (Gemma) has to run in between.
 		if l.postAttn == nil {


### PR DESCRIPTION
Splitting the fused q|k|v weight the loader already builds cost two extra dispatches over matrices narrow enough to leave the GPU idle. Tensor gains a byte offset into its buffer and a View that borrows a window of one, so decode runs the projection as a single dispatch and q, k and v come back out of the result without a copy. Prefill cannot use a view -- its multi-row result puts q, k and v side by side inside every row -- so a slice_cols kernel lifts each window out instead, which is what lets the fused weight serve both paths and keeps the split weights off the device entirely. Every kernel binds its tensor operands through bind/bindN, which is what makes the offset apply uniformly rather than at two dozen call sites. Measured on a Radeon 780M through dozen on Qwen3-0.6B, interleaved against main: decode 20.55 to 21.41 tok/s over eight pairs, four percent, paired t of 3.4; prefill is unchanged within noise, and peak RSS drops 76MB because the three column slices the loader used to stage on the CPU are gone. Output matches main token for token. One real bug fixed on the way: the bind-group cache keyed on binding, buffer and size but not the offset, so two windows of one buffer would have collided and handed a kernel the wrong range -- latent today because nothing else binds at an offset, a trap for whoever adds the next one.