### PR TITLE
Block prefill attention so the wide kernels engage

### DIFF
--- a/internal/llm/attnblock.go
+++ b/internal/llm/attnblock.go
@@ -1,0 +1,97 @@
+package llm
+
+import (
+	"math"
+
+	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/kernels"
+)
+
+// attendGroupBlock is attendGroup over a block of consecutive query
+// rows. attendGroup streams each cached K and V row once per call, so a
+// prefill at group 2 reloads every row for every second dot — the 8-wide
+// dot and axpy kernels sit idle. Blocking qb rows lifts the fan-out to
+// nq = qb*group dots per K load, which is where the long-context prefill
+// spent nine tenths of its time. Row r of the block attends its own
+// steps0+r positions: the shared prefix runs through the wide kernels
+// and the ragged causal tail runs per row, in the same per-element
+// order as attendGroup, so the output stays bit-identical.
+//
+// qrs[r] is row r's query slice (group heads of this KV head already
+// offset out), ars[r] its output slice. ws needs (steps0+qb)*nq floats,
+// si steps0+qb, packO nq*headSz; sliding-window layers take the per-row
+// path instead.
+func (m *qwen) attendGroupBlock(b *qblock, qrs, ars [][]float32, kh, group, steps0 int, ws, si, packQ, packO []float32) {
+	d := m.headSz
+	qb := len(qrs)
+	nq := qb * group
+	kvOff := kh * d
+	scale := float32(1 / math.Sqrt(float64(d)))
+
+	// Shared prefix: every row of the block sees positions [0, steps0).
+	for r, qr := range qrs {
+		copy(packQ[r*group*d:(r+1)*group*d], qr[:group*d])
+	}
+	for j := 0; j < steps0; j++ {
+		tensai.DotVecs(packQ, b.kc[j][kvOff:kvOff+d], ws[j*nq:(j+1)*nq])
+	}
+	// The causal tail: row r alone sees positions [steps0, steps0+r].
+	for r := 1; r < qb; r++ {
+		for j := steps0; j < steps0+r; j++ {
+			tensai.DotVecs(packQ[r*group*d:(r+1)*group*d], b.kc[j][kvOff:kvOff+d],
+				ws[j*nq+r*group:j*nq+(r+1)*group])
+		}
+	}
+
+	for r := 0; r < qb; r++ {
+		steps := steps0 + r
+		for i := 0; i < group; i++ {
+			// Same gather-scale-exp-normalize as attendGroup, one
+			// (row, head) at a time over that row's own length.
+			maxs := float32(math.Inf(-1))
+			for j := 0; j < steps; j++ {
+				s := ws[j*nq+r*group+i] * scale
+				si[j] = s
+				if s > maxs {
+					maxs = s
+				}
+			}
+			h := kh*group + i
+			if b.sinks != nil && b.sinks[h] > maxs {
+				maxs = b.sinks[h]
+			}
+			kernels.ExpShift(si[:steps], si[:steps], maxs)
+			var sum float32
+			for _, v := range si[:steps] {
+				sum += v
+			}
+			if b.sinks != nil {
+				sum += kernels.ExpF(b.sinks[h] - maxs)
+			}
+			inv := 1 / sum
+			for j := 0; j < steps; j++ {
+				ws[j*nq+r*group+i] = si[j] * inv
+			}
+		}
+	}
+
+	// Value accumulation, one V load for the whole block on the shared
+	// prefix. The tail entries of ws for rows past their own limit were
+	// never written, and are never read either: the tail loops below run
+	// exactly each row's own positions.
+	for i := range packO[:nq*d] {
+		packO[i] = 0
+	}
+	for j := 0; j < steps0; j++ {
+		tensai.Axpys(ws[j*nq:(j+1)*nq], b.vc[j][kvOff:kvOff+d], packO[:nq*d])
+	}
+	for r := 1; r < qb; r++ {
+		for j := steps0; j < steps0+r; j++ {
+			tensai.Axpys(ws[j*nq+r*group:j*nq+(r+1)*group], b.vc[j][kvOff:kvOff+d],
+				packO[r*group*d:(r+1)*group*d])
+		}
+	}
+	for r, ar := range ars {
+		copy(ar[:group*d], packO[r*group*d:(r+1)*group*d])
+	}
+}

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -1166,29 +1166,66 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			}
 
 			// Causal attention: row t sees cache positions [0, startPos+t].
