### PR TITLE
Load gpt-oss from its published safetensors

### DIFF
--- a/encoding/safetensors/safetensors.go
+++ b/encoding/safetensors/safetensors.go
@@ -177,6 +177,8 @@ func dtypeSize(dtype string) (int64, error) {
 		return 2, nil
 	case "F64":
 		return 8, nil
+	case "U8", "I8":
+		return 1, nil
 	default:
 		return 0, fmt.Errorf("safetensors: unsupported dtype %q", dtype)
 	}
@@ -191,6 +193,13 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 	}
 	if _, err := dtypeSize(e.Dtype); err != nil {
 		return nil, fmt.Errorf("%w (tensor %q)", err, name)
+	}
+	if e.Dtype == "U8" || e.Dtype == "I8" {
+		// These carry packed payloads -- MXFP4 nibbles and their e8m0
+		// exponents -- whose meaning lives in the format that wrote them,
+		// and widening a quarter of a gigabyte of nibbles to float32 is
+		// not what any caller wants. Raw hands back the bytes instead.
+		return nil, fmt.Errorf("safetensors: tensor %q is %s; use Raw (tensor %q)", name, e.Dtype, name)
 	}
 	var buf []byte
 	if f.data != nil {
@@ -229,6 +238,32 @@ func (f *File) Tensor(name string) (*tensai.Tensor, error) {
 		}
 	}
 	return out, nil
+}
+
+// Raw returns a tensor's bytes as they sit in the file, for dtypes whose
+// payload is packed rather than numeric -- MXFP4 weights arrive as U8
+// blocks of nibbles beside U8 e8m0 scales, and expanding those to float32
+// would cost a couple of gigabytes a layer. The slice aliases the mapped
+// file when there is one, so treat it as read-only and do not retain it
+// past Close.
+func (f *File) Raw(name string) (data []byte, shape []int, err error) {
+	e, ok := f.entries[name]
+	if !ok {
+		return nil, nil, fmt.Errorf("safetensors: no tensor %q", name)
+	}
+	if f.data != nil {
+		lo, hi := f.dataOff+e.DataOffsets[0], f.dataOff+e.DataOffsets[1]
+		if hi > int64(len(f.data)) || lo < 0 || lo > hi {
+			return nil, nil, fmt.Errorf("safetensors: tensor %q extends past the file", name)
+		}
+		data = f.data[lo:hi]
+	} else {
+		data = make([]byte, e.DataOffsets[1]-e.DataOffsets[0])
+		if _, err := f.r.ReadAt(data, f.dataOff+e.DataOffsets[0]); err != nil {
+			return nil, nil, fmt.Errorf("safetensors: reading tensor %q: %w", name, err)
+		}
+	}
+	return data, append([]int(nil), e.Shape...), nil
 }
 
 // f16to32 widens an IEEE 754 binary16 value, including subnormals,
@@ -411,6 +446,15 @@ func (s *Shards) Tensor(name string) (*tensai.Tensor, error) {
 		return nil, fmt.Errorf("safetensors: no tensor %q", name)
 	}
 	return f.Tensor(name)
+}
+
+// Raw returns one tensor's packed bytes from its shard.
+func (s *Shards) Raw(name string) ([]byte, []int, error) {
+	f, ok := s.byName[name]
+	if !ok {
+		return nil, nil, fmt.Errorf("safetensors: no tensor %q", name)
+	}
+	return f.Raw(name)
 }
 
 // SaveFile writes tensors to path via Save.

