### PR TITLE
Rescue tool calls a model writes into its text

### DIFF
--- a/internal/llm/serve.go
+++ b/internal/llm/serve.go
@@ -465,6 +465,80 @@ func parseToolCalls(s string) (string, []toolCall) {
 	return strings.TrimSpace(text.String()), calls
 }
 
+// parseLooseToolCalls rescues a call the model wrote into its text
+// instead of its trained format: a ```json fenced block — or the whole
+// turn — holding {"name": ..., "arguments": {...}} whose name matches a
+// declared tool. Four-bit sub-1B models keep the intent to call but
+// lose the tag discipline, and without this they answer as prose and
+// the agent loop never runs the tool. Requiring a known name keeps a
+// reply that merely shows JSON from being swallowed.
+func parseLooseToolCalls(s string, tools []toolDef) (string, []toolCall) {
+	known := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		known[t.Function.Name] = true
+	}
+	try := func(body string) (toolCall, bool) {
+		var call struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &call); err != nil || !known[call.Name] {
+			return toolCall{}, false
+		}
+		args := strings.TrimSpace(string(call.Arguments))
+		if args == "" || args == "null" {
+			args = "{}"
+		}
+		return toolCall{Type: "function", Function: callFunc{Name: call.Name, Arguments: args}}, true
+	}
+	add := func(calls []toolCall, c toolCall) []toolCall {
+		idx := len(calls)
+		c.Index = &idx
+		c.ID = fmt.Sprintf("call_%d", idx)
+		return append(calls, c)
+	}
+	var calls []toolCall
+	var text strings.Builder
+	rest := s
+	for {
+		i := strings.Index(rest, "```")
+		if i < 0 {
+			text.WriteString(rest)
+			break
+		}
+		after := rest[i+3:]
+		body, tail := after, ""
+		closed := false
+		if j := strings.Index(after, "```"); j >= 0 {
+			body, tail, closed = after[:j], after[j+3:], true
+		}
+		// Drop a language word on the fence line ("json", "tool_code", ...).
+		if k := strings.IndexByte(body, '\n'); k >= 0 && len(strings.Fields(body[:k])) <= 1 {
+			body = body[k+1:]
+		}
+		if c, ok := try(body); ok {
+			text.WriteString(rest[:i])
+			calls = add(calls, c)
+		} else if closed {
+			text.WriteString(rest[:i+3] + after[:len(after)-len(tail)])
+		} else {
+			text.WriteString(rest)
+			break
+		}
+		rest = tail
+		if !closed {
+			break
+		}
+	}
+	if len(calls) == 0 {
+		if c, ok := try(s); ok {
+			return "", add(nil, c)
+		}
+		return s, nil
+	}
+	return strings.TrimSpace(text.String()), calls
+}
+
 // parseXMLToolCalls does for Qwen3.5 what parseToolCalls does for the
 // Hermes families: it splits a finished turn into what the model meant
 // to say and the calls it emitted. The block opens with the same
@@ -776,8 +850,12 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	// writes before it answers is reasoning, not content, and clients
 	// that show the two differently need them apart.
 	var send func(field, piece string)
+	// streamed counts the content bytes already sent, so text held back
+	// on a false call marker can go out after the final parse clears it.
+	streamed := 0
 	flush := func(piece string) {
 		if send != nil && piece != "" {
+			streamed += len(piece)
 			send("content", piece)
 		}
 	}
@@ -818,17 +896,24 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		held.WriteString(piece)
 		text := held.String()
-		if i := strings.Index(text, "<tool_call>"); i >= 0 {
-			sawCall = true
-			held.Reset()
-			if i > 0 {
-				flush(text[:i])
+		// A fence can open a call a weak model writes as plain JSON (see
+		// parseLooseToolCalls); held text that turns out to be ordinary
+		// content goes out after the final parse, via streamed.
+		for _, marker := range []string{"<tool_call>", "```"} {
+			if i := strings.Index(text, marker); i >= 0 {
+				sawCall = true
+				held.Reset()
+				if i > 0 {
+					flush(text[:i])
+				}
+				return
 			}
-			return
 		}
 		keep := 0
 		if !final {
-			keep = partialMarker(text, "<tool_call>")
+			for _, marker := range []string{"<tool_call>", "```"} {
+				keep = max(keep, partialMarker(text, marker))
+			}
 		}
 		held.Reset()
 		held.WriteString(text[len(text)-keep:])
@@ -1004,14 +1089,21 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		} else {
 			content, calls = parseToolCalls(content)
 		}
+		if len(calls) == 0 {
+			content, calls = parseLooseToolCalls(content, tools)
+		}
 		if len(calls) > 0 {
 			finish = "tool_calls"
 		}
 	}