-			// Rows are independent, so they fan out across CPUs.
+			// Rows are independent, so they fan out across CPUs — in blocks
+			// sized so the dots per K load land on the 8-wide kernels, which
+			// keeps a several-thousand-token prefill from drowning in
+			// attention (see attendGroupBlock). Sliding windows shift the
+			// start per row, so they keep the row path.
+			qb := max(1, 8/group)
+			if qb == 1 {
+				qb = 2
+			}
+			if b.window > 0 {
+				qb = 1
+			}
 			attn := tensai.NewMatrix(n, qDim)
 			var wg sync.WaitGroup
-			rowCh := make(chan int, n)
-			for t := 0; t < n; t++ {
+			rowCh := make(chan int, (n+qb-1)/qb)
+			for t := 0; t < n; t += qb {
 				rowCh <- t
 			}
 			close(rowCh)
-			for w := min(runtime.NumCPU(), n); w > 0; w-- {
+			nq := qb * group
+			dh := m.headSz
+			for w := min(runtime.NumCPU(), (n+qb-1)/qb); w > 0; w-- {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					scores := make([]float32, group*(startPos+n))
-					ws := make([]float32, group*(startPos+n))
-					for t := range rowCh {
-						steps := startPos + t + 1
-						qr := qkv.Data[t*qkvW : t*qkvW+qDim]
+					ws := make([]float32, (startPos+n+qb)*nq)
+					si := make([]float32, startPos+n+qb)
+					packQ := make([]float32, nq*dh)
+					packO := make([]float32, nq*dh)
+					qrs := make([][]float32, qb)
+					ars := make([][]float32, qb)
+					qrow := func(t int) []float32 {
 						if cfg.AttnOutputGate {
-							qr = qbuf[t*qDim : (t+1)*qDim]
+							return qbuf[t*qDim : (t+1)*qDim]
 						}
-						ar := attn.Data[t*qDim : (t+1)*qDim]
+						return qkv.Data[t*qkvW : t*qkvW+qDim]
+					}
+					for t0 := range rowCh {
+						tEnd := min(t0+qb, n)
+						if tEnd-t0 < qb || qb == 1 {
+							// A short final block (and the window path) runs
+							// row by row, exactly as before.
+							for t := t0; t < tEnd; t++ {
+								steps := startPos + t + 1
+								qr := qrow(t)
+								ar := attn.Data[t*qDim : (t+1)*qDim]
+								for kh := 0; kh < cfg.KVHeads; kh++ {
+									m.attendGroup(b, qr, ar, kh, group, steps, scores, ws)
+								}
+							}
+							continue
+						}
 						for kh := 0; kh < cfg.KVHeads; kh++ {
-							m.attendGroup(b, qr, ar, kh, group, steps, scores, ws)
+							qOff := kh * group * dh
+							for r := 0; r < qb; r++ {
+								qrs[r] = qrow(t0 + r)[qOff : qOff+group*dh]
+								ars[r] = attn.Data[(t0+r)*qDim+qOff : (t0+r)*qDim+qOff+group*dh]
+							}
+							m.attendGroupBlock(b, qrs, ars, kh, group, startPos+t0+1, ws, si, packQ, packO)
 						}
 					}
 				}()


### PR DESCRIPTION
attendGroup streams each cached K and V row once per query row, so a family with a small head group (Qwen3-0.6B shares a KV head between just two query heads) feeds the 8-wide dot and axpy kernels two lanes at a time — and a long prefill drowns in attention: 88% of a 4K-token profile, throughput falling from 210 to 54 tok/s between 400 and 4K tokens. Fanning the query rows out in blocks of ceil(8/group) lifts the dots per K load onto the existing 8-wide kernels; no new kernels. The shared causal prefix runs blocked and the ragged tail runs per row in attendGroup's exact per-element order, so greedy output is bit-identical — verified against the previous build on qwen2 (group 7), qwen3 (group 2), and qwen3.5. Measured prefill on Qwen3-0.6B Q4_K_M: 401 tokens 213 to 231 tok/s, 2K 128 to 179, 4K 67 to 125. Sliding-window layers keep the per-row path.