--- a/internal/llm/gptoss.go
+++ b/internal/llm/gptoss.go
@@ -1,0 +1,209 @@
+package llm
+
+// gpt-oss's published checkpoint keeps its mixture-of-experts weights
+// MXFP4-packed inside the safetensors file rather than as bf16: each
+// expert projection arrives as a U8 "_blocks" tensor of nibble pairs
+// beside a U8 "_scales" tensor of e8m0 exponents, one per group of 32
+// inputs. Everything else in the block -- attention, router, norms -- is
+// ordinary bf16.
+//
+// Two things differ from the same weights seen through a GGUF, and both
+// are silent if you get them wrong, because a permuted weight still
+// produces fluent-looking nonsense:
+//
+//   - Nibble order. llama.cpp splits a 16-byte group as value i and
+//     value i+16; the reference unpacker here pairs them, low nibble to
+//     2i and high to 2i+1.
+//   - gate/up interleaving. gpt-oss reads its fused projection as
+//     gate = out[..., 0::2] and up = out[..., 1::2], while moeFFN wants
+//     them concatenated. The GGUF converter splits them into separate
+//     ffn_gate_exps/ffn_up_exps tensors, so the GGUF path never sees
+//     this; loading the original weights has to de-interleave.
+
+import (
+	"fmt"
+	"math"
+
+	tensai "github.com/mattn/tensai"
+)
+
+// mxfp4Table is FP4 (E2M1) doubled onto an integer grid, matching
+// encoding/gguf's; the block scale halves to compensate.
+var mxfp4Table = [16]float32{0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12}
+
+// dequantMXFP4Row expands one row: len(scales) groups of 32 values from
+// 16 bytes each. dst must hold 32*len(scales) floats.
+func dequantMXFP4Row(blocks, scales []byte, dst []float32) {
+	for g, e := range scales {
+		s := float32(math.Ldexp(1, int(e)-128))
+		blk := blocks[g*16 : g*16+16]
+		out := dst[g*32 : g*32+32]
+		for i, q := range blk {
+			out[2*i] = s * mxfp4Table[q&0x0F]
+			out[2*i+1] = s * mxfp4Table[q>>4]
+		}
+	}
+}
+
+// mxfp4Expert reads one expert's projection out of the [experts, out,
+// groups, 16] block tensor and its [experts, out, groups] scales, and
+// returns it already transposed to the [in, out] a matvec wants.
+//
+// interleaved de-interleaves gpt-oss's fused gate|up on the way: output
+// row 2k is gate column k and row 2k+1 is up column k, so the result
+// carries gate in the first half of its columns and up in the second,
+// which is the layout moeFFN slices.
+func mxfp4Expert(blocks, scales []byte, shape []int, e int, interleaved bool) (*tensai.Matrix, error) {
+	if len(shape) != 4 || shape[3] != 16 {
+		return nil, fmt.Errorf("gpt-oss: expert blocks have shape %v, want [experts, out, groups, 16]", shape)
+	}
+	experts, out, groups := shape[0], shape[1], shape[2]
+	if e < 0 || e >= experts {
+		return nil, fmt.Errorf("gpt-oss: expert %d out of range %d", e, experts)
+	}
+	if interleaved && out%2 != 0 {
+		return nil, fmt.Errorf("gpt-oss: fused gate|up has odd width %d", out)
+	}
+	in := groups * 32
+	if want := experts * out * groups * 16; len(blocks) != want {
+		return nil, fmt.Errorf("gpt-oss: expert blocks are %d bytes, want %d", len(blocks), want)
+	}
+	if want := experts * out * groups; len(scales) != want {
+		return nil, fmt.Errorf("gpt-oss: expert scales are %d bytes, want %d", len(scales), want)
+	}
+	w := tensai.NewMatrix(in, out)
+	row := make([]float32, in)
+	half := out / 2
+	for r := 0; r < out; r++ {
+		i := e*out + r
+		dequantMXFP4Row(blocks[i*groups*16:(i+1)*groups*16], scales[i*groups:(i+1)*groups], row)
+		c := r
+		if interleaved {
+			if r%2 == 0 {
+				c = r / 2
+			} else {
+				c = half + r/2
+			}
+		}
+		for k, v := range row {
+			w.Data[k*out+c] = v
+		}
+	}
+	return w, nil
+}
+
+// deinterleaveBias reorders a fused gate|up bias the same way
+// mxfp4Expert reorders the weight's columns.
+func deinterleaveBias(v []float32) []float32 {
+	if v == nil {
+		return nil
+	}
+	out := make([]float32, len(v))
+	half := len(v) / 2
+	for i, x := range v {
+		if i%2 == 0 {
+			out[i/2] = x
+		} else {
+			out[half+i/2] = x
+		}
+	}
+	return out
+}
+
+// gptOssConfig fills in what gpt-oss's config.json spells differently
+// from the fields the runtime already reads from GGUF metadata. Its
+// mixture-of-experts sizes, YaRN parameters, and per-layer attention
+// spans all live under Hugging Face names.
+type gptOssConfig struct {
+	NumLocalExperts int      `json:"num_local_experts"`
+	ExpertsPerTok   int      `json:"num_experts_per_tok"`
+	ExpertsPerToken int      `json:"experts_per_token"`
+	LayerTypes      []string `json:"layer_types"`
+	RopeScaling     *struct {
+		Type     string  `json:"rope_type"`
+		Factor   float64 `json:"factor"`
+		BetaFast float64 `json:"beta_fast"`
+		BetaSlow float64 `json:"beta_slow"`
+		OrigCtx  int     `json:"original_max_position_embeddings"`
+	} `json:"rope_scaling"`
+}
+
+// applyGptOss folds the Hugging Face spelling into the config the rest of
+// the loader and the runtime already understand.
+func applyGptOss(c *config, hf gptOssConfig) {
+	c.NExpert = hf.NumLocalExperts
+	c.NExpertUsed = hf.ExpertsPerTok
+	if c.NExpertUsed == 0 {
+		c.NExpertUsed = hf.ExpertsPerToken
+	}
+	// The experts are the FFN; intermediate_size is their width.
+	c.MoeFF = c.Intermediate
+	if r := hf.RopeScaling; r != nil && r.Type == "yarn" {
+		c.YarnFactor = r.Factor
+		c.YarnOrigCtx = r.OrigCtx
+		c.YarnBetaFast = r.BetaFast
+		c.YarnBetaSlow = r.BetaSlow
+	}
+}
+
+// gptOssSlides reports whether layer i uses the sliding window. The
+// checkpoint lists this per layer; gpt-oss alternates, starting sliding.
+func gptOssSlides(hf gptOssConfig, i int) bool {
+	if i < len(hf.LayerTypes) {
+		return hf.LayerTypes[i] == "sliding_attention"
+	}
+	return i%2 == 0
+}
+
+// loadGptOssExperts fills in a block's mixture of experts from the
+// MXFP4-packed safetensors tensors. Each expert is dequantized to
+// float32, requantized to the runtime's width, and dropped again, so the
+// peak is one expert's worth of float32 per worker rather than the whole
+// layer's.
+func loadGptOssExperts(
+	b *qblock,
+	cfg config,
+	p string,
+	bits int,
+	raw func(string) ([]byte, []int),
+	vecOpt func(string) []float32,
+	router func(string) *tensai.Matrix,
+) {
+	b.router = router(p + "mlp.router.weight")
+	b.routerBias = vecOpt(p + "mlp.router.bias")
+	b.topK = cfg.NExpertUsed
+	b.softmaxK = true // gpt-oss softmaxes over the chosen experts, not all
+	b.oaiGLU = true   // clamped SwiGLU with the (up+1) linear term
+	b.experts = make([]expertFFN, cfg.NExpert)
+
+	guBlocks, guShape := raw(p + "mlp.experts.gate_up_proj_blocks")
+	guScales, _ := raw(p + "mlp.experts.gate_up_proj_scales")
+	dnBlocks, dnShape := raw(p + "mlp.experts.down_proj_blocks")
+	dnScales, _ := raw(p + "mlp.experts.down_proj_scales")
+	guBias := vecOpt(p + "mlp.experts.gate_up_proj_bias")
+	dnBias := vecOpt(p + "mlp.experts.down_proj_bias")
+
+	guWidth := guShape[1]
+	for e := range b.experts {
+		gu, err := mxfp4Expert(guBlocks, guScales, guShape, e, true)
+		if err != nil {
+			panic(err)
+		}
+		dn, err := mxfp4Expert(dnBlocks, dnScales, dnShape, e, false)
+		if err != nil {
+			panic(err)
+		}
+		ex := &b.experts[e]
+		if bits == 0 {
+			panic("gpt-oss needs -q8 or -q4: its experts are already 4-bit in the checkpoint")
+		}
+		ex.qGU = quantizeMat(gu, bits)
+		ex.qDown = quantizeMat(dn, bits)
+		if guBias != nil {
+			ex.guBias = deinterleaveBias(guBias[e*guWidth : (e+1)*guWidth])
+		}
+		if dnBias != nil {
+			ex.downBias = dnBias[e*cfg.HiddenSize : (e+1)*cfg.HiddenSize]
+		}
+	}
+}

