### PR TITLE
Download a gguf the way safetensors repos already download

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -48,7 +48,7 @@ Run "tensai <command> -h" for the command's flags.`
 // Options they fill.
 func modelFlags(fs *flag.FlagSet) (*llm.Options, func()) {
 	o := &llm.Options{Log: os.Stderr}
-	model := fs.String("model", "", `which model to run: a name from "tensai models", a path to a directory or .gguf, or a Hugging Face repo to download`)
+	model := fs.String("model", "", `which model to run: a name from "tensai models", a path to a directory or .gguf, a Hugging Face repo to download, or org/repo/file.gguf for one of its gguf files`)
 	q8 := fs.Bool("q8", false, "decode against int8-quantized weights")
 	q4 := fs.Bool("q4", false, "decode against int4-quantized weights (group-wise)")
 	fs.BoolVar(&o.GPU, "gpu", false, "decode on the GPU (requires -q8 or -q4 and a wgpu build tag)")
@@ -127,13 +127,8 @@ func resolveModel(o *llm.Options, ref string) error {
 			return local(ref)
 		}
 	}
-	// A reference that can only be a filesystem path must exist: letting
-	// an absolute path or a .gguf name fall through would send it to the
-	// network as if it were a repo and leave a junk directory named after
-	// the typo in the cache.
-	if filepath.IsAbs(ref) || strings.HasSuffix(ref, ".gguf") {
-		return fmt.Errorf("no model at %s", ref)
-	}
+	// A cached model by bare name — gguf files included, so the name
+	// "tensai models" prints is always a valid reference.
 	root := llm.CacheRoot()
 	if ref == filepath.Base(ref) {
 		for _, cand := range []string{ref, ref + ".gguf"} {
@@ -143,6 +138,22 @@ func resolveModel(o *llm.Options, ref string) error {
 			}
 			return local(p)
 		}
+	}
+	// org/repo/file.gguf names one file in a Hugging Face repo: download
+	// it into the cache root, where the listing and a bare name find it.
+	if strings.HasSuffix(ref, ".gguf") && !filepath.IsAbs(ref) && strings.Count(ref, "/") == 2 {
+		p, err := llm.FetchGGUF(ref)
+		if err != nil {
+			return err
+		}
+		return local(p)
+	}
+	// A reference that can only be a filesystem path must exist: letting
+	// an absolute path or a .gguf name fall through would send it to the
+	// network as if it were a repo and leave a junk directory named after
+	// the typo in the cache.
+	if filepath.IsAbs(ref) || strings.HasSuffix(ref, ".gguf") {
+		return fmt.Errorf("no model at %s", ref)
 	}
 	// Nothing local: the last reading that can still work is a repo, and
 	// a repo has an org, so a bare name here is simply not found.

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -571,6 +571,22 @@ func fetchOnce(base, dir, name, tmp string) (retry bool, err error) {
 	return false, nil
 }
 
+// FetchGGUF downloads one GGUF file from a Hugging Face repo — a
+// reference of the form org/repo/file.gguf — into the cache root and
+// returns the local path. The file keeps its own name and lands beside
+// the other cached ggufs, so "tensai models" lists it and a later bare
+// file name finds it. An already-downloaded file returns immediately,
+// and a partial one resumes.
+func FetchGGUF(ref string) (string, error) {
+	parts := strings.Split(ref, "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" ||
+		!strings.HasSuffix(parts[2], ".gguf") || parts[2] == ".gguf" {
+		return "", fmt.Errorf("gguf reference %q is not org/repo/file.gguf", ref)
+	}
+	base := "https://huggingface.co/" + parts[0] + "/" + parts[1] + "/resolve/main/"
+	return fetch(base, CacheRoot(), parts[2])
+}
+
 // progressReader reports download progress on stderr, at most twice a
 // second so slow terminals don't throttle the transfer.
 type progressReader struct {

--- a/internal/llm/fetch_test.go
+++ b/internal/llm/fetch_test.go
@@ -174,3 +174,19 @@ func TestFetchDoesNotRetryNotFound(t *testing.T) {
 		t.Errorf("a 404 was retried %d times", n-1)
 	}
 }
+
+func TestFetchGGUFRejectsBadRefs(t *testing.T) {
+	for _, ref := range []string{
+		"file.gguf",              // no repo
+		"repo/file.gguf",         // no org
+		"org/repo/sub/file.gguf", // nested path
+		"org/repo/file",          // not a gguf
+		"org//file.gguf",         // empty repo
+		"//file.gguf",            // empty org and repo
+		"org/repo/.gguf",         // no file name
+	} {
+		if _, err := FetchGGUF(ref); err == nil {
+			t.Errorf("FetchGGUF(%q): expected an error", ref)
+		}
+	}
+}


### PR DESCRIPTION
A safetensors repo downloads itself on first -model use, but a gguf had to be curled by hand from the resolve URL. -model org/repo/file.gguf now fetches that one file into the cache root through the same resuming, retrying fetch the repos use; "tensai models" lists it, models rm removes it with its repack caches, and a bare file name loads it afterwards. The bare-gguf-name cache lookup also moves ahead of the path-must-exist guard from #171 — its typo protection stays, but the name the listing prints is now always a valid reference. Verified end to end against Hugging Face (download, load, generate; a bad ref errors without leaving anything in the cache).