### PR TITLE
Name a downloaded gguf by the repo it came from

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -454,8 +454,12 @@ func modelsCmd(args []string) error {
 			return fmt.Errorf("usage: tensai models rm <name>...")
 		}
 		for _, name := range args[1:] {
-			// The listing may print an org/name, which is what a user
-			// copies; the cache directory is only ever the last element.
+			// The listing may print an org/name — or org/repo/file.gguf
+			// for a downloaded gguf — which is what a user copies; the
+			// cached entry is only ever the last element.
+			if strings.Count(name, "/") == 2 && strings.HasSuffix(name, ".gguf") {
+				name = name[strings.LastIndex(name, "/")+1:]
+			}
 			if org, base, ok := strings.Cut(name, "/"); ok {
 				if org == "" || org != filepath.Base(org) || org == "." || org == ".." ||
 					strings.Contains(base, "/") {
@@ -475,8 +479,9 @@ func modelsCmd(args []string) error {
 			}
 			fmt.Println("removed", target)
 			if strings.HasSuffix(name, ".gguf") {
-				// The repack caches live beside their gguf.
-				caches, _ := filepath.Glob(target + ".tensai-*.cache")
+				// The repack caches and the origin sidecar live beside
+				// their gguf.
+				caches, _ := filepath.Glob(target + ".tensai-*")
 				for _, c := range caches {
 					if os.Remove(c) == nil {
 						fmt.Println("removed", c)
@@ -524,7 +529,14 @@ func modelsCmd(args []string) error {
 					}
 				}
 			}
-			emit(ent.Name(), fmt.Sprintf("%-40s %8s  %-8s %-11s %s", ent.Name(), humanSize(size), "gguf",
+			name := ent.Name()
+			// A downloaded gguf lists under its repo, and the full
+			// org/repo/file.gguf it prints is itself a -model reference
+			// that fetches the same file elsewhere.
+			if repo := llm.GGUFOrigin(filepath.Join(root, ent.Name())); repo != "" {
+				name = repo + "/" + ent.Name()
+			}
+			emit(name, fmt.Sprintf("%-40s %8s  %-8s %-11s %s", name, humanSize(size), "gguf",
 				llm.Inspect(filepath.Join(root, ent.Name())), newest.Format("2006-01-02")))
 			total += size
 			found = true

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -584,7 +584,44 @@ func FetchGGUF(ref string) (string, error) {
 		return "", fmt.Errorf("gguf reference %q is not org/repo/file.gguf", ref)
 	}
 	base := "https://huggingface.co/" + parts[0] + "/" + parts[1] + "/resolve/main/"
-	return fetch(base, CacheRoot(), parts[2])
+	p, err := fetch(base, CacheRoot(), parts[2])
+	if err == nil {
+		recordGGUFOrigin(p, parts[0]+"/"+parts[1])
+	}
+	return p, err
+}
+
+// recordGGUFOrigin is recordOrigin for a single cached gguf file, which
+// has no directory of its own: the repo lands in a sidecar next to it.
+func recordGGUFOrigin(path, repo string) {
+	if path == "" || !strings.Contains(repo, "/") {
+		return
+	}
+	p := path + originSidecar
+	if b, err := os.ReadFile(p); err == nil && string(b) == repo {
+		return
+	}
+	os.WriteFile(p, []byte(repo), 0o644)
+}
+
+// originSidecar suffixes a cached gguf's origin marker.
+const originSidecar = ".tensai-origin"
+
+// GGUFOrigin returns the org/repo a cached gguf was downloaded from, or
+// "" when no valid record exists. The full reference the listing prints
+// — org/repo/file.gguf — downloads the same file on another machine.
+func GGUFOrigin(path string) string {
+	b, err := os.ReadFile(path + originSidecar)
+	if err != nil {
+		return ""
+	}
+	repo := strings.TrimSpace(string(b))
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" ||
+		strings.ContainsAny(repo, `\`) || strings.Contains(repo, "..") {
+		return ""
+	}
+	return repo
 }
 
 // progressReader reports download progress on stderr, at most twice a

--- a/internal/llm/origin_test.go
+++ b/internal/llm/origin_test.go
@@ -52,3 +52,26 @@ func TestRecordOriginNeedsARepo(t *testing.T) {
 		t.Errorf("a bare name was recorded as an origin")
 	}
 }
+
+func TestGGUFOrigin(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "model.gguf")
+	if err := os.WriteFile(p, []byte("GGUF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := GGUFOrigin(p); got != "" {
+		t.Fatalf("no sidecar: got %q", got)
+	}
+	recordGGUFOrigin(p, "org/repo")
+	if got := GGUFOrigin(p); got != "org/repo" {
+		t.Fatalf("got %q, want org/repo", got)
+	}
+	for _, bad := range []string{"norepo", "a/b/c", "..", `or\g/repo`, "org/.."} {
+		if err := os.WriteFile(p+originSidecar, []byte(bad), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := GGUFOrigin(p); got != "" {
+			t.Fatalf("sidecar %q: got %q, want empty", bad, got)
+		}
+	}
+}


### PR DESCRIPTION
A cached model directory lists under its org via .tensai-origin, but a downloaded gguf listed as a bare file name that says nothing about where it came from. FetchGGUF now records the repo in a sidecar beside the file, the listing prints org/repo/file.gguf — itself a valid -model reference that fetches the same file on another machine, keeping the rule that every name the listing prints can be typed back — and models rm accepts that printed form and removes the sidecar along with the repack caches.