### PR TITLE
Unpack K two lanes per load in the f16 attention kernels

### DIFF
--- a/gpu/wgpu_scaling_bench_test.go
+++ b/gpu/wgpu_scaling_bench_test.go
@@ -1,0 +1,68 @@
+//go:build wgpu || wgpu24
+
+package gpu
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/mattn/tensai"
+)
+
+// benchAttnAt times one 512-query prefill chunk attending seqKV cached
+// positions — the shape of the last chunk of a long prompt, where the
+// grouped kernel spends its time.
+func benchAttnAt(b *testing.B, seqKV int) {
+	g, err := Open()
+	if err != nil {
+		b.Skipf("wgpu unavailable: %v", err)
+	}
+	defer g.Close()
+	rng := rand.New(rand.NewSource(9))
+	const heads, kvHeads, dh = 14, 2, 64
+	const d, kvDim = heads * dh, kvHeads * dh
+	const seqQ = 512
+	upload := func(f *tensai.Tensor) *Tensor {
+		if g.HasF16() {
+			c, err := g.NewF16Tensor(seqKV, kvDim)
+			if err != nil {
+				b.Fatal(err)
+			}
+			src, err := g.Upload(f)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := src.CopyRowsInto(c, 0); err != nil {
+				b.Fatal(err)
+			}
+			src.Free()
+			return c
+		}
+		gt, err := g.Upload(f)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return gt
+	}
+	gk := upload(randTensor(rng, seqKV, kvDim))
+	defer gk.Free()
+	gv := upload(randTensor(rng, seqKV, kvDim))
+	defer gv.Free()
+	gq, err := g.Upload(randTensor(rng, seqQ, d))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer gq.Free()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := gq.GroupedCausalAttention(gk, gv, heads, kvHeads, seqKV, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		out.Free()
+	}
+}
+
+func BenchmarkGPUAttnChunk1K(b *testing.B) { benchAttnAt(b, 1024) }
+func BenchmarkGPUAttnChunk2K(b *testing.B) { benchAttnAt(b, 2048) }
+func BenchmarkGPUAttnChunk4K(b *testing.B) { benchAttnAt(b, 4000) }

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -1346,7 +1346,10 @@ struct APParams { seqQ: u32, seqKV: u32, dh: u32, d: u32, rows: u32, off: u32, d
 @group(0) @binding(3) var<storage, read> offs: array<vec4<u32>>;
 @group(0) @binding(10) var<uniform> ap: APParams;
 @group(0) @binding(11) var<storage, read> aq: array<f32>;
-@group(0) @binding(12) var<storage, read> akh: array<f16>;
+// K is bound as u32 words: the QK loop unpacks two f16 lanes per load,
+// halving its load instructions against per-element f16 reads. V keeps
+// the f16 view — its loop is lane-coalesced already.
+@group(0) @binding(12) var<storage, read> akh: array<u32>;
 @group(0) @binding(13) var<storage, read> avh: array<f16>;
 @group(0) @binding(14) var<storage, read_write> aout: array<f32>;
 
@@ -1411,16 +1414,17 @@ fn attn_causal_gh(@builtin(workgroup_id) wid: vec3<u32>,
         var d0 = 0.0; var d1 = 0.0; var d2 = 0.0; var d3 = 0.0;
         var d4 = 0.0; var d5 = 0.0; var d6 = 0.0; var d7 = 0.0;
         if (valid) {
-            for (var c = 0u; c < ap.dh; c = c + 1u) {
-                let kv = f32(akh[offKV + j * ap.dkv + c]);
-                d0 = d0 + qrow_h[c] * kv;
-                d1 = d1 + qrow_h[ap.dh + c] * kv;
-                d2 = d2 + qrow_h[2u * ap.dh + c] * kv;
-                d3 = d3 + qrow_h[3u * ap.dh + c] * kv;
-                d4 = d4 + qrow_h[4u * ap.dh + c] * kv;
-                d5 = d5 + qrow_h[5u * ap.dh + c] * kv;
-                d6 = d6 + qrow_h[6u * ap.dh + c] * kv;
-                d7 = d7 + qrow_h[7u * ap.dh + c] * kv;
+            let kbase = (offKV + j * ap.dkv) >> 1u;
+            for (var c = 0u; c < ap.dh; c = c + 2u) {
+                let kv = unpack2x16float(akh[kbase + (c >> 1u)]);
+                d0 = d0 + qrow_h[c] * kv.x + qrow_h[c + 1u] * kv.y;
+                d1 = d1 + qrow_h[ap.dh + c] * kv.x + qrow_h[ap.dh + c + 1u] * kv.y;
+                d2 = d2 + qrow_h[2u * ap.dh + c] * kv.x + qrow_h[2u * ap.dh + c + 1u] * kv.y;
+                d3 = d3 + qrow_h[3u * ap.dh + c] * kv.x + qrow_h[3u * ap.dh + c + 1u] * kv.y;
+                d4 = d4 + qrow_h[4u * ap.dh + c] * kv.x + qrow_h[4u * ap.dh + c + 1u] * kv.y;
+                d5 = d5 + qrow_h[5u * ap.dh + c] * kv.x + qrow_h[5u * ap.dh + c + 1u] * kv.y;
+                d6 = d6 + qrow_h[6u * ap.dh + c] * kv.x + qrow_h[6u * ap.dh + c + 1u] * kv.y;
+                d7 = d7 + qrow_h[7u * ap.dh + c] * kv.x + qrow_h[7u * ap.dh + c + 1u] * kv.y;
             }
             d0 = d0 * scale; d1 = d1 * scale; d2 = d2 * scale; d3 = d3 * scale;
             d4 = d4 * scale; d5 = d5 * scale; d6 = d6 * scale; d7 = d7 * scale;
@@ -1620,16 +1624,17 @@ fn attn_split_gh(@builtin(workgroup_id) wid: vec3<u32>,
         var d0 = 0.0; var d1 = 0.0; var d2 = 0.0; var d3 = 0.0;
         var d4 = 0.0; var d5 = 0.0; var d6 = 0.0; var d7 = 0.0;
         if (valid) {
-            for (var c = 0u; c < ap.dh; c = c + 1u) {
-                let kv = f32(akh[offKV + j * ap.dkv + c]);
-                d0 = d0 + qrow_h[c] * kv;
-                d1 = d1 + qrow_h[ap.dh + c] * kv;
-                d2 = d2 + qrow_h[2u * ap.dh + c] * kv;
-                d3 = d3 + qrow_h[3u * ap.dh + c] * kv;
-                d4 = d4 + qrow_h[4u * ap.dh + c] * kv;
-                d5 = d5 + qrow_h[5u * ap.dh + c] * kv;
-                d6 = d6 + qrow_h[6u * ap.dh + c] * kv;
-                d7 = d7 + qrow_h[7u * ap.dh + c] * kv;
+            let kbase = (offKV + j * ap.dkv) >> 1u;
+            for (var c = 0u; c < ap.dh; c = c + 2u) {
+                let kv = unpack2x16float(akh[kbase + (c >> 1u)]);
+                d0 = d0 + qrow_h[c] * kv.x + qrow_h[c + 1u] * kv.y;
+                d1 = d1 + qrow_h[ap.dh + c] * kv.x + qrow_h[ap.dh + c + 1u] * kv.y;
+                d2 = d2 + qrow_h[2u * ap.dh + c] * kv.x + qrow_h[2u * ap.dh + c + 1u] * kv.y;
+                d3 = d3 + qrow_h[3u * ap.dh + c] * kv.x + qrow_h[3u * ap.dh + c + 1u] * kv.y;
+                d4 = d4 + qrow_h[4u * ap.dh + c] * kv.x + qrow_h[4u * ap.dh + c + 1u] * kv.y;
+                d5 = d5 + qrow_h[5u * ap.dh + c] * kv.x + qrow_h[5u * ap.dh + c + 1u] * kv.y;
+                d6 = d6 + qrow_h[6u * ap.dh + c] * kv.x + qrow_h[6u * ap.dh + c + 1u] * kv.y;
+                d7 = d7 + qrow_h[7u * ap.dh + c] * kv.x + qrow_h[7u * ap.dh + c + 1u] * kv.y;
             }
             d0 = d0 * scale; d1 = d1 * scale; d2 = d2 * scale; d3 = d3 * scale;
             d4 = d4 * scale; d5 = d5 * scale; d6 = d6 * scale; d7 = d7 * scale;


### PR DESCRIPTION
The QK loop of attn_causal_gh and attn_split_gh read the half-precision K cache one f16 element at a time — 64 scalar loads per lane per cached row, and the profile of a long prefill sits in exactly that loop. Binding K as u32 words and unpacking two lanes per load (unpack2x16float) halves the loop's load instructions; every accumulator still adds its products in the same order, so outputs stay bit-identical — the existing f16 reference tests and an end-to-end greedy diff both hold. A chunk-shaped benchmark now tracks the kernel at 1K/2K/4K contexts. Measured on Qwen2.5-0.5B Q8: prefill at 4K tokens 738 to 839 tok/s (llama.cpp Vulkan 1131), at 2K 1291 to 1378, 401 unchanged; decode at a 400-token context 42.8 to 56.8 tok/s.