### PR TITLE
Run blocked attention eight rows deep on the eight-wide kernels

### DIFF
--- a/internal/kernels/dispatch_simd.go
+++ b/internal/kernels/dispatch_simd.go
@@ -530,6 +530,11 @@ func DotVecs(qs, k []float32, out []float32) {
 		return
 	}
 	i := 0
+	// Eights first: one k load feeds eight dots, and a blocked caller
+	// arrives with a multiple of eight.
+	for ; i+8 <= len(out); i += 8 {
+		dotVec8(qs[i*d:(i+8)*d], k, out[i:i+8])
+	}
 	for ; i+4 <= len(out); i += 4 {
 		dotVec4(qs[i*d:(i+4)*d], k, out[i:i+4])
 	}
@@ -650,6 +655,10 @@ func Axpys(ws []float32, v, outs []float32) {
 		return
 	}
 	i := 0
+	// Eights first, as in DotVecs: one v load feeds eight rows.
+	for ; i+8 <= len(ws); i += 8 {
+		axpy8(ws[i:i+8], v, outs[i*d:(i+8)*d])
+	}
 	for ; i+4 <= len(ws); i += 4 {
 		axpy4(ws[i:i+4], v, outs[i*d:(i+4)*d])
 	}

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -1171,10 +1171,10 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			// keeps a several-thousand-token prefill from drowning in
 			// attention (see attendGroupBlock). Sliding windows shift the
 			// start per row, so they keep the row path.
-			qb := max(1, 8/group)
-			if qb == 1 {
-				qb = 2
-			}
+			// Eight rows per block puts nq on a multiple of eight — every
+			// dot and axpy runs the 8-wide kernel — and halves the passes
+			// over the K and V arrays besides.
+			qb := 8
 			if b.window > 0 {
 				qb = 1
 			}


### PR DESCRIPTION
The DotVecs and Axpys dispatchers chunked odd widths in fours, so a group-7 attention block (nq 14) ran dotVec4 three times and dotVec2 once per cached K row — the 4K-token profile showed exactly that split at the top. The dispatchers now take eights first, and the prefill attention block grows to eight query rows, so every head grouping lands nq on a multiple of eight and the number of passes over the K and V arrays halves besides. Greedy output stays bit-identical (each dot and each accumulation row is computed independently, in the same order). Prefill at 4K tokens: Qwen2.5-0.5B q8 240 to 279 tok/s (llama.cpp CPU: 301), Qwen3-0.6B q4 127 to 137; 401-token prefill is unchanged. Benchmarked on AC power after establishing that a battery-power sag had contaminated an earlier reading.