--- a/internal/llm/gptoss_test.go
+++ b/internal/llm/gptoss_test.go
@@ -1,0 +1,165 @@
+package llm
+
+import (
+	"math"
+	"testing"
+)
+
+// fp4 is the FP4 (E2M1) codebook at its true magnitudes, against which
+// mxfp4Table is doubled. Written out independently here so the test does
+// not just restate the table it is checking.
+var fp4 = [16]float64{0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6}
+
+// packRow lays out one row of MXFP4 the way the checkpoint does: 16 bytes
+// per group of 32 values, low nibble first, and one e8m0 exponent byte
+// per group.
+func packRow(codes []uint8, exps []uint8) (blocks, scales []byte) {
+	groups := len(codes) / 32
+	blocks = make([]byte, groups*16)
+	for g := 0; g < groups; g++ {
+		for i := 0; i < 16; i++ {
+			lo := codes[g*32+2*i] & 0x0F
+			hi := codes[g*32+2*i+1] & 0x0F
+			blocks[g*16+i] = lo | hi<<4
+		}
+	}
+	return blocks, append([]byte(nil), exps...)
+}
+
+func TestDequantMXFP4Row(t *testing.T) {
+	// Two groups, every code used, two different exponents.
+	codes := make([]uint8, 64)
+	for i := range codes {
+		codes[i] = uint8(i % 16)
+	}
+	exps := []uint8{127, 130} // 2^0 and 2^3 once the doubled table halves
+	blocks, scales := packRow(codes, exps)
+	got := make([]float32, 64)
+	dequantMXFP4Row(blocks, scales, got)
+
+	for i, c := range codes {
+		scale := math.Ldexp(1, int(exps[i/32])-127)
+		want := fp4[c] * scale
+		if math.Abs(float64(got[i])-want) > 1e-6 {
+			t.Fatalf("value %d (code %d, exp %d): got %g want %g", i, c, exps[i/32], got[i], want)
+		}
+	}
+}
+
+// TestMXFP4ExpertLayout pins both permutations that would otherwise fail
+// silently: the [experts, out, groups, 16] indexing with its transpose to
+// [in, out], and the de-interleaving of gpt-oss's fused gate|up.
+func TestMXFP4ExpertLayout(t *testing.T) {
+	const experts, out, groups = 3, 8, 2
+	const in = groups * 32
+	// Give every (expert, out-row, input) a distinguishable value: code
+	// index walks so no two positions in a row share a magnitude
+	// pattern, and each row gets its own exponent.
+	blocks := make([]byte, experts*out*groups*16)
+	scales := make([]byte, experts*out*groups)
+	codeAt := func(e, r, k int) uint8 { return uint8((e*out+r+k)%15 + 1) } // never 0
+	for e := 0; e < experts; e++ {
+		for r := 0; r < out; r++ {
+			codes := make([]uint8, in)
+			for k := range codes {
+				codes[k] = codeAt(e, r, k)
+			}
+			exps := make([]uint8, groups)
+			for g := range exps {
+				exps[g] = uint8(127 + (r+g)%3)
+			}
+			b, s := packRow(codes, exps)
+			i := e*out + r
+			copy(blocks[i*groups*16:], b)
+			copy(scales[i*groups:], s)
+		}
+	}
+	shape := []int{experts, out, groups, 16}
+
+	want := func(e, r, k int) float64 {
+		return fp4[codeAt(e, r, k)] * math.Ldexp(1, (r+k/32)%3)
+	}
+
+	// Plain (down_proj): out row r becomes column r.
+	for _, e := range []int{0, 2} {
+		w, err := mxfp4Expert(blocks, scales, shape, e, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if w.Rows != in || w.Cols != out {
+			t.Fatalf("shape = %dx%d, want %dx%d", w.Rows, w.Cols, in, out)
+		}
+		for r := 0; r < out; r++ {
+			for k := 0; k < in; k++ {
+				if got, exp := float64(w.Data[k*out+r]), want(e, r, k); math.Abs(got-exp) > 1e-6 {
+					t.Fatalf("expert %d [in %d, out %d]: got %g want %g", e, k, r, got, exp)
+				}
+			}
+		}
+	}
+
+	// Fused gate|up: row 2c is gate column c, row 2c+1 is up column
+	// half+c. Getting this backwards swaps the SwiGLU's two operands,
+	// which produces fluent nonsense rather than an error.
+	const half = out / 2
+	w, err := mxfp4Expert(blocks, scales, shape, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for r := 0; r < out; r++ {
+		col := r / 2
+		if r%2 == 1 {
+			col = half + r/2
+		}
+		for k := 0; k < in; k++ {
+			if got, exp := float64(w.Data[k*out+col]), want(1, r, k); math.Abs(got-exp) > 1e-6 {
+				t.Fatalf("fused row %d -> col %d [in %d]: got %g want %g", r, col, k, got, exp)
+			}
+		}
+	}
+}
+
+func TestDeinterleaveBias(t *testing.T) {
+	got := deinterleaveBias([]float32{0, 10, 1, 11, 2, 12})
+	want := []float32{0, 1, 2, 10, 11, 12}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("deinterleaveBias = %v, want %v", got, want)
+		}
+	}
+	if deinterleaveBias(nil) != nil {
+		t.Error("deinterleaveBias(nil) should stay nil")
+	}
+}
+
+func TestApplyGptOss(t *testing.T) {
+	c := config{Intermediate: 2880}
+	hf := gptOssConfig{NumLocalExperts: 32, ExpertsPerTok: 4}
+	hf.RopeScaling = &struct {
+		Type     string  `json:"rope_type"`
+		Factor   float64 `json:"factor"`
+		BetaFast float64 `json:"beta_fast"`
+		BetaSlow float64 `json:"beta_slow"`
+		OrigCtx  int     `json:"original_max_position_embeddings"`
+	}{Type: "yarn", Factor: 32, BetaFast: 32, BetaSlow: 1, OrigCtx: 4096}
+	applyGptOss(&c, hf)
+	if c.NExpert != 32 || c.NExpertUsed != 4 || c.MoeFF != 2880 {
+		t.Errorf("moe dims = %d/%d/%d, want 32/4/2880", c.NExpert, c.NExpertUsed, c.MoeFF)
+	}
+	if c.YarnFactor != 32 || c.YarnOrigCtx != 4096 || c.YarnBetaFast != 32 || c.YarnBetaSlow != 1 {
+		t.Errorf("yarn = %v/%d/%v/%v", c.YarnFactor, c.YarnOrigCtx, c.YarnBetaFast, c.YarnBetaSlow)
+	}
+}
+
+func TestGptOssSlides(t *testing.T) {
+	hf := gptOssConfig{LayerTypes: []string{"sliding_attention", "full_attention", "sliding_attention"}}
+	for i, want := range []bool{true, false, true} {
+		if got := gptOssSlides(hf, i); got != want {
+			t.Errorf("layer %d slides = %v, want %v", i, got, want)
+		}
+	}
+	// Past the listed layers it falls back to the alternation.
+	if !gptOssSlides(hf, 4) || gptOssSlides(hf, 5) {
+		t.Error("fallback alternation is wrong")
+	}
+}

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -62,6 +62,9 @@ type config struct {
 	YarnOrigCtx  int     `json:"-"`
 	YarnBetaFast float64 `json:"-"`
 	YarnBetaSlow float64 `json:"-"`
+	// gptOss keeps the Hugging Face spelling of the fields above around
+	// for the loader, which needs its per-layer attention spans.
+	gptOss gptOssConfig `json:"-"`
 }
 
 // qmat abstracts the int8 and int4 twins behind one matvec call, plus the
