### PR TITLE
Release both bindings, and name the Windows binary .exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,18 @@
 # library. See docs/guide/gpu.md.
 WGPU ?= wgpu24
 BIN := tensai
+# Windows will not run a file without the extension, so the local build
+# carries it; BIN itself stays bare because it also names the release
+# archives, which are cross-built from Linux.
+ifeq ($(OS),Windows_NT)
+EXE := .exe
+RM_F := del /q
+RM_RF := rmdir /s /q
+else
+EXE :=
+RM_F := rm -f
+RM_RF := rm -rf
+endif
 VERSION := $$(make -s show-version)
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 BUILD_LDFLAGS := "-s -w -X main.revision=$(CURRENT_REVISION)"
@@ -18,7 +30,7 @@ all: clean build
 
 .PHONY: build
 build:
-	go build -tags $(WGPU) -ldflags=$(BUILD_LDFLAGS) -o $(BIN) ./cmd/tensai
+	go build -tags $(WGPU) -ldflags=$(BUILD_LDFLAGS) -o $(BIN)$(EXE) ./cmd/tensai
 
 .PHONY: install
 install:
@@ -32,9 +44,18 @@ $(GOBIN)/gobump:
 	go install github.com/x-motemen/gobump/cmd/gobump@latest
 
 .PHONY: cross
+# Both bindings ship: tensai_* is the wgpu24 build, which wants a
+# v29-series libwgpu_native, and tensai-wgpu22_* the v22 one. Neither
+# archive carries the library, so a driver that disagrees with one of them
+# would otherwise leave a user with no binary and a Go toolchain to
+# install. The binary inside is called tensai either way.
 cross: $(GOBIN)/goxz
 	goxz -n $(BIN) -pv=v$(VERSION) -os linux,darwin,windows -arch amd64,arm64 \
-		-build-tags $(WGPU) -build-ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
+		-build-tags wgpu24 -build-ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
+	goxz -n $(BIN)-wgpu22 -o $(BIN) -pv=v$(VERSION) -os linux,darwin -arch amd64,arm64 \
+		-build-tags wgpu -build-ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
+	goxz -n $(BIN)-wgpu22 -o $(BIN).exe -pv=v$(VERSION) -os windows -arch amd64,arm64 \
+		-build-tags wgpu -build-ldflags=$(BUILD_LDFLAGS) ./cmd/tensai
 
 $(GOBIN)/goxz:
 	go install github.com/Songmu/goxz/cmd/goxz@latest
@@ -45,7 +66,8 @@ test:
 
 .PHONY: clean
 clean:
-	rm -rf $(BIN) goxz
+	-$(RM_F) $(BIN)$(EXE)
+	-$(RM_RF) goxz
 	go clean
 
 .PHONY: bump

--- a/docs/guide/gpu.ja.md
+++ b/docs/guide/gpu.ja.md
@@ -121,3 +121,6 @@ make build WGPU=wgpu    # v22 の束縛
 `install` と `cross` も同じ変数を見ます。バイナリとライブラリは対にしてください —
 `wgpu24` ビルドには v29 系の `libwgpu_native`、`wgpu` ビルドには v22 が要ります。
 バイナリの隣にあるもの以外を読ませたいときは `TENSAI_WGPU_LIB` で指定します。
+リリースは両方を配っているので、片方と相性の悪いドライバに当たっても Go を
+入れ直す必要はありません — `tensai_*` が `wgpu24` ビルド、`tensai-wgpu22_*` が
+もう一方で、中のバイナリ名はどちらも `tensai` です。

--- a/docs/guide/gpu.md
+++ b/docs/guide/gpu.md
@@ -92,7 +92,10 @@ The crossover moves with the CPU kernel, GPU driver, and transfer pattern — th
 
 ## `-tags wgpu24`: the new wgpu-native API, and the real GPU inside WSL2
 
-`-tags wgpu24` builds the same `gpu.Open` API against the reworked wgpu-native C API — pair it with a **v29-series** release binary. The new API's payoff is `WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter`, which un-hides non-conformant Vulkan drivers. Concretely: Mesa's dozen (Vulkan-on-D3D12) exposes the real host GPU inside WSL2, but the v22 API hides it as non-conformant and falls back to lavapipe; the wgpu24 build reaches it:
+`-tags wgpu24` builds the same `gpu.Open` API against the reworked wgpu-native C API — pair it with a **v29-series** release binary. Releases carry both, so a driver that disagrees with one of them
+does not also require a Go toolchain: `tensai_*` is the `wgpu24` build and
+`tensai-wgpu22_*` the other, and the binary inside is called `tensai` either
+way. The new API's payoff is `WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter`, which un-hides non-conformant Vulkan drivers. Concretely: Mesa's dozen (Vulkan-on-D3D12) exposes the real host GPU inside WSL2, but the v22 API hides it as non-conformant and falls back to lavapipe; the wgpu24 build reaches it:
 
 ```bash
 VK_DRIVER_FILES=/path/to/dzn_icd.json \


### PR DESCRIPTION
Releases carried only the wgpu24 build, and since no archive bundles libwgpu_native the version has to be matched by hand -- so a driver that disagrees with the v29 binding left a user with no working binary and a Go toolchain to install first. Both now ship: tensai_* is the wgpu24 build and tensai-wgpu22_* the v22 one, with the binary inside called tensai either way. goxz names a Windows binary .exe on its own but stops doing so once -o renames it, so the renamed build splits Windows into its own invocation rather than shipping something Windows cannot execute. The local build gets the same treatment through an EXE suffix that is empty everywhere else, and clean now uses commands that exist on the host it runs on, since rm failing on cmd.exe stopped make before it reached build and left the previous binary in place looking freshly built. Verified by cross-building all twelve archives and checking that every Windows one holds tensai.exe; the Windows branch of the conditional is the part this machine cannot exercise.