### PR TITLE
Batch what the delta rule allows

### DIFF
--- a/docs/llm.ja.md
+++ b/docs/llm.ja.md
@@ -25,6 +25,13 @@ greedy の続きは GPT-2 のよく知られたリファレンス出力とトー
 | qwen2 | Qwen 1.5/2/2.5, Qwen2.5-Coder, R1-Distill-Qwen 系 | attention バイアス |
 | qwen3 | Qwen3 dense | ヘッドごとの QK-norm、明示的 head_dim、`-think` |
 | qwen3_5 | Qwen3.5 / 3.6 / 3.8 | 4 層に 3 層が gated delta rule、残り 1 層が通常の attention。正規化は 1 + w、RoPE はヘッドの 1/4 だけ回し、クエリが attention 出力のゲートを連れる。CPU のみ、`-draft` 不可 |
+
+`qwen3_5` のプレフィルは、モデルの大きさから想像するより高くつきます。delta 層は
+状態をトークンごとに引き継ぐので、バッチが効くのは再帰の周りの射影だけで、長い
+プロンプトはプレフィルというよりデコードに近くなります。0.8B で AVX2 マシンなら
+1 トークンあたり約 10 ミリ秒 — 同規模の qwen3 が 4 ミリ秒なので、システムプロンプトが
+数千トークンあると待たされます。アーキテクチャが許すチャンク化を実装すれば大半は
+縮みますが、まだ入っていません。
 | llama | Llama 2/3, SmolLM2, Mistral, R1-Distill-Llama | みんながフォークしたブロック |
 | smollm3 | SmolLM3-3B | 4 層ごとに RoPE をスキップ |
 | gemma3 | Gemma 3 | 5/6 層のスライディングウィンドウ、サンドイッチ norm、gelu-tanh ゲート、SentencePiece |

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -25,6 +25,14 @@ The `tensai` command runs modern instruction-tuned models: RMSNorm, rotary posit
 | qwen2 | Qwen 1.5/2/2.5, Qwen2.5-Coder, the R1-Distill-Qwen line | attention biases |
 | qwen3 | Qwen3 dense | per-head QK-norm, explicit head_dim, `-think` |
 | qwen3_5 | Qwen3.5, Qwen3.6, Qwen3.8 | a gated delta rule on three layers in four, ordinary attention on the fourth; norms scale by 1 + w, RoPE turns a quarter of each head, and the queries carry a gate for the attention output. CPU only, and no `-draft` |
+
+A `qwen3_5` prompt costs more to prefill than its size suggests: the delta
+layers carry state token by token, so only the projections around the
+recurrence batch, and a long prompt is closer to decoding it than to
+prefilling one. Roughly ten milliseconds a token on an AVX2 machine for the
+0.8B, against four for a qwen3 of the same size — enough that a couple of
+thousand tokens of system prompt is a wait. The chunked formulation the
+architecture allows would close most of that and is not implemented yet.
 | llama | Llama 2/3, SmolLM2, Mistral, R1-Distill-Llama | the block everyone forked |
 | smollm3 | SmolLM3-3B | RoPE skipped every fourth layer |
 | gemma3 | Gemma 3 | sliding windows on 5/6 layers, sandwich norms, gelu-tanh gate, SentencePiece |

