### PR TITLE
Spend the delta layer's prefill on arithmetic

### DIFF
--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -13,6 +13,7 @@ func LeakyBwd(dst, grad, src []float32, alpha float32) {
 }
 func SigmoidFwd(dst, src []float32)              { sigmoidFwdGeneric(dst, src) }
 func SiluMul(gate, up []float32)                 { siluMulGeneric(gate, up) }
+func Silu(v []float32)                           { siluGeneric(v) }
 func SigmoidBwd(dst, grad, y []float32)          { sigmoidBwdGeneric(dst, grad, y) }
 func TanhFwd(dst, src []float32)                 { tanhFwdGeneric(dst, src) }
 func TanhBwd(dst, grad, y []float32)             { tanhBwdGeneric(dst, grad, y) }

--- a/internal/kernels/dispatch_simd.go
+++ b/internal/kernels/dispatch_simd.go
@@ -134,6 +134,21 @@ func SiluMul(gate, up []float32) {
 	})
 }
 
+// Silu applies x * sigmoid(x) in place. SiluMul is the same thing paired
+// with a gate; the delta rule wants it on its own, over a convolution's
+// output rather than a SwiGLU's.
+func Silu(v []float32) {
+	if !simd.HasAVX2 {
+		siluGeneric(v)
+		return
+	}
+	one := archsimd.BroadcastFloat32x8(1)
+	zero := archsimd.BroadcastFloat32x8(0)
+	mapSlices(v, v, func(x archsimd.Float32x8) archsimd.Float32x8 {
+		return x.Div(one.Add(vexpf(zero.Sub(x))))
+	})
+}
+
 func SigmoidBwd(dst, grad, y []float32) {
 	if !simd.HasAVX2 {
 		sigmoidBwdGeneric(dst, grad, y)

--- a/internal/kernels/kernels.go
+++ b/internal/kernels/kernels.go
@@ -77,6 +77,13 @@ func siluMulGeneric(gate, up []float32) {
 	}
 }
 
+// siluGeneric applies x * sigmoid(x) in place.
+func siluGeneric(v []float32) {
+	for i, x := range v {
+		v[i] = x / (1 + ExpF(-x))
+	}
+}
+
 // sigmoidBwdGeneric computes dst = grad * y * (1-y) from the forward output y.
 func sigmoidBwdGeneric(dst, grad, y []float32) {
 	for i, g := range grad {

--- a/internal/llm/delta.go
+++ b/internal/llm/delta.go
@@ -35,6 +35,10 @@ type deltaWeights struct {
 	qZ, qOut *qmat
 	// a and b are [hidden, heads], small enough to leave in float32.
 	wA, wB *tensai.Matrix
+	// wQZ fuses qkv with z and wAB a with b: both pairs read the same
+	// activation, so a batch pays for one pass over it instead of two.
+	wQZ, wAB *tensai.Matrix
+	qQZ      *qmat
 }
 
 // deltaState is what a linear-attention layer carries between tokens: the
@@ -42,12 +46,19 @@ type deltaWeights struct {
 type deltaState struct {
 	s    []float32 // [heads, kDim, vDim]
 	conv []float32 // [convK-1, convDim], oldest first
+	// parallel spreads the heads across cores. Decode calls the layer
+	// once per token and the state is a megabyte, so the dispatch pays
+	// for itself; prefill calls it once per token as well but with the
+	// projections already batched around it, where the goroutines cost
+	// more than the heads save.
+	parallel bool
 }
 
 func (d *deltaWeights) newState() *deltaState {
 	return &deltaState{
-		s:    make([]float32, d.heads*d.kDim*d.vDim),
-		conv: make([]float32, (d.convK-1)*d.convDim),
+		parallel: true,
+		s:        make([]float32, d.heads*d.kDim*d.vDim),
+		conv:     make([]float32, (d.convK-1)*d.convDim),
 	}
 }
 
@@ -66,7 +77,9 @@ func (c config) linearLayer(i int) bool {
 // loader's usual transpose-and-quantize path.
 func loadDelta(cfg config, p string, vec func(string) []float32,
 	linq func(string) (*tensai.Matrix, *qmat),
-	linqF32 func(string) *tensai.Matrix) *deltaWeights {
+	linqF32 func(string) *tensai.Matrix,
+	linqFused func(...string) (*tensai.Matrix, *qmat),
+	linqF32Fused func(...string) *tensai.Matrix) *deltaWeights {
 	d := &deltaWeights{
 		heads:  cfg.LinearValueHeads,
 		kDim:   cfg.LinearKeyDim,
@@ -85,6 +98,8 @@ func loadDelta(cfg config, p string, vec func(string) []float32,
 	// would save nothing and cost the precision the decay depends on.
 	d.wA = linqF32(p + "linear_attn.in_proj_a.weight")
 	d.wB = linqF32(p + "linear_attn.in_proj_b.weight")
+	d.wQZ, d.qQZ = linqFused(p+"linear_attn.in_proj_qkv.weight", p+"linear_attn.in_proj_z.weight")
+	d.wAB = linqF32Fused(p+"linear_attn.in_proj_a.weight", p+"linear_attn.in_proj_b.weight")
 	if err := d.check(); err != nil {
 		panic(err)
 	}
@@ -163,13 +178,13 @@ func (d *deltaWeights) mix(st *deltaState, qkv, z, a, b []float32, scratch *delt
 	prev := st.conv
 	out := scratch.conv
 	for c := 0; c < d.convDim; c++ {
-		var acc float32
+		acc := qkv[c] * d.conv[c*kw+kw-1]
 		for t := 0; t < kw-1; t++ {
 			acc += prev[t*d.convDim+c] * d.conv[c*kw+t]
 		}
-		acc += qkv[c] * d.conv[c*kw+kw-1]
-		out[c] = silu(acc)
+		out[c] = acc
 	}
+	kernels.Silu(out)
 	// Roll the window forward by one.
 	copy(prev, prev[d.convDim:])
 	copy(prev[(kw-2)*d.convDim:], qkv)
@@ -181,7 +196,7 @@ func (d *deltaWeights) mix(st *deltaState, qkv, z, a, b []float32, scratch *delt
 	// Heads share nothing: each owns its slice of the state and of every
 	// scratch buffer, so they run wherever there is a core. The state is
 	// a megabyte a layer, which is what makes this worth the dispatch.
-	if workers := min(runtime.NumCPU(), h); workers > 1 {
+	if workers := min(runtime.NumCPU(), h); workers > 1 && st.parallel {
 		var wg sync.WaitGroup
 		for w := 0; w < workers; w++ {
 			wg.Add(1)

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -399,6 +399,34 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 		return mm.T()
 	}
 
+	linqF32Fused := func(names ...string) *tensai.Matrix {
+		parts := make([]*tensai.Matrix, len(names))
+		for i, name := range names {
+			t, err := f.Tensor(name)
+			if err != nil {
+				panic(err)
+			}
+			mm, err := t.Matrix()
+			if err != nil {
+				panic(err)
+			}
+			parts[i] = mm.T()
+		}
+		rows, cols := parts[0].Rows, 0
+		for _, m := range parts {
+			cols += m.Cols
+		}
+		out := tensai.NewMatrix(rows, cols)
+		off := 0
+		for _, m := range parts {
+			for r := 0; r < rows; r++ {
+				copy(out.Data[r*cols+off:], m.Data[r*m.Cols:(r+1)*m.Cols])
+			}
+			off += m.Cols
+		}
+		return out
+	}
+
 	headSz := cfg.HiddenSize / cfg.Heads
 	if cfg.HeadDim != 0 {
 		headSz = cfg.HeadDim
@@ -456,7 +484,7 @@ func loadQwen(cfgPath, weightsPath string, bits int) (*qwen, error) {
 			b.qNorm = normVecOpt(p + "self_attn.q_norm.weight")
 			b.kNorm = normVecOpt(p + "self_attn.k_norm.weight")
 			if cfg.linearLayer(i) {
-				b.delta = loadDelta(cfg, p, vec, linq, linqRouter)
+				b.delta = loadDelta(cfg, p, vec, linq, linqRouter, linqFused, linqF32Fused)
 				b.wGU, b.qGU = linqFused(p+"mlp.gate_proj.weight", p+"mlp.up_proj.weight")
 				b.wDown, b.qDown = linq(p + "mlp.down_proj.weight")
 				return
@@ -1092,20 +1120,23 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			if m.dscratch == nil {
 				m.dscratch = newDeltaScratch(d, hs)
 			}
-			qkvB := mmb(a, d.wQKV, d.qQKV, nil)
-			zB := mmb(a, d.wZ, d.qZ, nil)
-			aB := mmb(a, d.wA, nil, nil)
-			bB := mmb(a, d.wB, nil, nil)
+			// The four inputs come from one activation, so they come out
+			// of two matmuls rather than four: qkv and z share the
+			// quantized weight, a and b the float one.
+			qzB := mmb(a, d.wQZ, d.qQZ, nil)
+			abB := mmb(a, d.wAB, nil, nil)
+			// Only the state carries between tokens, and it is not worth
+			// a goroutine per token here.
+			b.dstate.parallel = false
 			mixed := tensai.NewMatrix(n, d.vDim*d.heads)
 			for t := 0; t < n; t++ {
-				res := d.mix(b.dstate,
-					qkvB.Data[t*qkvB.Cols:(t+1)*qkvB.Cols],
-					zB.Data[t*zB.Cols:(t+1)*zB.Cols],
-					aB.Data[t*aB.Cols:(t+1)*aB.Cols],
-					bB.Data[t*bB.Cols:(t+1)*bB.Cols],
-					m.dscratch)
+				qz := qzB.Data[t*qzB.Cols : (t+1)*qzB.Cols]
+				ab := abB.Data[t*abB.Cols : (t+1)*abB.Cols]
+				res := d.mix(b.dstate, qz[:d.convDim], qz[d.convDim:],
+					ab[:d.heads], ab[d.heads:], m.dscratch)
 				copy(mixed.Data[t*mixed.Cols:(t+1)*mixed.Cols], res)
 			}
+			b.dstate.parallel = true
 			outB := mmb(mixed, d.wOut, d.qOut, nil)
 			for i := range x.Data {
 				x.Data[i] += outB.Data[i]


### PR DESCRIPTION
A profile of a 925-token prefill found the sequential recurrence at eleven percent and two thirds of that inside silu, which ran a scalar exp over six thousand channels a token. It is a kernel now, next to the SiluMul the SwiGLU already uses. The head fan-out that helps decode was costing more than it saved in prefill, where it spawned sixteen goroutines per token behind projections that were already batched, so it is now decode's alone. And the four inputs a delta layer reads come from one activation, so the two that share a quantized weight and the two that share a float one fuse into a pair of matmuls instead of four passes. Together on the 0.8B: a 925-token prompt prefills in 7.5s against 9.4, and decode goes from 25.9 to 26.7 tok/s. What the profile also says is that the remaining fifty-five percent is ordinary quantized matmul, so the chunked delta rule would buy a few percent at most; qwen3_5 simply asks more arithmetic per token than a qwen3 of the same size, and its prefill is not going to reach one.