### PR TITLE
Spin on PAUSE between a token's fan-outs instead of sleeping

### DIFF
--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -22,6 +22,7 @@ import (
 	tensai "github.com/mattn/tensai"
 	"github.com/mattn/tensai/encoding/safetensors"
 	"github.com/mattn/tensai/internal/kernels"
+	"github.com/mattn/tensai/internal/workpool"
 	"github.com/mattn/tensai/quant"
 )
 
@@ -1322,21 +1323,15 @@ func (m *qwen) step(token, pos int) []float32 {
 
 		clear(attn)
 		steps := len(b.kc)
-		// Short contexts run the heads serially; past that the goroutine
+		// Short contexts run the heads serially; past that the dispatch
 		// cost disappears into the O(steps*headSz) work per head.
-		if workers := min(runtime.NumCPU(), cfg.Heads); workers > 1 && steps >= 64 {
-			var wg sync.WaitGroup
-			for w := 0; w < workers; w++ {
-				wg.Add(1)
-				go func(w int) {
-					defer wg.Done()
-					scores := make([]float64, steps)
-					for h := w; h < cfg.Heads; h += workers {
-						m.attendHead(b, q, attn, h, group, steps, scores)
-					}
-				}(w)
-			}
-			wg.Wait()
+		if runtime.NumCPU() > 1 && cfg.Heads > 1 && steps >= 64 {
+			workpool.Run(cfg.Heads, 1, func(lo, hi int) {
+				scores := make([]float64, steps)
+				for h := lo; h < hi; h++ {
+					m.attendHead(b, q, attn, h, group, steps, scores)
+				}
+			})
 		} else {
 			scores := make([]float64, steps)
 			for h := 0; h < cfg.Heads; h++ {

--- a/internal/workpool/pause_amd64.go
+++ b/internal/workpool/pause_amd64.go
@@ -1,0 +1,6 @@
+package workpool
+
+// pause executes the PAUSE instruction: it stalls the pipeline for tens
+// of cycles, releasing execution resources to the sibling hyperthread,
+// without yielding the P the way Gosched would.
+func pause()

--- a/internal/workpool/pause_amd64.s
+++ b/internal/workpool/pause_amd64.s
@@ -1,0 +1,5 @@
+#include "textflag.h"
+
+TEXT ·pause(SB), NOSPLIT, $0-0
+	PAUSE
+	RET

--- a/internal/workpool/pause_other.go
+++ b/internal/workpool/pause_other.go
@@ -1,0 +1,7 @@
+//go:build !amd64
+
+package workpool
+
+import "runtime"
+
+func pause() { runtime.Gosched() }

--- a/internal/workpool/pool.go
+++ b/internal/workpool/pool.go
@@ -1,0 +1,154 @@
+// Package workpool runs decode-time parallel work on resident workers.
+//
+// A decode step is ~100 short parallel regions (~200us each) per token,
+// and spawning goroutines puts a sleep/wake on every one of them: the
+// wake cost, not memory access, is what keeps the cycled-weight
+// bandwidth at 62% of a single sweep (see PERF-INVESTIGATION.md). ggml
+// hides it with a resident thread pool that spins on PAUSE between
+// regions. Earlier Go attempts substituted Gosched or a bare busy loop
+// for PAUSE and lost — a yielded P gets rescheduled, and a bare spin
+// starves the sibling hyperthread. This pool spins on the real PAUSE
+// instruction, briefly, then parks: within a token the next region
+// arrives in microseconds, so the spin window almost always absorbs it,
+// and the park bounds the burn between tokens and after decode ends.
+package workpool
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type op struct {
+	body   func(lo, hi int)
+	n      int
+	chunk  int
+	cursor atomic.Int64
+	left   atomic.Int64
+	chunks int64
+}
+
+var (
+	setupOnce sync.Once
+	workers   int
+	seq       atomic.Uint64
+	cur       atomic.Pointer[op]
+	parked    atomic.Int64
+	wake      chan struct{}
+	busy      atomic.Bool
+)
+
+// spinFor is how long a worker spins on PAUSE waiting for the next
+// region before parking. Regions inside one token are microseconds
+// apart; sampling between tokens is longer and should park. Swept over
+// 5us-2ms: shorter loses regions to parking mid-token, longer burns the
+// hyperthread siblings through the serial stretches for nothing.
+const spinFor = 20 * time.Microsecond
+
+func setup() {
+	workers = runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 0
+		return
+	}
+	wake = make(chan struct{}, workers)
+	for i := 0; i < workers-1; i++ {
+		go worker()
+	}
+}
+
+func worker() {
+	var last uint64
+	for {
+		if s := seq.Load(); s != last {
+			last = s
+			if o := cur.Load(); o != nil {
+				runOp(o)
+			}
+			continue
+		}
+		deadline := time.Now().Add(spinFor)
+		fresh := false
+		for !fresh {
+			for i := 0; i < 256; i++ {
+				if seq.Load() != last {
+					fresh = true
+					break
+				}
+				pause()
+			}
+			if !fresh && !time.Now().Before(deadline) {
+				break
+			}
+		}
+		if fresh {
+			continue
+		}
+		// Parking publishes parked before re-reading seq, and Run
+		// publishes seq before reading parked (both sequentially
+		// consistent), so a submit can miss this worker's increment only
+		// if the worker saw the new seq — no lost wakeup either way.
+		parked.Add(1)
+		if seq.Load() != last {
+			parked.Add(-1)
+			continue
+		}
+		<-wake
+		parked.Add(-1)
+	}
+}
+
+func runOp(o *op) {
+	for {
+		c := o.cursor.Add(1) - 1
+		if c >= o.chunks {
+			return
+		}
+		lo := int(c) * o.chunk
+		hi := min(lo+o.chunk, o.n)
+		o.body(lo, hi)
+		o.left.Add(-1)
+	}
+}
+
+// Run splits [0, n) into chunks whose bounds are multiples of align and
+// runs body over them on the resident workers, the caller included, and
+// returns when every chunk has finished. When the pool is disabled or
+// already mid-op the caller just runs the whole range itself.
+func Run(n, align int, body func(lo, hi int)) {
+	setupOnce.Do(setup)
+	if workers == 0 || !busy.CompareAndSwap(false, true) {
+		body(0, n)
+		return
+	}
+	chunk := ((n+workers-1)/workers + align - 1) &^ (align - 1)
+	if chunk <= 0 {
+		chunk = align
+	}
+	o := &op{body: body, n: n, chunk: chunk}
+	o.chunks = int64((n + chunk - 1) / chunk)
+	o.left.Store(o.chunks)
+	cur.Store(o)
+	seq.Add(1)
+	if p := parked.Load(); p > 0 {
+		for i := int64(0); i < p; i++ {
+			select {
+			case wake <- struct{}{}:
+			default:
+			}
+		}
+	}
+	runOp(o)
+	// The last chunks may still be running on workers; they are at most
+	// one region long, so waiting is short. The occasional yield keeps a
+	// preempted worker from deadlocking against a full complement of
+	// spinning peers.
+	for i := 0; o.left.Load() != 0; i++ {
+		pause()
+		if i&1023 == 1023 {
+			runtime.Gosched()
+		}
+	}
+	busy.Store(false)
+}

--- a/internal/workpool/pool_test.go
+++ b/internal/workpool/pool_test.go
@@ -1,0 +1,57 @@
+package workpool
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunCoversRange(t *testing.T) {
+	for _, tc := range []struct{ n, align int }{
+		{1003, 8}, {16, 8}, {1, 1}, {4864, 32}, {7, 16},
+	} {
+		hits := make([]int32, tc.n)
+		Run(tc.n, tc.align, func(lo, hi int) {
+			if lo < 0 || hi > tc.n || lo >= hi {
+				t.Errorf("n=%d align=%d: bad chunk [%d,%d)", tc.n, tc.align, lo, hi)
+				return
+			}
+			if lo%tc.align != 0 {
+				t.Errorf("n=%d align=%d: chunk start %d not aligned", tc.n, tc.align, lo)
+			}
+			for i := lo; i < hi; i++ {
+				atomic.AddInt32(&hits[i], 1)
+			}
+		})
+		for i, h := range hits {
+			if h != 1 {
+				t.Fatalf("n=%d align=%d: index %d covered %d times", tc.n, tc.align, i, h)
+			}
+		}
+	}
+}
+
+// Concurrent submitters contend for the single op slot; the losers must
+// still cover their whole range through the serial fallback.
+func TestRunConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for rep := 0; rep < 50; rep++ {
+				var sum atomic.Int64
+				Run(999, 8, func(lo, hi int) {
+					for i := lo; i < hi; i++ {
+						sum.Add(int64(i))
+					}
+				})
+				if got := sum.Load(); got != 999*998/2 {
+					t.Errorf("sum = %d, want %d", got, 999*998/2)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/quant/mxfp4.go
+++ b/quant/mxfp4.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/workpool"
 )
 
 // MXFP4Matrix is a weight matrix in microscaling FP4: 32-row groups per
@@ -75,12 +76,11 @@ func (q *MXFP4Matrix) MatVec(x, out []tensai.Float) error {
 			len(x), len(out), q.Rows, q.Cols)
 	}
 	xu, sx := quantizeActs(x)
-	workers := matvecWorkerCount(q.Cols, q.Rows)
-	if workers == 1 {
+	if matvecWorkerCount(q.Cols, q.Rows) == 1 {
 		mxfp4MatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, 0, q.Cols)
 		return nil
 	}
-	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+	workpool.Run(q.Cols, q4Tile, func(lo, hi int) {
 		mxfp4MatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 	})
 	return nil

--- a/quant/quant.go
+++ b/quant/quant.go
@@ -6,14 +6,17 @@ import (
 	"sync"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/workpool"
 )
 
 // matvecWorkerCount sizes the worker pool for quantized matvecs. Unlike
 // dotWorkerCount's cap of 8 (tuned for training matmuls that share the
 // machine with other layers), a decode matvec is the only thing running,
-// so it may use every CPU.
+// so it may use every CPU. The threshold sat at 1<<20 when splitting
+// meant spawning goroutines; on the resident workpool dispatch is cheap
+// enough that the sub-megabyte o-projection pays for itself too.
 func matvecWorkerCount(cols, rows int) int {
-	if cols*rows < 1<<20 {
+	if cols*rows < 1<<18 {
 		return 1
 	}
 	workers := runtime.GOMAXPROCS(0)
@@ -247,13 +250,12 @@ func (q *QMatrix) MatVec(x, out []tensai.Float) error {
 			len(x), len(out), q.Rows, q.Cols)
 	}
 	xu, sx := quantizeActs(x)
-	workers := matvecWorkerCount(q.Cols, q.Rows)
-	if workers == 1 {
+	if matvecWorkerCount(q.Cols, q.Rows) == 1 {
 		qmatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, 0, q.Cols)
 		return nil
 	}
 	// Chunks stay multiples of 8 so only the last one has a scalar tail.
-	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+	workpool.Run(q.Cols, q4Tile, func(lo, hi int) {
 		qmatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, q.Cols, lo, hi)
 	})
 	return nil

--- a/quant/quant4.go
+++ b/quant/quant4.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/workpool"
 )
 
 // q4Group is the number of input rows sharing one scale. 64 keeps
@@ -195,14 +196,13 @@ func (q *Q4Matrix) MatVec(x, out []tensai.Float) error {
 	for i, u := range xu {
 		gsum[min(i/grp, len(gsum)-1)] += int32(u) - 64
 	}
-	workers := matvecWorkerCount(q.Cols, q.Rows)
-	if workers == 1 {
+	if matvecWorkerCount(q.Cols, q.Rows) == 1 {
 		q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
 	// Tile-aligned chunks keep every worker's vector span inside whole
 	// layout tiles, and its memory walk sequential.
-	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+	workpool.Run(q.Cols, q4Tile, func(lo, hi int) {
 		q4matvecCols(out, xu, xq, sx, gsum, q.Q, q.Scale, q.ScaleMin, grp, q.Cols, lo, hi)
 	})
 	return nil

--- a/quant/quant8g.go
+++ b/quant/quant8g.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/workpool"
 )
 
 // q8Group is the number of input rows sharing one scale in a Q8GMatrix —
@@ -76,12 +77,11 @@ func (q *Q8GMatrix) MatVec(x, out []tensai.Float) error {
 	}
 	xu, sx := quantizeActs(x)
 	grp := q.group()
-	workers := matvecWorkerCount(q.Cols, q.Rows)
-	if workers == 1 {
+	if matvecWorkerCount(q.Cols, q.Rows) == 1 {
 		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, 0, q.Cols)
 		return nil
 	}
-	parallelChunks(q.Cols, workers, q4Tile, func(lo, hi int) {
+	workpool.Run(q.Cols, q4Tile, func(lo, hi int) {
 		q8gMatvecCols(out, xu, sx, q.Q, q.Scale, q.ColSum64, grp, q.Cols, lo, hi)
 	})
 	return nil


### PR DESCRIPTION
A decode step runs about a hundred short parallel regions per token, and spawning goroutines paid a sleep/wake on every one — the cost PERF-INVESTIGATION.md identified as the decode gap. This adds a resident worker pool that spins on the real PAUSE instruction for 20us between regions before parking, so the next region almost always lands on already-running workers. Earlier attempts failed by substituting Gosched or a bare busy loop for PAUSE. Dispatch is now cheap enough that the sub-megabyte o-projection parallelizes too. CPU decode goes 34.8 to 46.7 tok/s (llama.cpp -dev none at matched context: 50.7), prefill is unchanged, and greedy output is bit-identical.