@@ -171,8 +174,19 @@ func loadConfig(path string) (config, error) {
 	}
 	switch c.ModelType {
 	case "qwen2", "qwen3", "llama", "smollm3":
+	case "gpt_oss":
+		var hf gptOssConfig
+		if err := json.Unmarshal(raw, &hf); err != nil {
+			return c, fmt.Errorf("parsing gpt-oss config: %w", err)
+		}
+		applyGptOss(&c, hf)
+		c.gptOss = hf
+		// config.json spells it with an underscore and the GGUF metadata
+		// with a hyphen; the template family table knows the hyphen, and
+		// without this the harmony channels leak into the answer.
+		c.ChatStyle = "gpt-oss"
 	default:
-		return c, fmt.Errorf("unsupported model_type %q (this example speaks qwen2, qwen3, llama, and smollm3)", c.ModelType)
+		return c, fmt.Errorf("unsupported model_type %q (this example speaks qwen2, qwen3, llama, smollm3, and gpt_oss)", c.ModelType)
 	}
 	return c, nil
 }
@@ -181,6 +195,10 @@ func loadConfig(path string) (config, error) {
 // loader needs.
 type weightsFile interface {
 	Tensor(string) (*tensai.Tensor, error)
+	// Raw reads a packed tensor's bytes without widening them: gpt-oss's
+	// experts sit in the file as MXFP4 and only the loader knows how to
+	// read them.
+	Raw(string) ([]byte, []int, error)
 	Close() error
 }
 
@@ -259,6 +277,31 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 		return nil, quantizeMat(w, bits)
 	}
 
