### PR TITLE
Project gate and up in one dispatch and join them in another

### DIFF
--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -109,6 +109,9 @@ func (t *Tensor) Add(o *Tensor) error { return errNoWGPU }
 // SiluMul always fails in builds without the wgpu tag.
 func (t *Tensor) SiluMul(o *Tensor) error { return errNoWGPU }
 
+// GLUSplit always fails in builds without the wgpu tag.
+func (t *Tensor) GLUSplit(inter int, gelu bool) (*Tensor, error) { return nil, errNoWGPU }
+
 // CopyRowsInto always fails in builds without the wgpu tag.
 func (t *Tensor) CopyRowsInto(dst *Tensor, off int) error { return errNoWGPU }
 

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -1009,6 +1009,32 @@ fn slice_cols(@builtin(workgroup_id) wg: vec3<u32>,
     }
 }
 
+// glu_split joins a fused gate|up matmul result in one dispatch:
+// out[r][i] = act(src[r][i]) * src[r][inter+i], the activation silu or
+// (gelu != 0) gelu_tanh — the same expressions as silu_mul_ip and
+// gelu_mul_ip, so a fused projection matches the split one bit for bit.
+struct GSParams { rows: u32, inter: u32, gelu: u32, pad: u32 }
+@group(0) @binding(44) var<uniform> gsp: GSParams;
+
+@compute @workgroup_size(256, 1, 1)
+fn glu_split(@builtin(workgroup_id) wg: vec3<u32>,
+             @builtin(num_workgroups) nwg: vec3<u32>,
+             @builtin(local_invocation_id) lid: vec3<u32>) {
+    let idx = (wg.y * nwg.x + wg.x) * 256u + lid.x;
+    if (idx < gsp.rows * gsp.inter) {
+        let r = idx / gsp.inter;
+        let i = idx - r * gsp.inter;
+        let g = slsrc[r * 2u * gsp.inter + i];
+        let u = slsrc[r * 2u * gsp.inter + gsp.inter + i];
+        var a = g / (1.0 + exp(-g));
+        if (gsp.gelu != 0u) {
+            let inner = 0.7978845608028654 * (g + 0.044715 * g * g * g);
+            a = 0.5 * g * (1.0 + tanh(inner));
+        }
+        sldst[idx] = a * u;
+    }
+}
+
 // gelu_mul_ip: dst = gelu_tanh(dst) * src — Gemma's gate.
 @compute @workgroup_size(256, 1, 1)
 fn gelu_mul_ip(@builtin(workgroup_id) wg: vec3<u32>,
@@ -1744,6 +1770,7 @@ type gpuPipelines struct {
 	qacts, qmatmulI, attnF16, rowsToF16            uintptr
 	attnSplit, attnReduce, ropeCache               uintptr
 	layAttnSplit, layAttnReduce, layRopeCache      uintptr
+	gluSplit, layGluSplit                          uintptr
 	sliceCols, laySliceCols                        uintptr
 	layMatmul, layMatmulT, layMatmulS, layMatmulTS uintptr
 	layScale, laySoftmax, layAttn, layQmatmul      uintptr
@@ -1778,6 +1805,7 @@ func (g *Device) initPipelines() error {
 		{&g.pipes.attnG, &g.pipes.layAttnG, "attn_causal_g"},
 		{&g.pipes.qmatmulT, &g.pipes.layQmatmulT, "qmatmul_t"},
 		{&g.pipes.sliceCols, &g.pipes.laySliceCols, "slice_cols"},
+		{&g.pipes.gluSplit, &g.pipes.layGluSplit, "glu_split"},
 	} {
 		*x.pipe = g.makePipeline(x.entry)
 		if *x.pipe == 0 || uncapturedCB != "" {
@@ -3487,6 +3515,58 @@ func (t *Tensor) Add(o *Tensor) error {
 // joint, with t the gate projection and o the up projection.
 func (t *Tensor) SiluMul(o *Tensor) error {
 	return t.eltwiseIP(t.g.pipes.siluMulIP, t.g.pipes.laySiluMulIP, o)
+}
+
+// GLUSplit joins a fused gate|up projection: t holds rows of 2*inter
+// with gate in the first half and up in the second, and the result is
+// act(gate) * up per row — silu, or gelu_tanh when gelu is set. One
+// dispatch in place of the slice-out-and-multiply chain.
+func (t *Tensor) GLUSplit(inter int, gelu bool) (*Tensor, error) {
+	if t.freed {
+		return nil, errors.New("tensai: gpu tensor already freed")
+	}
+	if inter <= 0 || t.Size()%(2*inter) != 0 {
+		return nil, fmt.Errorf("tensai: glu split of %d elements into pairs of %d", t.Size(), inter)
+	}
+	rows := t.Size() / (2 * inter)
+	g := t.g
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	uncapturedCB = ""
+
+	outBytes := uint64(rows*inter) * 4
+	if err := g.checkSize(outBytes); err != nil {
+		return nil, err
+	}
+	bufOut := g.takeOutBuffer(outBytes)
+	var gu uint32
+	if gelu {
+		gu = 1
+	}
+	params := [4]uint32{uint32(rows), uint32(inter), gu, 0}
+	bufParams := g.takeBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16)
+	defer g.putBuffer(wgpuBufferUsageUniform|wgpuBufferUsageCopyDst, 16, bufParams)
+	fnQueueWriteBuffer(g.queue, bufParams, 0, unsafe.Pointer(&params[0]), 16)
+
+	entries := [3]wgpuBindGroupEntry{
+		{binding: 44, buffer: bufParams, size: 16},
+		bind(37, t),
+		{binding: 38, buffer: bufOut, size: outBytes},
+	}
+	bindGroup := g.cachedBindGroup(g.pipes.layGluSplit, entries[:])
+	runtime.KeepAlive(&entries)
+
+	x, y := split2D((rows*inter + gpuKernelWG - 1) / gpuKernelWG)
+	if err := g.dispatch(g.pipes.gluSplit, bindGroup, x, y, 1); err != nil {
+		g.dropBuffer(bufOut)
+		return nil, err
+	}
+	return &Tensor{g: g, buf: bufOut, shape: []int{rows, inter}}, nil
 }
 
 // GeluMul computes t = gelu_tanh(t) * o elementwise in place — Gemma's

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -29,18 +29,18 @@ type gpuMat interface {
 }
 
 type gpuLayer struct {
-	ln1, ln2                          *gpu.Tensor
-	qNorm, kNorm                      *gpu.Tensor // Qwen3/Gemma QK-norm; nil otherwise
-	postAttn, postFFN                 *gpu.Tensor // Gemma sandwich norms; nil otherwise
-	noPE                              bool
-	window                            int
-	ropeTheta                         float64
-	geglu                             bool
-	bq, bk, bv                        *gpu.Tensor
-	bQKV                              *gpu.Tensor // fused q|k|v bias, when the split aligns
-	qQKV                              gpuMat      // fused q|k|v projection; nil when split
-	qq, qk, qv, qo, qGate, qUp, qDown gpuMat
-	kc, vc                            *gpu.Tensor // [nCtx, kvDim]
+	ln1, ln2                   *gpu.Tensor
+	qNorm, kNorm               *gpu.Tensor // Qwen3/Gemma QK-norm; nil otherwise
+	postAttn, postFFN          *gpu.Tensor // Gemma sandwich norms; nil otherwise
+	noPE                       bool
+	window                     int
+	ropeTheta                  float64
+	geglu                      bool
+	bq, bk, bv                 *gpu.Tensor
+	bQKV                       *gpu.Tensor // fused q|k|v bias, when the split aligns
+	qQKV                       gpuMat      // fused q|k|v projection; nil when split
+	qq, qk, qv, qo, qGU, qDown gpuMat
+	kc, vc                     *gpu.Tensor // [nCtx, kvDim]
 }
 
 type gpuQwen struct {
@@ -208,7 +208,6 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 		return must(g.Upload(&tensai.Tensor{Shape: []int{len(v)}, Data: v}))
 	}
 	hs := m.cfg.Heads * m.headSz // query dimension; equals hidden except qwen3
-	inter := m.cfg.Intermediate
 	gq := &gpuQwen{m: m, g: g, nCtx: nCtx, layers: make([]gpuLayer, len(m.blocks))}
 	// A half-precision KV cache halves the resident cache when the device
 	// has shader-f16 and the model's head grouping fits the f16 kernel.
@@ -263,8 +262,9 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw io.Writer) (*gpuQwen, err
 			l.qv = upSlice(b.qQKV, hs+kvDim, hs+2*kvDim)
 		}
 		l.qo = up(b.qo)
-		l.qGate = upSlice(b.qGU, 0, inter)
-		l.qUp = upSlice(b.qGU, inter, 2*inter)
+		// gate and up stay one fused weight: one dispatch projects both,
+		// and glu_split joins the halves.
+		l.qGU = up(b.qGU)
 		l.qDown = up(b.qDown)
 		if useF16 {
 			l.kc = must(g.NewF16Tensor(nCtx, kvDim))
@@ -448,17 +448,10 @@ func (gq *gpuQwen) prefillChunk(tokens []int, startPos int) []float32 {
 		}
 
 		a = must(x.RMSNorm(l.ln2, cfg.RMSEps))
-		gate := must(l.qGate.MatMul(a))
-		up := must(l.qUp.MatMul(a))
+		gu := must(l.qGU.MatMul(a))
 		a.Free()
-		if l.geglu {
-			if err := gate.GeluMul(up); err != nil {
-				panic(err)
-			}
-		} else if err := gate.SiluMul(up); err != nil {
-			panic(err)
-		}
-		up.Free()
+		gate := must(gu.GLUSplit(cfg.Intermediate, l.geglu))
+		gu.Free()
 		if l.postFFN == nil {
 			must(l.qDown.MatMulOpts(gate, nil, x))
 			gate.Free()
@@ -589,16 +582,9 @@ func (gq *gpuQwen) step(token, pos int) []float32 {
 			proj.Free()
 		}
 
-		gate := must(l.qGate.MatMulRMSNorm(x, l.ln2, cfg.RMSEps, nil, nil))
-		up := must(l.qUp.MatMulRMSNorm(x, l.ln2, cfg.RMSEps, nil, nil))
-		if l.geglu {
-			if err := gate.GeluMul(up); err != nil {
-				panic(err)
-			}
-		} else if err := gate.SiluMul(up); err != nil {
-			panic(err)
-		}
-		up.Free()
+		gu := must(l.qGU.MatMulRMSNorm(x, l.ln2, cfg.RMSEps, nil, nil))
+		gate := must(gu.GLUSplit(cfg.Intermediate, l.geglu))
+		gu.Free()
 		if l.postFFN == nil {
 			must(l.qDown.MatMulOpts(gate, nil, x))
 			gate.Free()


### PR DESCRIPTION
The loader already fuses the gate and up weights, but the GPU path sliced them apart at upload and paid two projections plus an in-place join per layer. Uploading the fused weight lets one matmul cover both halves — decode's fused norm prologue runs once instead of twice — and the new glu_split kernel joins them with the same silu/gelu expressions as the in-place kernels, so outputs stay bit-identical. Decode and prefill both drop a dispatch per layer, and no extra weight memory is used. GPU decode goes 40.8 to 42.3 tok/s at a 400-token context (30.5 at the start of this effort, llama.cpp Vulkan 48.0); greedy output is unchanged.