### PR TITLE
Speak o200k's own spelling of its split pattern

### DIFF
--- a/tokenizer/o200k_canonical_test.go
+++ b/tokenizer/o200k_canonical_test.go
@@ -1,0 +1,139 @@
+package tokenizer
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// o200k's split, as tiktoken and the Hugging Face tokenizer.json spell it:
+//
+//	[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?
+//	|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?
+//	|\p{N}{1,3}
+//	| ?[^\s\p{L}\p{N}]+[\r\n/]*
+//	|\s*[\r\n]+
+//	|\s+(?!\S)
+//	|\s+
+//
+// Every alternative but the last two is a plain RE2 expression, so the
+// reference below runs them with regexp and hand-rolls only the two
+// whitespace ones, whose (?!\S) RE2 cannot express. That gives the
+// hand-written scanner something independent to be checked against --
+// the Python reference in verify_hf.py needs a network and a pip
+// install, and this does not.
+var canonicalAlts = []*regexp.Regexp{
+	regexp.MustCompile(`^[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?`),
+	regexp.MustCompile(`^[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?`),
+	regexp.MustCompile(`^\p{N}{1,3}`),
+	regexp.MustCompile(`^ ?[^\s\p{L}\p{N}]+[\r\n/]*`),
+	regexp.MustCompile(`^\s*[\r\n]+`),
+}
+
+func canonicalSplit(s string) []string {
+	var out []string
+	for len(s) > 0 {
+		matched := false
+		for _, re := range canonicalAlts {
+			if m := re.FindString(s); m != "" {
+				out = append(out, m)
+				s = s[len(m):]
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		// `\s+(?!\S)` then `\s+`. A greedy \s run is followed by a
+		// non-space or by end of text, so the lookahead alternative
+		// takes the run minus its last rune when something follows, and
+		// the whole run at the end; the bare \s+ then takes whatever is
+		// left.
+		rs := []rune(s)
+		n := 0
+		for n < len(rs) && unicode.IsSpace(rs[n]) {
+			n++
+		}
+		if n == 0 {
+			panic("canonicalSplit: no alternative matched " + s)
+		}
+		take := n
+		if n < len(rs) && n > 1 {
+			take = n - 1
+		}
+		out = append(out, string(rs[:take]))
+		s = string(rs[take:])
+	}
+	return out
+}
+
+// corpus stresses the classes where llama.cpp's ASCII-range spelling of
+// o200k and tiktoken's category spelling disagree, alongside the cases
+// they share.
+var canonicalCorpus = []string{
+	// Scripts whose NFC form keeps combining marks -- the whole point.
+	"नमस्ते दुनिया",
+	"ที่นี่มีอะไร",
+	"עִבְרִית עם ניקוד",
+	"العربية مع تشكيل",
+	"한국어 텍스트",
+	"မြန်မာဘာသာ",
+	"ਪੰਜਾਬੀ",
+	"தமிழ் மொழி",
+	// Latin, cased and accented.
+	"Hello, I'm a language model,",
+	"camelCase HTTPResponse XMLHttpRequest",
+	"café naïve résumé Ærø",
+	"ÉCOLE Ünicode ĲSSELMEER",
+	"I'LL and I'll and it's and IT'S and won't and WON'T",
+	// Digits, punctuation, whitespace, the o200k slash tail.
+	"numbers 123 4567 89 0 12345678901234567890",
+	"punct!!! ...---??? ***(())[]{}",
+	"paths/like/this and //double// and /",
+	"  leading and   multiple   gaps  ",
+	"tabs\tand\nnewlines\r\nmixed \n\n whitespace \t\n x",
+	"trailing newline\n",
+	"\n\n\nleading newlines",
+	"   ",
+	"",
+	// Marks and symbols on their own, and mixed scripts.
+	"́standalone combining",
+	"emoji 👍🏽 and 🇯🇵 flags",
+	"日本語abc mixed 한글 and ไทย",
+	"math ∑∫√ and ©®™",
+	"áb́ć",
+}
+
+func TestO200KCanonicalSplit(t *testing.T) {
+	tok := &Tokenizer{cfg: o200kConfig}
+	for _, in := range canonicalCorpus {
+		want := canonicalSplit(in)
+		got := tok.split(in)
+		if len(want) == 0 && len(got) == 0 {
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("split(%q)\n got %q\nwant %q", in, got, want)
+		}
+		if strings.Join(got, "") != in {
+			t.Errorf("split(%q) does not reassemble: %q", in, strings.Join(got, ""))
+		}
+	}
+}
+
+// TestO200KCanonicalPatternAccepted pins that the tokenizer.json spelling
+// gpt-oss and the Hugging Face o200k models ship resolves to the o200k
+// scanner rather than being rejected.
+func TestO200KCanonicalPatternAccepted(t *testing.T) {
+	const harmony = `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+	cfg, err := classifyRegex(harmony)
+	if err != nil {
+		t.Fatalf("classifyRegex(o200k_harmony) = %v", err)
+	}
+	if cfg != o200kConfig {
+		t.Errorf("classifyRegex(o200k_harmony) = %+v, want o200kConfig", cfg)
+	}
+}

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -53,10 +53,17 @@ type splitConfig struct {
 	// is its own pre-token, so a digit never absorbs a preceding space, and
 	// whitespace running into a digit behaves as if at end of text.
 	individualDigits bool
-	// caseWords selects o200k's case-aware word alternatives: a run of
-	// uppercase-ish letters (any letter but ASCII a-z) then a run of
-	// lowercase-ish ones (any letter but ASCII A-Z), with contractions
-	// attaching as a suffix instead of splitting on their own.
+	// caseWords selects o200k's case-aware word alternatives: a run from
+	// [\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}] then one from
+	// [\p{Ll}\p{Lm}\p{Lo}\p{M}], with contractions attaching as a
+	// suffix instead of splitting on their own.
+	//
+	// llama.cpp spells these classes as "any letter but ASCII a-z" and
+	// "any letter but ASCII A-Z", which agrees for Latin and for the
+	// unicased scripts but drops \p{M}: a combining mark ends the run
+	// instead of continuing it, so "नमस्ते" splits mid-word. NFC keeps
+	// those marks in Devanagari, Thai, and Hebrew, so the categories are
+	// what the models were actually trained on and what this implements.
 	caseWords bool
 	// punctSlash admits '/' into the punctuation run's newline tail
 	// (o200k's "[\r\n/]*").
@@ -224,6 +231,11 @@ func classifyRegex(re string) (splitConfig, error) {
 		return gpt2Config, nil
 	case strings.HasPrefix(re, `[^\r\n\p{L}\p{N}]?((?=[\p{L}])([^a-z]))*`):
 		// o200k (gpt-4o and friends), in llama.cpp's lookahead spelling.
+		return o200kConfig, nil
+	case strings.HasPrefix(re, `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+`):
+		// The same split in tiktoken's own spelling, which is what the
+		// Hugging Face tokenizer.json carries for o200k_base and for
+		// gpt-oss's o200k_harmony.
 		return o200kConfig, nil
 	case strings.HasPrefix(re, `(?i:'s|'t|'re|'ve|'m|'ll|'d)`):
 		cfg := cl100kConfig
@@ -400,10 +412,10 @@ func (t *Tokenizer) split(s string) []string {
 				// then a lowercase-ish one (letters except ASCII A-Z) —
 				// the backtracking-free reading of its two alternatives —
 				// plus an optional contraction suffix.
-				for j < len(rs) && unicode.IsLetter(rs[j]) && !(rs[j] >= 'a' && rs[j] <= 'z') {
+				for j < len(rs) && isUpperWord(rs[j]) {
 					j++
 				}
-				for j < len(rs) && unicode.IsLetter(rs[j]) && !(rs[j] >= 'A' && rs[j] <= 'Z') {
+				for j < len(rs) && isLowerWord(rs[j]) {
 					j++
 				}
 				if j < len(rs) && rs[j] == '\'' {
@@ -524,6 +536,24 @@ func matchContraction(rs []rune, ci bool) int {
 	}
 	return 0
 }
+
+// o200k's word classes. \p{Lm} and \p{Lo} sit in both, so a run of
+// unicased letters can be consumed by either -- the span works out the
+// same, which is all pre-tokenization needs.
+func isUpperWord(r rune) bool {
+	return unicode.Is(unicode.Lu, r) || unicode.Is(unicode.Lt, r) || isCaselessWord(r)
+}
+
+func isLowerWord(r rune) bool {
+	return unicode.Is(unicode.Ll, r) || isCaselessWord(r)
+}
+
+func isCaselessWord(r rune) bool {
+	return unicode.Is(unicode.Lm, r) || unicode.Is(unicode.Lo, r) || unicode.Is(unicode.M, r)
+}
+
+// isWordRune reports whether r can open either alternative.
+func isWordRune(r rune) bool { return isUpperWord(r) || isLowerWord(r) }
 
 func isPunct(r rune) bool {
 	return !unicode.IsSpace(r) && !unicode.IsLetter(r) && !unicode.IsNumber(r)


### PR DESCRIPTION
Loading `openai/gpt-oss-20b` failed with `unsupported split pattern`. Its `tokenizer.json` carries o200k_harmony's split the way tiktoken writes it, in Unicode categories, while the only o200k spelling recognised here was llama.cpp's, which approximates the two letter classes as "any letter but ASCII a-z" and "any letter but ASCII A-Z".

Those are not the same classes, so this could not just be aliased onto the existing config. tiktoken's are `[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]` and `[\p{Ll}\p{Lm}\p{Lo}\p{M}]`, and the approximation drops `\p{M}` — a combining mark ends a word run instead of continuing it. NFC keeps those marks in Devanagari, Thai, and Hebrew, so the scanner was splitting नमस्ते after नमस, ที่ after ท, and עִבְרִית after its first letter. Latin, Arabic, and the CJK scripts agree under either spelling, which is why the existing tests never caught it.

The scanner therefore moves to the categories the models were actually trained on, rather than gaining a second mode. That also fixes the same mis-tokenization on the GGUF side, since llama.cpp's `gpt-4o` pre-tokenizer tag routes through this config too. `classifyRegex` then learns tiktoken's spelling alongside llama.cpp's.

For verification, every alternative of the canonical pattern except the two whitespace ones is plain RE2. The new test runs those through `regexp`, hand-rolls the `(?!\S)` pair, and diffs the hand-written scanner against that reference over a corpus of the mark-carrying scripts plus the Latin, digit, punctuation and whitespace cases — so it needs neither a network nor a `pip install`, unlike `verify_hf.py`. The real gpt-oss-20b `tokenizer.json` now loads and round-trips, Devanagari and Thai included.

This is only the tokenizer half of running gpt-oss. The safetensors loader still rejects `model_type: "gpt_oss"`, even though the architecture itself — MoE, attention sinks, sliding window — is already implemented and reachable through the GGUF path; that follows in a second PR.

https://claude.ai/code/session_01XjN5GeBQjrtyiuwd75VX45