+	// raw hands back a packed U8 tensor's bytes; gpt-oss's experts are
+	// MXFP4 inside the file and expanding them to float32 would cost
+	// gigabytes a layer.
+	raw := func(name string) ([]byte, []int) {
+		data, shape, err := f.Raw(name)
+		if err != nil {
+			panic(err)
+		}
+		return data, shape
+	}
+	// linqRouter keeps the router in float32: it is [hidden, nExpert],
+	// far too small to be worth quantizing and too load-bearing to want
+	// the error.
+	linqRouter := func(name string) *tensai.Matrix {
+		t, err := f.Tensor(name)
+		if err != nil {
+			panic(err)
+		}
+		mm, err := t.Matrix()
+		if err != nil {
+			panic(err)
+		}
+		return mm.T()
+	}
+
 	headSz := cfg.HiddenSize / cfg.Heads
 	if cfg.HeadDim != 0 {
 		headSz = cfg.HeadDim
@@ -318,6 +361,18 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 			b.wQKV, b.qQKV = linqFused(p+"self_attn.q_proj.weight", p+"self_attn.k_proj.weight", p+"self_attn.v_proj.weight")
 			b.bQKV = catVec(vecOpt(p+"self_attn.q_proj.bias"), vecOpt(p+"self_attn.k_proj.bias"), vecOpt(p+"self_attn.v_proj.bias"))
 			b.wo, b.qo = linq(p + "self_attn.o_proj.weight")
+			if cfg.ModelType == "gpt_oss" {
+				// Sinks absorb the attention mass that the sliding
+				// layers would otherwise have given to positions outside
+				// their window.
+				b.sinks = vecOpt(p + "self_attn.sinks")
+				b.bo = vecOpt(p + "self_attn.o_proj.bias")
+				if gptOssSlides(cfg.gptOss, i) {
+					b.window = cfg.SlidingWin
+				}
+				loadGptOssExperts(b, cfg, p, bits, raw, vecOpt, linqRouter)
+				return
+			}
 			b.wGU, b.qGU = linqFused(p+"mlp.gate_proj.weight", p+"mlp.up_proj.weight")
 			b.wDown, b.qDown = linq(p + "mlp.down_proj.weight")
 		}(i)