--- a/internal/llm/delta.go
+++ b/internal/llm/delta.go
@@ -11,6 +11,8 @@ package llm
 import (
 	"fmt"
 	"math"
+	"runtime"
+	"sync"
 
 	"github.com/mattn/tensai"
 	"github.com/mattn/tensai/internal/kernels"
@@ -139,15 +141,22 @@ func silu(x float32) float32 {
 // step advances one token through the layer, in place on x. conv holds the
 // previous convK-1 rows; the state absorbs the token and answers the query.
 func (d *deltaWeights) step(st *deltaState, x []float32, scratch *deltaScratch) []float32 {
-	qkv := scratch.qkv
-	mvInto(qkv, x, d.wQKV, d.qQKV, nil)
-	z := scratch.z
-	mvInto(z, x, d.wZ, d.qZ, nil)
-	a := scratch.a
-	mvInto(a, x, d.wA, nil, nil)
-	b := scratch.b
-	mvInto(b, x, d.wB, nil, nil)
+	mvInto(scratch.qkv, x, d.wQKV, d.qQKV, nil)
+	mvInto(scratch.z, x, d.wZ, d.qZ, nil)
+	mvInto(scratch.a, x, d.wA, nil, nil)
+	mvInto(scratch.b, x, d.wB, nil, nil)
+	res := d.mix(st, scratch.qkv, scratch.z, scratch.a, scratch.b, scratch)
+	y := scratch.proj
+	mvInto(y, res, d.wOut, d.qOut, nil)
+	return y
+}
 
+// mix is the half of the layer that cannot be batched: the convolution
+// reads the window the previous tokens left, and the state each token
+// writes is what the next one reads. Everything around it -- the four
+// projections in and the one out -- is an ordinary matmul, which is why
+// prefill does those over the whole batch and calls only this per token.
+func (d *deltaWeights) mix(st *deltaState, qkv, z, a, b []float32, scratch *deltaScratch) []float32 {
 	// Causal depthwise convolution over the qkv channels, then silu. The
 	// window is the state's convK-1 rows followed by this token.
 	kw := d.convK
@@ -167,10 +176,38 @@ func (d *deltaWeights) step(st *deltaState, x []float32, scratch *deltaScratch) 
 
 	kd, vd, h := d.kDim, d.vDim, d.heads
 	keyDim := kd * h
-	qs, ks, vs := out[:keyDim], out[keyDim:2*keyDim], out[2*keyDim:]
 	res := scratch.out
 	qScale := float32(1 / math.Sqrt(float64(kd)))
+	// Heads share nothing: each owns its slice of the state and of every
+	// scratch buffer, so they run wherever there is a core. The state is
+	// a megabyte a layer, which is what makes this worth the dispatch.
+	if workers := min(runtime.NumCPU(), h); workers > 1 {
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				for hi := w; hi < h; hi += workers {
+					d.head(st, scratch, res, out, z, a, b, hi, kd, vd, keyDim, qScale)
+				}
+			}(w)
+		}
+		wg.Wait()
+		return res
+	}
 	for hi := 0; hi < h; hi++ {
+		d.head(st, scratch, res, out, z, a, b, hi, kd, vd, keyDim, qScale)
+	}
+	return res
+}
+
+// head advances one head of the delta rule. It is its own function so the
+// loop above can hand a head to a goroutine without capturing anything the
+// others touch.
+func (d *deltaWeights) head(st *deltaState, scratch *deltaScratch, res, out, z, a, b []float32,
+	hi, kd, vd, keyDim int, qScale float32) {
+	qs, ks, vs := out[:keyDim], out[keyDim:2*keyDim], out[2*keyDim:]
+	{
 		q := qs[hi*kd : (hi+1)*kd]
 		k := ks[hi*kd : (hi+1)*kd]
 		v := vs[hi*vd : (hi+1)*vd]
@@ -183,7 +220,7 @@ func (d *deltaWeights) step(st *deltaState, x []float32, scratch *deltaScratch) 
 		decay := float32(math.Exp(float64(-float32(math.Exp(float64(d.aLog[hi]))) * softplus(a[hi]+d.dtBias[hi]))))
 
 		s := st.s[hi*kd*vd : (hi+1)*kd*vd]
-		mem := scratch.mem[:vd]
+		mem := scratch.mem[hi*vd : (hi+1)*vd]
 		for j := range mem {
 			mem[j] = 0
 		}
@@ -195,17 +232,21 @@ func (d *deltaWeights) step(st *deltaState, x []float32, scratch *deltaScratch) 
 				tensai.Axpy(k[i], row, mem)
 			}
 		}