-
 	if req.Stream {
 		if len(pend) > 0 {
 			push("", true)
+		}
+		// Text held back on a marker that never became a call still
+		// belongs to the client.
+		if len(calls) == 0 && len(content) > streamed {
+			flush(content[streamed:])
 		}
 		// The calls go out as deltas of their own, one chunk each and
 		// complete, so a client accumulating fragments by index ends up

--- a/internal/llm/serve_tools_test.go
+++ b/internal/llm/serve_tools_test.go
@@ -366,3 +366,39 @@ func TestToolSignaturesMatchPythonJSON(t *testing.T) {
 		t.Errorf("signature is not written the way the template writes it:\ngot:  %s\nwant: %s", got, want)
 	}
 }
+
+func TestParseLooseToolCalls(t *testing.T) {
+	tools := []toolDef{weatherTool()}
+	for _, tt := range []struct {
+		name, in  string
+		wantText  string
+		wantCalls int
+		wantFn    string
+		wantArgs  string
+	}{
+		{"fenced json call", "```json\n{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Osaka\"}}\n```", "", 1, "get_weather", `{"city": "Osaka"}`},
+		{"fence without lang", "```\n{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Osaka\"}}\n```", "", 1, "get_weather", `{"city": "Osaka"}`},
+		{"unterminated fence", "```json\n{\"name\": \"get_weather\", \"arguments\": {}}", "", 1, "get_weather", "{}"},
+		{"bare object turn", `{"name": "get_weather", "arguments": {"city": "Osaka"}}`, "", 1, "get_weather", `{"city": "Osaka"}`},
+		{"text around call", "調べます。\n```json\n{\"name\": \"get_weather\", \"arguments\": {}}\n```\n以上", "調べます。\n\n以上", 1, "get_weather", "{}"},
+		{"unknown tool stays text", "```json\n{\"name\": \"rm_rf\", \"arguments\": {}}\n```", "```json\n{\"name\": \"rm_rf\", \"arguments\": {}}\n```", 0, "", ""},
+		{"ordinary code block", "例です:\n```go\nfmt.Println(1)\n```", "例です:\n```go\nfmt.Println(1)\n```", 0, "", ""},
+		{"plain text", "こんにちは", "こんにちは", 0, "", ""},
+	} {
+		text, calls := parseLooseToolCalls(tt.in, tools)
+		if len(calls) != tt.wantCalls {
+			t.Fatalf("%s: got %d calls, want %d", tt.name, len(calls), tt.wantCalls)
+		}
+		if strings.TrimSpace(text) != strings.TrimSpace(tt.wantText) {
+			t.Errorf("%s: text %q, want %q", tt.name, text, tt.wantText)
+		}
+		if tt.wantCalls == 1 {
+			if calls[0].Function.Name != tt.wantFn {
+				t.Errorf("%s: name %q", tt.name, calls[0].Function.Name)
+			}
+			if calls[0].Function.Arguments != tt.wantArgs {
+				t.Errorf("%s: args %q, want %q", tt.name, calls[0].Function.Arguments, tt.wantArgs)
+			}
+		}
+	}
+}


### PR DESCRIPTION
A four-bit sub-1B model keeps the intent to call — the right tool, plausible arguments — but writes the JSON into its answer as a fenced block instead of the trained <tool_call> tag, so the agent loop never runs the tool and the model invents the result. When the tag parsers find nothing, a fenced (or whole-turn) {"name": ..., "arguments": ...} object naming a declared tool now becomes a proper tool_calls entry with finish_reason tool_calls; requiring a declared name keeps replies that merely show JSON from being swallowed. Streaming holds text back at a code fence the way it already does at <tool_call>, and anything held on a fence that never becomes a call is flushed after the final parse, so ordinary fenced answers still arrive intact. Verified end to end with yagi against Qwen3-0.6B Q4_K_M served by tensai: a run_command turn that previously ended as prose now executes and answers from the real output.