### PR DESCRIPTION
Stacked on #163, which this needs to read gpt-oss's tokenizer at all.

The runtime already had everything gpt-oss needs — mixture of experts, attention sinks, YaRN, the clamped SwiGLU, per-layer sliding windows — but only the GGUF loader could reach it, so `model_type: "gpt_oss"` was refused and `-model openai/gpt-oss-20b` could not run.

Most of the wiring is config: the mixture sizes, YaRN parameters, and per-layer attention spans all live under Hugging Face names rather than the GGUF metadata keys those fields are otherwise filled from. The weights are the real work. gpt-oss ships its experts MXFP4-packed inside the safetensors — a `U8` `_blocks` tensor of nibble pairs beside `U8` `_scales` of e8m0 exponents — so the reader grows `Raw`, handing back a packed tensor's bytes instead of widening them. Widening is not an option: one layer's blocks are 265MB of nibbles that would become 2.1GB of float32. `Tensor` now refuses `U8`/`I8` and points at `Raw` rather than returning something meaningless.

Two details in that layout differ from the same weights seen through a GGUF, and both fail silently, since a permuted weight produces fluent nonsense rather than an error:

- **Nibble order.** llama.cpp splits a 16-byte group as value `i` and value `i+16`; the checkpoint pairs them, low nibble to `2i` and high to `2i+1`.
- **gate/up interleaving.** gpt-oss reads its fused projection as `gate = out[..., 0::2]` and `up = out[..., 1::2]`, while `moeFFN` wants the two concatenated. llama.cpp's converter splits them into separate `ffn_gate`/`ffn_up` tensors, so the GGUF path never sees this.

Both are pinned by tests that give every position a distinguishable value, so a permutation fails loudly instead of degrading. Experts dequantize and requantize one at a time, keeping the peak at one expert's float32 per worker rather than a whole layer's.

One more thing was needed to make the answers readable: `config.json` spells the type `gpt_oss` and the GGUF metadata `gpt-oss`, and the chat template family table knows the hyphen — so the harmony channel markers leaked into the reply until the loader normalized it.

Verified against the real `openai/gpt-oss-20b`, 24 layers loaded from the three published shards: *"What is the capital of France?"* → **"The capital of France is Paris."**, and *"What is 17 times 23?"* → **"17 × 23 = 391"**, both arriving through the analysis and final channels.

Worth flagging separately: `run` still prints the harmony channel markers around the answer. That is neither new nor specific to this loader — the harmony template sets no `reasonOpen`/`reasonClose`, so the GGUF path shows them too — and folding those channels into the reasoning field the API already has deserves its own change and its own tests.

https://claude.ai/code/session_01XjN5GeBQjrtyiuwd75VX45