-		// Write the difference back along the key, then answer the query.
+		// The correction the key writes is the same vector for every row
+		// of the state, so it is computed once and each row takes a
+		// multiple of it -- which is an axpy, not a scalar loop.
+		delta := scratch.delta[hi*vd : (hi+1)*vd]
+		for j := range delta {
+			delta[j] = (v[j] - mem[j]) * beta
+		}
 		o := res[hi*vd : (hi+1)*vd]
 		for j := range o {
 			o[j] = 0
 		}
 		for i := 0; i < kd; i++ {
 			row := s[i*vd : (i+1)*vd]
-			if ki := k[i]; ki != 0 {
-				for j := 0; j < vd; j++ {
-					row[j] += ki * (v[j] - mem[j]) * beta
-				}
+			if k[i] != 0 {
+				tensai.Axpy(k[i], delta, row)
 			}
 			if q[i] != 0 {
 				tensai.Axpy(q[i], row, o)
@@ -222,26 +263,24 @@ func (d *deltaWeights) step(st *deltaState, x []float32, scratch *deltaScratch) 
 			o[j] = d.norm[j] * (o[j] * inv) * silu(zg[j])
 		}
 	}
-	y := scratch.proj
-	mvInto(y, res, d.wOut, d.qOut, nil)
-	return y
 }
 
 // deltaScratch is one token's working set, reused across layers.
 type deltaScratch struct {
-	qkv, conv, z, a, b, mem, out, proj []float32
+	qkv, conv, z, a, b, mem, delta, out, proj []float32
 }
 
 func newDeltaScratch(d *deltaWeights, hidden int) *deltaScratch {
 	return &deltaScratch{
-		qkv:  make([]float32, d.convDim),
-		conv: make([]float32, d.convDim),
-		z:    make([]float32, d.vDim*d.heads),
-		a:    make([]float32, d.heads),
-		b:    make([]float32, d.heads),
-		mem:  make([]float32, d.vDim),
-		out:  make([]float32, d.vDim*d.heads),
-		proj: make([]float32, hidden),
+		qkv:   make([]float32, d.convDim),
+		conv:  make([]float32, d.convDim),
+		z:     make([]float32, d.vDim*d.heads),
+		a:     make([]float32, d.heads),
+		b:     make([]float32, d.heads),
+		mem:   make([]float32, d.vDim*d.heads),
+		delta: make([]float32, d.vDim*d.heads),
+		out:   make([]float32, d.vDim*d.heads),
+		proj:  make([]float32, hidden),
 	}
 }
 

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -1080,21 +1080,35 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 		b := &m.blocks[li]
 		norm(b.ln1)
 		if b.delta != nil {
-			// The recurrence carries token to token, so the batch buys
-			// nothing here: each row advances the state in turn. A
-			// chunked formulation exists and is the next thing to do.
+			// Only the convolution and the recurrence are sequential --
+			// each token reads what the last one left. The projections
+			// around them are ordinary matmuls, and they are most of the
+			// arithmetic, so they run over the whole batch and the loop
+			// carries just the state.
+			d := b.delta
 			if b.dstate == nil {
-				b.dstate = b.delta.newState()
+				b.dstate = d.newState()
 			}
 			if m.dscratch == nil {
-				m.dscratch = newDeltaScratch(b.delta, hs)
+				m.dscratch = newDeltaScratch(d, hs)
 			}
+			qkvB := mmb(a, d.wQKV, d.qQKV, nil)
+			zB := mmb(a, d.wZ, d.qZ, nil)
+			aB := mmb(a, d.wA, nil, nil)
+			bB := mmb(a, d.wB, nil, nil)
+			mixed := tensai.NewMatrix(n, d.vDim*d.heads)
 			for t := 0; t < n; t++ {
-				y := b.delta.step(b.dstate, a.Data[t*hs:(t+1)*hs], m.dscratch)
-				row := x.Data[t*hs : (t+1)*hs]
-				for i := range row {
-					row[i] += y[i]
-				}
+				res := d.mix(b.dstate,
+					qkvB.Data[t*qkvB.Cols:(t+1)*qkvB.Cols],
+					zB.Data[t*zB.Cols:(t+1)*zB.Cols],
+					aB.Data[t*aB.Cols:(t+1)*aB.Cols],
+					bB.Data[t*bB.Cols:(t+1)*bB.Cols],
+					m.dscratch)
+				copy(mixed.Data[t*mixed.Cols:(t+1)*mixed.Cols], res)
+			}
+			outB := mmb(mixed, d.wOut, d.qOut, nil)
+			for i := range x.Data {
+				x.Data[i] += outB.Data[i]
 			}
 		} else {
 			qkv := mmb(a, b.wQKV, b.qQKV, b.bQKV)


### PR DESCRIPTION
A qwen3_5 prompt prefilled at the speed of decoding it, which an agent's couple of thousand tokens of system prompt turns into a wait long enough to look like a hang. Only the convolution and the recurrence are actually sequential; the four projections in and the one out are ordinary matmuls, and they are most of the arithmetic, so prefill now runs them over the whole batch and the token loop carries just the state. Inside the recurrence the correction a key writes is one vector shared by every row of the state, so computing it once turns a scalar loop into an axpy, and heads share nothing, so they run wherever there is a core. Measured on the 0.8B: a 624-token prompt prefills in 6.1s against 11.9, and decode goes from 21.7 to 23.2 tok/s. The reassociation shifts the last bits, so int8 greedy decoding can pick a different word of equal standing; in float32 the output is unchanged. The delta rule stays pinned to the reference values by its test. What remains is the chunked formulation, which would close most of the rest.