### PR TITLE
Give the delta rule the cores it was leaving idle

### DIFF
--- a/internal/llm/delta.go
+++ b/internal/llm/delta.go
@@ -280,12 +280,37 @@ func (d *deltaWeights) head(st *deltaState, scratch *deltaScratch, res, out, z, 
 	}
 }
 
-// deltaScratch is one token's working set, reused across layers.
+// deltaScratch is one token's working set, reused across layers. The
+// per-head copies exist because a prefill batch runs the heads at once,
+// and each wants its own mem and delta; decode reuses the first.
 type deltaScratch struct {
 	qkv, conv, z, a, b, mem, delta, out, proj []float32
+	perHead                                   []*deltaScratch
+	batch                                     []float32
+}
+
+// batchConv hands back a [rows, cols] buffer for a prefill batch's
+// convolution output, growing the one it keeps rather than allocating a
+// fresh twenty megabytes per layer.
+func (s *deltaScratch) batchConv(rows, cols int) []float32 {
+	if n := rows * cols; cap(s.batch) < n {
+		s.batch = make([]float32, n)
+	} else {
+		s.batch = s.batch[:n]
+	}
+	return s.batch
 }
 
 func newDeltaScratch(d *deltaWeights, hidden int) *deltaScratch {
+	s := newDeltaScratchOne(d, hidden)
+	s.perHead = make([]*deltaScratch, d.heads)
+	for i := range s.perHead {
+		s.perHead[i] = newDeltaScratchOne(d, hidden)
+	}
+	return s
+}
+
+func newDeltaScratchOne(d *deltaWeights, hidden int) *deltaScratch {
 	return &deltaScratch{
 		qkv:   make([]float32, d.convDim),
 		conv:  make([]float32, d.convDim),
@@ -308,4 +333,80 @@ func (m *qwen) hasDelta() bool {
 		}
 	}
 	return false
+}
+
+// mixBatch is mix over a whole prefill batch. The convolution is a
+// sequence-wide pass, and after it every head walks the batch on its own
+// state, so the recurrence -- which is sequential in tokens but not in
+// heads -- runs on as many cores as there are heads instead of one.
+// That is the difference between prefill using four of sixteen and most
+// of them.
+func (d *deltaWeights) mixBatch(st *deltaState, qz *tensai.Matrix, ab *tensai.Matrix,
+	mixed *tensai.Matrix, scratch *deltaScratch) {
+	n := mixed.Rows
+	kd, vd, h := d.kDim, d.vDim, d.heads
+	keyDim := kd * h
+	kw := d.convK
+	// The convolution first, for every token: each channel mixes with its
+	// three predecessors, which for the first tokens are the window the
+	// previous batch left.
+	conv := scratch.batchConv(n, d.convDim)
+	prev := st.conv
+	for t := 0; t < n; t++ {
+		src := qz.Data[t*qz.Cols : t*qz.Cols+d.convDim]
+		out := conv[t*d.convDim : (t+1)*d.convDim]
+		for c := 0; c < d.convDim; c++ {
+			acc := src[c] * d.conv[c*kw+kw-1]
+			for i := 0; i < kw-1; i++ {
+				j := t - (kw - 1) + i
+				if j < 0 {
+					acc += prev[(kw-1+j)*d.convDim+c] * d.conv[c*kw+i]
+				} else {
+					acc += qz.Data[j*qz.Cols+c] * d.conv[c*kw+i]
+				}
+			}
+			out[c] = acc
+		}
+	}
+	kernels.Silu(conv)
+	// Carry the window forward by the last kw-1 tokens of the batch.
+	for i := 0; i < kw-1; i++ {
+		j := n - (kw - 1) + i
+		dst := prev[i*d.convDim : (i+1)*d.convDim]
+		if j < 0 {
+			copy(dst, prev[(kw-1+j)*d.convDim:])
+			continue
+		}
+		copy(dst, qz.Data[j*qz.Cols:j*qz.Cols+d.convDim])
+	}
+
+	qScale := float32(1 / math.Sqrt(float64(kd)))
+	work := func(hi int) {
+		sc := scratch.perHead[hi]
+		for t := 0; t < n; t++ {
+			d.head(st, sc, mixed.Data[t*mixed.Cols:(t+1)*mixed.Cols],
+				conv[t*d.convDim:(t+1)*d.convDim],
+				qz.Data[t*qz.Cols+d.convDim:(t+1)*qz.Cols],
+				ab.Data[t*ab.Cols:t*ab.Cols+h],
+				ab.Data[t*ab.Cols+h:(t+1)*ab.Cols],
+				hi, kd, vd, keyDim, qScale)
+		}
+	}
+	if workers := min(runtime.NumCPU(), h); workers > 1 {
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				for hi := w; hi < h; hi += workers {
+					work(hi)
+				}
+			}(w)
+		}
+		wg.Wait()
+		return
+	}
+	for hi := 0; hi < h; hi++ {
+		work(hi)
+	}
 }

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -1125,18 +1125,8 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			// quantized weight, a and b the float one.
 			qzB := mmb(a, d.wQZ, d.qQZ, nil)
 			abB := mmb(a, d.wAB, nil, nil)
-			// Only the state carries between tokens, and it is not worth
-			// a goroutine per token here.
-			b.dstate.parallel = false
 			mixed := tensai.NewMatrix(n, d.vDim*d.heads)
-			for t := 0; t < n; t++ {
-				qz := qzB.Data[t*qzB.Cols : (t+1)*qzB.Cols]
-				ab := abB.Data[t*abB.Cols : (t+1)*abB.Cols]
-				res := d.mix(b.dstate, qz[:d.convDim], qz[d.convDim:],
-					ab[:d.heads], ab[d.heads:], m.dscratch)
-				copy(mixed.Data[t*mixed.Cols:(t+1)*mixed.Cols], res)
-			}
-			b.dstate.parallel = true
+			d.mixBatch(b.dstate, qzB, abB, mixed, m.dscratch)
 			outB := mmb(mixed, d.wOut, d.qOut, nil)
 			for i := range x.Data {
 				x.Data[i] += outB.Data[i]


### PR DESCRIPTION
A prefill on a qwen3_5 model used four of sixteen cores. The recurrence is only thirteen percent of the samples but it ran on one thread between batched matmuls, so it was half the wall clock. It is sequential in tokens and not in heads, so the loops swap: the convolution runs once over the sequence, and then each head walks the whole batch on its own state, one goroutine per layer instead of sixteen per token. Utilization goes from 402 to 881 percent and a 925-token prompt prefills in 4.7s against 8.1, with decode up from 24.6 to 25.5 tok/s. It is now faster than a qwen3 of a comparable size on the same prompt, which is the point of the architecture finally showing: eighteen of its twenty-four layers have no attention to grow quadratically. Output is unchanged in float32 and on the prompts checked in int8.