### PR TITLE
Keep an oversized lm_head on the GPU and fuse decode's norms

### DIFF
--- a/gpu/wgpu_decode_bench_test.go
+++ b/gpu/wgpu_decode_bench_test.go
@@ -1,0 +1,145 @@
+//go:build wgpu || wgpu24
+
+package gpu
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/quant"
+)
+
+// The fused norm prologue must match the standalone rmsnorm_row dispatch
+// followed by the plain matvec bit for bit — greedy decode depends on it.
+func TestGPUMatMulRMSNorm(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+	rng := rand.New(rand.NewSource(65))
+	const rows, cols = 896, 300
+	q, err := g.UploadQ8(quant.Quantize(tensai.RandomMatrix(rows, cols, rng)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Free()
+	x, err := g.Upload(randTensor(rng, 1, rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer x.Free()
+	norm, err := g.Upload(randTensor(rng, rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer norm.Free()
+	bias, err := g.Upload(randTensor(rng, cols))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bias.Free()
+	const eps = 1e-6
+
+	fused, err := q.MatMulRMSNorm(x, norm, eps, bias, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fused.Free()
+	nx, err := x.RMSNorm(norm, eps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nx.Free()
+	split, err := q.MatMulOpts(nx, bias, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer split.Free()
+
+	gt, err := fused.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := split.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range wt.Data {
+		if gt.Data[i] != wt.Data[i] {
+			t.Fatalf("logit %d: fused %v != split %v", i, gt.Data[i], wt.Data[i])
+		}
+	}
+}
+
+// benchChain times a decode-shaped dispatch chain: single-row matvecs
+// bouncing between hidden and intermediate width, all recorded into one
+// submission the way step() records a token, flushed by one readback.
+// Varying the number of links at the same total weight traffic separates
+// the per-dispatch overhead from the streaming itself.
+func benchChain(b *testing.B, links, inter int) {
+	g, err := Open()
+	if err != nil {
+		b.Skipf("wgpu unavailable: %v", err)
+	}
+	defer g.Close()
+	rng := rand.New(rand.NewSource(64))
+	up, err := g.UploadQ8(quant.Quantize(tensai.RandomMatrix(896, inter, rng)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer up.Free()
+	down, err := g.UploadQ8(quant.Quantize(tensai.RandomMatrix(inter, 896, rng)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer down.Free()
+	x, err := g.Upload(randTensor(rng, 1, 896))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer x.Free()
+	run := func() {
+		if err := g.BeginBatch(); err != nil {
+			b.Fatal(err)
+		}
+		cur := x
+		for i := 0; i < links; i++ {
+			h, err := up.MatMul(cur)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if cur != x {
+				cur.Free()
+			}
+			o, err := down.MatMul(h)
+			if err != nil {
+				b.Fatal(err)
+			}
+			h.Free()
+			cur = o
+		}
+		out, err := cur.DownloadRange(0, 896)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = out
+		if cur != x {
+			cur.Free()
+		}
+	}
+	run()                                             // warm the pipelines outside the timing
+	b.SetBytes(int64(links) * 2 * 896 * int64(inter)) // int8 weight bytes per submission
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}
+
+// 24 links x 4864 wide is one token's worth of gate+down traffic in 48
+// dispatches; 6 links x 4x the width carries the same bytes in an eighth
+// of the dispatches.
+func BenchmarkGPUDecodeChain48(b *testing.B) { benchChain(b, 24, 4864) }
+func BenchmarkGPUDecodeChain12(b *testing.B) { benchChain(b, 6, 4864*4) }
+
+// 200 near-empty dependent dispatches: the per-dispatch latency floor a
+// decode step pays on every norm, rope, and cache copy.
+func BenchmarkGPUDecodeChainTiny(b *testing.B) { benchChain(b, 100, 64) }

--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -133,6 +133,11 @@ func (q *QMatrix) MatMul(x *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 // MatMulOpts always fails in builds without the wgpu tag.
 func (q *QMatrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 
+// MatMulRMSNorm always fails in builds without the wgpu tag.
+func (q *QMatrix) MatMulRMSNorm(x, norm *Tensor, eps float64, bias, dst *Tensor) (*Tensor, error) {
+	return nil, errNoWGPU
+}
+
 // Shape returns zeros in builds without the wgpu tag.
 func (q *QMatrix) Shape() (int, int) { return 0, 0 }
 
@@ -169,6 +174,11 @@ func (q *Q4Matrix) MatMul(x *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 
 // MatMulOpts always fails in builds without the wgpu tag.
 func (q *Q4Matrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) { return nil, errNoWGPU }
+
+// MatMulRMSNorm always fails in builds without the wgpu tag.
+func (q *Q4Matrix) MatMulRMSNorm(x, norm *Tensor, eps float64, bias, dst *Tensor) (*Tensor, error) {
+	return nil, errNoWGPU
+}
 
 // Shape returns zeros in builds without the wgpu tag.
 func (q *Q4Matrix) Shape() (int, int) { return 0, 0 }

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -652,17 +652,20 @@ fn attn_causal(@builtin(workgroup_id) wid: vec3<u32>,
 // folds the row splits before the guarded store. The split keeps a decode
 // matvec — parallelism = output columns only — wide enough to fill the
 // device.
-struct QMParams { rows: u32, cols: u32, words: u32, m: u32, flags: u32, pad0: u32, pad1: u32, pad2: u32 }
+struct QMParams { rows: u32, cols: u32, words: u32, m: u32, flags: u32, eps: f32, pad1: u32, pad2: u32 }
 @group(0) @binding(15) var<uniform> qp: QMParams;
 @group(0) @binding(16) var<storage, read> qwt: array<u32>;
 @group(0) @binding(17) var<storage, read> qsc: array<f32>;
 @group(0) @binding(18) var<storage, read> qxv: array<f32>;
 @group(0) @binding(19) var<storage, read_write> qov: array<f32>;
 @group(0) @binding(34) var<storage, read> qbias: array<f32>;
+@group(0) @binding(39) var<storage, read> qnormw: array<f32>;
 
 const QWG = 16u;    // packed words per workgroup
 const QSPLIT = 16u; // row splits sharing one word
+const QXS = 2048u;  // widest activation row the norm prologue stages
 var<workgroup> qred: array<vec4<f32>, 256>;
+var<workgroup> qxs: array<f32, QXS>;
 
 @compute @workgroup_size(256, 1, 1)
 fn qmatmul(@builtin(workgroup_id) wid: vec3<u32>,
@@ -671,16 +674,55 @@ fn qmatmul(@builtin(workgroup_id) wid: vec3<u32>,
     let rsub = lid.x / QWG;
     let r = wid.y;
     let xbase = r * qp.rows;
+    // Flag 4 folds the row's RMS normalization in as a prologue: every
+    // workgroup redundantly computes the same inverse rms — a pass over
+    // one row is nothing next to the weight stream — and stages the
+    // normalized row in shared memory, sparing decode a dependent
+    // dispatch per norm without touching the streaming loop's flops.
+    // The stride and the reduction tree mirror rmsnorm_row exactly, so
+    // the products match the standalone dispatch bit for bit. Callers
+    // set the flag only when the row fits QXS.
+    if ((qp.flags & 4u) != 0u) {
+        var ss = 0.0;
+        for (var i = lid.x; i < qp.rows; i = i + 256u) {
+            let v = qxv[xbase + i];
+            ss = ss + v * v;
+        }
+        qred[lid.x].x = ss;
+        workgroupBarrier();
+        for (var s = 128u; s > 0u; s = s >> 1u) {
+            if (lid.x < s) { qred[lid.x].x = qred[lid.x].x + qred[lid.x + s].x; }
+            workgroupBarrier();
+        }
+        let inv = inverseSqrt(qred[0].x / f32(qp.rows) + qp.eps);
+        workgroupBarrier(); // qred is reused by the column reduction below
+        for (var i = lid.x; i < qp.rows; i = i + 256u) {
+            qxs[i] = qxv[xbase + i] * inv * qnormw[i];
+        }
+        workgroupBarrier();
+    }
     var acc = vec4<f32>(0.0, 0.0, 0.0, 0.0);
     if (w < qp.words) {
-        for (var i = rsub; i < qp.rows; i = i + QSPLIT) {
-            let xv = qxv[xbase + i];
-            let pw = qwt[i * qp.words + w];
-            acc = acc + xv * vec4<f32>(
-                f32(i32(pw << 24u) >> 24u),
-                f32(i32(pw << 16u) >> 24u),
-                f32(i32(pw << 8u) >> 24u),
-                f32(i32(pw) >> 24u));
+        if ((qp.flags & 4u) != 0u) {
+            for (var i = rsub; i < qp.rows; i = i + QSPLIT) {
+                let xv = qxs[i];
+                let pw = qwt[i * qp.words + w];
+                acc = acc + xv * vec4<f32>(
+                    f32(i32(pw << 24u) >> 24u),
+                    f32(i32(pw << 16u) >> 24u),
+                    f32(i32(pw << 8u) >> 24u),
+                    f32(i32(pw) >> 24u));
+            }
+        } else {
+            for (var i = rsub; i < qp.rows; i = i + QSPLIT) {
+                let xv = qxv[xbase + i];
+                let pw = qwt[i * qp.words + w];
+                acc = acc + xv * vec4<f32>(
+                    f32(i32(pw << 24u) >> 24u),
+                    f32(i32(pw << 16u) >> 24u),
+                    f32(i32(pw << 8u) >> 24u),
+                    f32(i32(pw) >> 24u));
+            }
         }
     }
     qred[lid.x] = acc;
@@ -2790,8 +2832,32 @@ func (q *QMatrix) MatMul(x *Tensor) (*Tensor, error) {
 // then the returned tensor — when dst is non-nil. One dispatch instead
 // of a matmul plus one or two element-wise passes.
 func (q *QMatrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) {
-	if q.freed || x.freed || (bias != nil && bias.freed) || (dst != nil && dst.freed) {
+	return q.matmulF32(x, bias, dst, nil, 0)
+}
+
+// MatMulRMSNorm is MatMulOpts with out = rmsnorm(x, norm, eps) @ Q: the
+// single-row matvec runs the normalization as a kernel prologue — one
+// dependent dispatch fewer per decode norm — while a batch, whose
+// dispatch count is amortized anyway, norms in its own dispatch first.
+func (q *QMatrix) MatMulRMSNorm(x, norm *Tensor, eps float64, bias, dst *Tensor) (*Tensor, error) {
+	// 2048 is the QXS shared-memory stage in the kernel.
+	if x.Size() == q.rows && q.rows <= 2048 {
+		return q.matmulF32(x, bias, dst, norm, float32(eps))
+	}
+	nx, err := x.RMSNorm(norm, eps)
+	if err != nil {
+		return nil, err
+	}
+	defer nx.Free()
+	return q.matmulF32(nx, bias, dst, nil, 0)
+}
+
+func (q *QMatrix) matmulF32(x, bias, dst, norm *Tensor, eps float32) (*Tensor, error) {
+	if q.freed || x.freed || (bias != nil && bias.freed) || (dst != nil && dst.freed) || (norm != nil && norm.freed) {
 		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if norm != nil && norm.Size() != q.rows {
+		return nil, fmt.Errorf("tensai: gpu qmatmul norm length %d != %d rows", norm.Size(), q.rows)
 	}
 	if q.g != x.g {
 		return nil, errors.New("tensai: gpu tensors belong to different GPUs")
@@ -2842,28 +2908,38 @@ func (q *QMatrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) {
 	} else {
 		bufOut = g.takeOutBuffer(outBytes)
 	}
-	params := [8]uint32{uint32(q.rows), uint32(q.cols), uint32(q.words), uint32(m), flags}
+	normBuf, normSize := q.scales, uint64(q.words*4)*4 // dummy; flags gate the read
+	if norm != nil {
+		flags |= 4
+		normBuf, normSize = norm.buf, uint64(norm.Size())*4
+	}
+	params := [8]uint32{uint32(q.rows), uint32(q.cols), uint32(q.words), uint32(m), flags, math.Float32bits(eps)}
 	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32)
 	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 32, bufParams)
 	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 32)
 
-	entries := [6]wgpuBindGroupEntry{
+	entries := [7]wgpuBindGroupEntry{
 		{binding: 15, buffer: bufParams, size: 32},
 		{binding: 16, buffer: q.buf, size: uint64(q.rows*q.words) * 4},
 		{binding: 17, buffer: q.scales, size: uint64(q.words*4) * 4},
 		bind(18, x),
 		{binding: 19, buffer: bufOut, size: outBytes},
 		{binding: 34, buffer: biasBuf, size: biasSize},
+		{binding: 39, buffer: normBuf, size: normSize},
 	}
 	// A large batch takes the tiled GEMM, a small one the row-blocked
-	// kernel; a single row keeps the matvec shape.
-	pipe, lay, gy := g.pipes.qmatmul, g.pipes.layQmatmul, uint32(m)
+	// kernel; a single row keeps the matvec shape. Only the matvec's
+	// layout knows the norm binding, so the batched kernels drop it.
+	pipe, lay, bound := g.pipes.qmatmul, g.pipes.layQmatmul, entries[:]
+	gy := uint32(m)
 	if m >= 32 {
 		pipe, lay, gy = g.pipes.qmatmulT, g.pipes.layQmatmulT, uint32((m+63)/64)
+		bound = entries[:6]
 	} else if m > 1 {
 		pipe, lay, gy = g.pipes.qmatmulB, g.pipes.layQmatmulB, uint32((m+7)/8)
+		bound = entries[:6]
 	}
-	bindGroup := g.cachedBindGroup(lay, entries[:])
+	bindGroup := g.cachedBindGroup(lay, bound)
 	runtime.KeepAlive(&entries)
 
 	err := g.dispatch(pipe, bindGroup,
@@ -3441,6 +3517,17 @@ func (q *Q4Matrix) MatMul(x *Tensor) (*Tensor, error) {
 // MatMulOpts is MatMul with a fused epilogue: a per-column bias added
 // when bias is non-nil, and the product accumulated into dst — which is
 // then the returned tensor — when dst is non-nil.
+// MatMulRMSNorm matches QMatrix.MatMulRMSNorm; the 4-bit kernel has no
+// fused prologue, so the normalization always runs as its own dispatch.
+func (q *Q4Matrix) MatMulRMSNorm(x, norm *Tensor, eps float64, bias, dst *Tensor) (*Tensor, error) {
+	nx, err := x.RMSNorm(norm, eps)
+	if err != nil {
+		return nil, err
+	}
+	defer nx.Free()
+	return q.MatMulOpts(nx, bias, dst)
+}
+
 func (q *Q4Matrix) MatMulOpts(x, bias, dst *Tensor) (*Tensor, error) {
 	if q.freed || x.freed || (bias != nil && bias.freed) || (dst != nil && dst.freed) {
 		return nil, errors.New("tensai: gpu tensor already freed")

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -24,6 +24,7 @@ import (
 type gpuMat interface {
 	MatMul(*gpu.Tensor) (*gpu.Tensor, error)
 	MatMulOpts(x, bias, dst *gpu.Tensor) (*gpu.Tensor, error)
+	MatMulRMSNorm(x, norm *gpu.Tensor, eps float64, bias, dst *gpu.Tensor) (*gpu.Tensor, error)
 	Free()
 }
 
@@ -49,11 +50,15 @@ type gpuQwen struct {
 	nCtx   int
 	gpuLen int // cache positions currently valid on the GPU
 	// The final norm and lm_head, resident when the device's storage
-	// limit has room for the whole vocabulary projection. Both nil on a
-	// device that cannot hold it, and decode falls back to reading the
-	// hidden state back and finishing on the CPU.
-	gNorm  *gpu.Tensor
-	lmHead gpuMat
+	// limit has room for the vocabulary projection — in one piece when it
+	// fits, else as column slices with lmOff holding each slice's first
+	// column and lmLogits collecting the slices for the one readback.
+	// Empty on a device that cannot hold a slice, and decode falls back
+	// to reading the hidden state back and finishing on the CPU.
+	gNorm    *gpu.Tensor
+	lmHead   []gpuMat
+	lmOff    []int
+	lmLogits *gpu.Tensor
 }
 
 // sliceQ4 copies a column range out of a fused 4-bit quantized matrix;
@@ -142,6 +147,55 @@ func tryUp(g *gpu.Device, q *qmat) (gpuMat, error) {
 	return g.UploadQ4(q.q4)
 }
 
+// upLm uploads the lm_head, split into column slices when the whole
+// weight overflows the device's storage limit — an untied Q8 head over a
+// 150K vocabulary is a few MB past dozen's 128MiB, and one buffer too
+// many used to send the entire projection back to the CPU every token.
+func upLm(g *gpu.Device, q *qmat) ([]gpuMat, []int, error) {
+	var rows, cols int
+	var colBytes uint64
+	if q.q8 != nil {
+		rows, cols = q.q8.Rows, q.q8.Cols
+		colBytes = uint64(4 * ((rows + 3) / 4)) // one uploaded column, as UploadQ8 lays it out
+	} else {
+		rows, cols = q.q4.Rows, q.q4.Cols
+		colBytes = uint64(2 * ((rows + 3) / 4))
+	}
+	chunk := cols
+	if limit := g.StorageLimit(); limit != 0 && colBytes*uint64(cols) > limit {
+		// A megabyte of slack covers the scale table and padding; slice
+		// boundaries stay on 64 columns so every part copies whole tiles.
+		chunk = int((limit-1<<20)/colBytes) &^ 63
+		if chunk <= 0 {
+			return nil, nil, fmt.Errorf("device stores %d bytes, one lm_head column is %d", limit, colBytes)
+		}
+	}
+	var parts []gpuMat
+	var offs []int
+	for lo := 0; lo < cols; lo += chunk {
+		hi := min(lo+chunk, cols)
+		var part gpuMat
+		var err error
+		switch {
+		case lo == 0 && hi == cols:
+			part, err = tryUp(g, q)
+		case q.q8 != nil:
+			part, err = g.UploadQ8(sliceQ(q.q8, lo, hi))
+		default:
+			part, err = g.UploadQ4(sliceQ4(q.q4, lo, hi))
+		}
+		if err != nil {
+			for _, p := range parts {
+				p.Free()
+			}
+			return nil, nil, err
+		}
+		parts = append(parts, part)
+		offs = append(offs, lo)
+	}
+	return parts, offs, nil
+}
+
 // newGPUQwen uploads the model's transformer blocks to the GPU: the int8
 // weight twins, the norm weights and biases, and zeroed KV caches sized
 // for nCtx positions.
@@ -227,11 +281,14 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 	// the whole token, logits included, stays one submission. Devices
 	// with a smaller storage limit just miss out and keep the CPU path.
 	if q := m.qLmT; q != nil {
-		if lm, err := tryUp(g, q); err != nil {
+		if parts, offs, err := upLm(g, q); err != nil {
 			fmt.Fprintf(logw, "lm_head stays on the cpu: %v\n", err)
 		} else {
-			gq.lmHead = lm
+			gq.lmHead, gq.lmOff = parts, offs
 			gq.gNorm = vec(m.normW)
+			if len(parts) > 1 {
+				gq.lmLogits = must(g.Upload(tensai.NewTensor(1, m.cfg.Vocab)))
+			}
 		}
 	}
 	// Warm every kernel the decode and both prefill batch sizes touch:
@@ -252,15 +309,18 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 // it the three split weights each produce their own tensor and owner is
 // nil. Only decode can take the fused path: a multi-row result interleaves
 // q, k, and v per row, and no contiguous view covers that.
-func (gq *gpuQwen) qkv(l *gpuLayer, a *gpu.Tensor) (q, k, v, owner *gpu.Tensor) {
+func (gq *gpuQwen) qkv(l *gpuLayer, x *gpu.Tensor, norm *gpu.Tensor, eps float64) (q, k, v, owner *gpu.Tensor) {
 	if l.qQKV == nil {
-		return must(l.qq.MatMulOpts(a, l.bq, nil)),
-			must(l.qk.MatMulOpts(a, l.bk, nil)),
-			must(l.qv.MatMulOpts(a, l.bv, nil)), nil
+		// Each projection re-derives the same inverse rms in its
+		// prologue; that is still three dispatches against the four the
+		// standalone norm made it.
+		return must(l.qq.MatMulRMSNorm(x, norm, eps, l.bq, nil)),
+			must(l.qk.MatMulRMSNorm(x, norm, eps, l.bk, nil)),
+			must(l.qv.MatMulRMSNorm(x, norm, eps, l.bv, nil)), nil
 	}
 	hs := gq.m.cfg.Heads * gq.m.headSz
 	kvDim := gq.m.cfg.KVHeads * gq.m.headSz
-	f := must(l.qQKV.MatMulOpts(a, l.bQKV, nil))
+	f := must(l.qQKV.MatMulRMSNorm(x, norm, eps, l.bQKV, nil))
 	return must(f.View(0, 1, hs)),
 		must(f.View(hs, 1, kvDim)),
 		must(f.View(hs+kvDim, 1, kvDim)), f
@@ -441,9 +501,7 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 	}
 	for i := range gq.layers {
 		l := &gq.layers[i]
-		a := must(x.RMSNorm(l.ln1, cfg.RMSEps))
-		q, k, v, qkvOwner := gq.qkv(l, a)
-		a.Free()
+		q, k, v, qkvOwner := gq.qkv(l, x, l.ln1, cfg.RMSEps)
 		if l.qNorm != nil {
 			nq := must(q.RMSNormEach(l.qNorm, cfg.RMSEps))
 			q.Free()
@@ -457,11 +515,22 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 			if theta == 0 {
 				theta = cfg.RopeTheta
 			}
-			if err := q.RoPE(m.headSz, pos, theta); err != nil {
-				panic(err)
-			}
-			if err := k.RoPE(m.headSz, pos, theta); err != nil {
-				panic(err)
+			if qkvOwner != nil && l.qNorm == nil {
+				// q and k sit side by side in the fused row and the heads
+				// are uniform, so one dispatch rotates both. Every small
+				// dispatch in this chain costs ~40us of dependent-dispatch
+				// latency on dozen, which is worth more than the rotation.
+				qk := must(qkvOwner.View(0, 1, cfg.Heads*m.headSz+kvDim))
+				if err := qk.RoPE(m.headSz, pos, theta); err != nil {
+					panic(err)
+				}
+			} else {
+				if err := q.RoPE(m.headSz, pos, theta); err != nil {
+					panic(err)
+				}
+				if err := k.RoPE(m.headSz, pos, theta); err != nil {
+					panic(err)
+				}
 			}
 		}
 		if err := k.CopyRowsInto(l.kc, pos*kvDim); err != nil {
@@ -497,10 +566,8 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 			proj.Free()
 		}
 
-		a = must(x.RMSNorm(l.ln2, cfg.RMSEps))
-		gate := must(l.qGate.MatMul(a))
-		up := must(l.qUp.MatMul(a))
-		a.Free()
+		gate := must(l.qGate.MatMulRMSNorm(x, l.ln2, cfg.RMSEps, nil, nil))
+		up := must(l.qUp.MatMulRMSNorm(x, l.ln2, cfg.RMSEps, nil, nil))
 		if l.geglu {
 			if err := gate.GeluMul(up); err != nil {
 				panic(err)
@@ -526,13 +593,23 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 	}
 	// With the lm_head resident the norm and the vocabulary projection
 	// ride the same submission, and the one readback is the logits
-	// themselves — the hidden state never crosses back.
-	if gq.lmHead != nil {
-		a := must(x.RMSNorm(gq.gNorm, cfg.RMSEps))
-		logits := must(gq.lmHead.MatMul(a))
-		a.Free()
+	// themselves — the hidden state never crosses back. A sliced head
+	// gathers its parts into one tensor first: a Download flushes and
+	// waits, so two of them would cost a second round trip.
+	if len(gq.lmHead) == 1 {
+		logits := must(gq.lmHead[0].MatMulRMSNorm(x, gq.gNorm, cfg.RMSEps, nil, nil))
 		defer logits.Free()
 		return must(logits.Download()).Data
+	}
+	if len(gq.lmHead) > 1 {
+		for i, part := range gq.lmHead {
+			p := must(part.MatMulRMSNorm(x, gq.gNorm, cfg.RMSEps, nil, nil))
+			if err := p.CopyRowsInto(gq.lmLogits, gq.lmOff[i]); err != nil {
+				panic(err)
+			}
+			p.Free()
+		}
+		return must(gq.lmLogits.Download()).Data
 	}
 	xt := must(x.Download())
 	a := make([]float32, hs)


### PR DESCRIPTION
An untied Q8 lm_head over a 150K vocabulary is a few MB past dozen's 128MiB storage limit, so the GPU decode path was downloading the hidden state and running the whole 137MB vocabulary projection on the CPU every token — 72% of the profile. It now uploads in column slices, each slice's logits gathered by CopyRowsInto so one readback still returns the full row. A new chain benchmark puts dozen's dependent small-dispatch latency at ~38us, so the decode RMS norms run as a shared-memory prologue inside the single-row matvec (mirroring rmsnorm_row's reduction tree bit for bit, with a test asserting exact equality), and one RoPE dispatch rotates q and k together on the fused row. GPU decode goes 30.5 to 32.5 tok/s on Qwen2.5-0.5B Q8; greedy output is identical, CPU paths untouched.