### PR TITLE
Make the autograd engine n-dimensional and recycle its buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 - **Matrix operations** - `Matrix` plus basic operations such as `Dot`, `Add`, `T`, and `AddBias`. Tensors are float32 (`tensai.Float`)
-- **N-dimensional tensors** - `Tensor` generalizes `Matrix` to any rank: element-wise `Add`/`Sub`/`Mul`/`Div` with NumPy-style broadcasting, batched `MatMul` (the leading axes broadcast, the per-matrix products run on the same kernel as `Dot`, parallelized across the batch), axis-permuting `Transpose`, `Reshape` with `-1` inference, and zero-copy views to and from `Matrix`
+- **N-dimensional tensors** - `Tensor` generalizes `Matrix` to any rank: element-wise `Add`/`Sub`/`Mul`/`Div` with NumPy-style broadcasting, batched `MatMul` (the leading axes broadcast, the per-matrix products run on the same kernel as `Dot`, parallelized across the batch) plus its transposed forms `MatMulTN` and `MatMulNT`, so a backward pass never materializes a transposed copy, axis-permuting `Transpose`, `Reshape` with `-1` inference, and zero-copy views to and from `Matrix`
 - **SIMD acceleration** - AVX2 kernels written with Go's experimental `simd/archsimd` package: still pure Go, no cgo, no assembly files. Matmul, ReLU/LeakyReLU, Sigmoid/Tanh/Softmax (via a vectorized polynomial `exp`), GELU (via a vectorized `erf`), LayerNorm, and the Adam update are all 8-lane vectorized. Build with `GOEXPERIMENT=simd` on amd64 (Go 1.26 and 1.27 APIs both supported via build tags); every other build uses the portable fallbacks automatically
 - **Low-allocation training** - layers reuse their forward/backward scratch buffers across training steps (a full MLP step runs in ~29 allocations), so GC stays out of the training loop; `Predict` always returns freshly allocated results
 - **Layers** - `Embedding`, `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `LayerNorm`, `Dropout`, plus `ReLU`, `LeakyReLU`, `GELU`, `Sigmoid`, `Tanh`, and `Softmax` activations
@@ -22,7 +22,7 @@
 - **k-NN baseline** - a `knn.Classifier` whose distance matrix runs on the same SIMD matmul kernel; useful as a no-training baseline next to the networks
 - **Dataset utilities** - `Dataset` pairs inputs with targets and provides `Shuffle`, train/test `Split` (copy-free views), buffer-reusing mini-batch iteration with `Batches`, and `Standardize`/`StandardizeWith`
 - **Sequential models** - stack layers and run `Compile` -> `Fit` / `FitStep` -> `Predict`
-- **Automatic differentiation** - a micrograd-style reverse-mode autograd engine over matrices (`Param` / `Input` / `Backward`), for models that don't fit the Sequential mold; `ToDot` renders the computation graph for Graphviz
+- **Automatic differentiation** - a micrograd-style reverse-mode autograd engine over n-dimensional tensors (`Param` / `Input` / `Backward`), for models that don't fit the Sequential mold. Values are `Tensor`s, so the same ops run on (batch, seq, model) activations: broadcasting element-wise arithmetic, batched `MatMul`, `Transpose`/`Reshape`, last-axis `Softmax`, axis reductions, `LayerNorm`, embedding `Embed`, and `CrossEntropy` all carry gradients, and a `Matrix` is still accepted anywhere a leaf is built. `ToDot` renders the computation graph for Graphviz
 - **Recurrence and attention** - `rnn.Cell`, `rnn.LSTMCell`, and single-head `rnn.SelfAttention` built on the autograd engine, with backpropagation through time handled automatically
 - **Serialization** - `Save`/`Load` (and `SaveFile`/`LoadFile`) round-trip trained Sequential parameters as JSON, including BatchNorm running statistics; `SaveParams`/`LoadParams` do the same for autograd parameters (RNN/LSTM/attention cells)
 - **TFLite export** - the `encoding/tflite` package marshals Sequential models (FP32, NHWC) into `.tflite` flatbuffers that run on the TFLite/LiteRT runtimes and [go-tflite](https://github.com/mattn/go-tflite), with the FlatBuffers writer implemented in-tree — still no dependencies
@@ -243,7 +243,7 @@ w2 := autograd.Param(tensai.RandomMatrix(8, 1, rng))
 trainer := autograd.NewTrainer(optim.NewAdam(0.05), w1, b1, w2)
 
 for step := 0; step < 2000; step++ {
-	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y)
+	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y.Tensor())
 	trainer.Step(loss) // backward + update + zero grads, returns the loss value
 }
 ```
@@ -252,7 +252,9 @@ For manual control, the pieces are still public: `loss.Backward()`, `p.Grad`, an
 
 The graph a loss node holds can be visualized: `loss.ToDot()` returns Graphviz DOT (label leaves with `.Named("w1")`), so `go run ./_example/dot | dot -Tsvg > graph.svg` draws the network the same way Gorgonia's encoding/dot does.
 
-Graphs are built dynamically per step (define-by-run) and are single-use. Available ops: `MatMul`, `Add`, `Sub`, `MulElem`, `Scale`, `AddRow`, `T`, `Softmax`, `ReLU`, `Sigmoid`, `Tanh`, `Sum`, `Mean`, `MSELoss`, and `SoftmaxCELoss`. Shape mismatches panic during graph construction. Every op's gradient is verified against finite differences in the test suite.
+A `Tape` recycles the buffers a step allocates — `tape.Bind(params...)` once, `tape.Reset()` after each step — which takes `_example/charrnn` from 22MB of allocation per training step to 0.75MB and about a quarter off its wall time; nothing from the finished step may be read after `Reset`. The same reuse is available one layer down through the `MatMulInto` / `AddInto` family, as `DotInto` has always offered for matrices.
+
+Graphs are built dynamically per step (define-by-run) and are single-use. Available ops: `MatMul` (batched, with broadcast leading axes), `Add`, `Sub`, `Mul`/`MulElem`, `Div`, `Scale`, `Neg`, `AddRow`, `T`/`Transpose`, `Reshape`, `Softmax` (last axis), `Sum`, `Mean`, `SumAxis`/`MeanAxis`, `LayerNorm`, `Embed`, `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, `GELU`, `Exp`, `Log`, `MSELoss`, `SoftmaxCELoss`, and `CrossEntropy`. Element-wise ops broadcast NumPy-style, and a gradient is summed back over whatever axes an operand was stretched along. Shape mismatches panic during graph construction. Every op's gradient is verified against finite differences in the test suite.
 
 ### Recurrent networks and attention
 
@@ -270,7 +272,7 @@ for step := 0; step < epochs; step++ {
 		h, c = cell.Step(autograd.Input(x), h, c)
 	}
 	logits := h.MatMul(wOut).AddRow(bOut)
-	trainer.Step(logits.SoftmaxCELoss(labels))
+	trainer.Step(logits.CrossEntropy(labels)) // labels is a []int of class indices
 }
 ```
 

--- a/_example/charrnn/main.go
+++ b/_example/charrnn/main.go
@@ -73,11 +73,11 @@ func (m *charModel) loss(text []rune, pos []int) *autograd.Node {
 	for t := 0; t < seqLen; t++ {
 		logits, hn, cn := m.step(autograd.Input(m.oneHot(text, pos, t)), h, c)
 		h, c = hn, cn
-		targets := tensai.NewMatrix(len(pos), 1)
+		targets := make([]int, len(pos))
 		for i, p := range pos {
-			targets.Data[i] = float32(m.index[text[p+t+1]])
+			targets[i] = m.index[text[p+t+1]]
 		}
-		l := logits.SoftmaxCELoss(targets)
+		l := logits.CrossEntropy(targets)
 		if total == nil {
 			total = l
 		} else {
@@ -143,12 +143,20 @@ func main() {
 	model := newCharModel(vocab, rng)
 	trainer := autograd.NewTrainer(optim.NewAdam(0.01), model.params()...)
 
+	// Unrolling 32 steps builds a large graph every iteration. Binding the
+	// parameters to a tape lets each iteration reuse the previous one's
+	// buffers instead of allocating them again: nothing from the finished
+	// step may be read after Reset, which suits a training loop exactly.
+	tape := autograd.NewTape()
+	tape.Bind(model.params()...)
+
 	for it := 1; it <= iters; it++ {
 		pos := make([]int, batchSize)
 		for i := range pos {
 			pos[i] = rng.Intn(len(text) - seqLen - 1)
 		}
 		lossVal := trainer.Step(model.loss(text, pos))
+		tape.Reset()
 		if it == 1 || it%50 == 0 {
 			fmt.Printf("iter %4d: loss=%.4f\n", it, lossVal)
 		}

--- a/autograd/autograd.go
+++ b/autograd/autograd.go
@@ -2,35 +2,67 @@ package autograd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/dims"
 	"github.com/mattn/tensai/internal/kernels"
-	"github.com/mattn/tensai/loss"
 	"github.com/mattn/tensai/optim"
 )
 
-// Node is a matrix-valued node in a dynamically built computation graph for
+// Node is a tensor-valued node in a dynamically built computation graph for
 // reverse-mode automatic differentiation. Build the forward computation by
 // chaining operations, then call Backward on the (scalar) result to fill
 // Grad on every Param node that contributed to it.
 //
+// Values are n-dimensional: a Matrix is accepted anywhere a leaf is built
+// and becomes a zero-copy 2-D tensor view, so the two-dimensional API from
+// before keeps working, and the same ops run on (batch, seq, model) shaped
+// activations. Element-wise ops broadcast NumPy-style and MatMul multiplies
+// stacks of matrices, exactly as tensai.Tensor does.
+//
 // Unlike the Layer API, shape mismatches panic: graph construction errors
 // are programming errors, and error returns would make chaining unusable.
 //
-//	w := tensai.Param(tensai.RandomMatrix(2, 8, rng))
-//	b := tensai.Param(tensai.NewMatrix(1, 8))
-//	loss := tensai.Input(x).MatMul(w).AddRow(b).ReLU().MSELoss(y)
+//	w := autograd.Param(tensai.RandomMatrix(2, 8, rng))
+//	b := autograd.Param(tensai.NewMatrix(1, 8))
+//	loss := autograd.Input(x).MatMul(w).Add(b).ReLU().MSELoss(y.Tensor())
 //	loss.Backward()
 //	// w.Grad and b.Grad now hold dLoss/dw and dLoss/db.
 type Node struct {
-	Value *tensai.Matrix
-	Grad  *tensai.Matrix
+	Value *tensai.Tensor
+	Grad  *tensai.Tensor
 
 	parents      []*Node
 	backFn       func()
+	tape         *Tape // buffer pool this graph draws from, if any
 	requiresGrad bool
 	op           string // operation that produced this node ("" for leaves)
 	name         string // optional display name for ToDot
+}
+
+// Array is the constraint for the array types a graph leaf can wrap. A
+// Matrix is taken as a zero-copy 2-D tensor view, so a parameter built from
+// a Matrix keeps sharing that matrix's backing data.
+type Array interface {
+	*tensai.Matrix | *tensai.Tensor
+}
+
+// tensorOf views v as a tensor without copying.
+func tensorOf[T Array](v T) *tensai.Tensor {
+	switch x := any(v).(type) {
+	case *tensai.Matrix:
+		if x == nil {
+			panic("tensai: nil matrix")
+		}
+		return x.Tensor()
+	case *tensai.Tensor:
+		if x == nil {
+			panic("tensai: nil tensor")
+		}
+		return x
+	}
+	panic("tensai: unreachable")
 }
 
 // Named sets a display name shown by ToDot and returns the node.
@@ -39,16 +71,16 @@ func (n *Node) Named(name string) *Node {
 	return n
 }
 
-// Input wraps a matrix as a constant graph leaf. No gradient is computed
-// for it.
-func Input(m *tensai.Matrix) *Node {
-	return &Node{Value: m}
+// Input wraps a matrix or tensor as a constant graph leaf. No gradient is
+// computed for it.
+func Input[T Array](v T) *Node {
+	return &Node{Value: tensorOf(v)}
 }
 
-// Param wraps a matrix as a trainable graph leaf. Backward accumulates its
-// gradient into Grad.
-func Param(m *tensai.Matrix) *Node {
-	return &Node{Value: m, requiresGrad: true}
+// Param wraps a matrix or tensor as a trainable graph leaf. Backward
+// accumulates its gradient into Grad.
+func Param[T Array](v T) *Node {
+	return &Node{Value: tensorOf(v), requiresGrad: true}
 }
 
 // ZeroGrads clears the gradients of the given nodes. Call it between
@@ -59,18 +91,100 @@ func ZeroGrads(nodes ...*Node) {
 	}
 }
 
-// ensureGrad lazily allocates a zero gradient buffer.
-func (n *Node) ensureGrad() *tensai.Matrix {
+// Shape returns the shape of the node's value.
+func (n *Node) Shape() []int { return n.Value.Shape }
+
+// Matrix returns a matrix view of a 2-D node value, sharing its backing
+// data. It panics for any other rank.
+func (n *Node) Matrix() *tensai.Matrix {
+	m, err := n.Value.Matrix()
+	if err != nil {
+		panic(err.Error())
+	}
+	return m
+}
+
+// ensureGrad lazily allocates a zero gradient buffer, from the tape when
+// the graph has one.
+func (n *Node) ensureGrad() *tensai.Tensor {
 	if n.Grad == nil {
-		n.Grad = tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
+		if n.tape != nil {
+			n.Grad = n.tape.zeros(n.Value.Shape)
+		} else {
+			n.Grad = n.Value.ZerosLike()
+		}
 	}
 	return n.Grad
 }
 
+// accum adds g into n's gradient, summing over every axis along which n was
+// broadcast to produce g.
+func (n *Node) accum(g *tensai.Tensor) {
+	addScaled(n.ensureGrad(), g, 1)
+}
+
+// accumScaled adds s*g into n's gradient, with the same reduction as accum.
+func (n *Node) accumScaled(g *tensai.Tensor, s tensai.Float) {
+	addScaled(n.ensureGrad(), g, s)
+}
+
+// addScaled adds s*src into dst, summing src over the axes along which dst
+// was broadcast to reach src's shape. dst's shape must broadcast to src's.
+func addScaled(dst, src *tensai.Tensor, s tensai.Float) {
+	if dims.Same(dst.Shape, src.Shape) {
+		if s == 1 {
+			kernels.AddSlice(dst.Data, src.Data)
+			return
+		}
+		for i, v := range src.Data {
+			dst.Data[i] += s * v
+		}
+		return
+	}
+	if len(src.Shape) == 0 {
+		dst.Data[0] += s * src.Data[0]
+		return
+	}
+	if len(dst.Shape) > len(src.Shape) {
+		panic(fmt.Sprintf("tensai: cannot reduce gradient %v into %v", src.Shape, dst.Shape))
+	}
+	// Walk src row-major; the stride table carries 0 on every axis dst is
+	// broadcast along, so those elements all land on the same dst cell.
+	strides := dims.BroadcastStrides(dst.Shape, src.Shape)
+	last := len(src.Shape) - 1
+	n := src.Shape[last]
+	idx := make([]int, len(src.Shape))
+	off := 0
+	for pos := 0; pos < len(src.Data); pos += n {
+		row := src.Data[pos : pos+n]
+		if strides[last] == 1 {
+			d := dst.Data[off : off+n]
+			for i, v := range row {
+				d[i] += s * v
+			}
+		} else { // broadcast along the last axis: the row collapses to a cell
+			var sum tensai.Float
+			for _, v := range row {
+				sum += v
+			}
+			dst.Data[off] += s * sum
+		}
+		for d := last - 1; d >= 0; d-- {
+			idx[d]++
+			off += strides[d]
+			if idx[d] < src.Shape[d] {
+				break
+			}
+			idx[d] = 0
+			off -= strides[d] * src.Shape[d]
+		}
+	}
+}
+
 // newNode wires up a result node, recording the operation that produced it
-// (used by ToDot).
-func newNode(op string, value *tensai.Matrix, parents ...*Node) *Node {
-	out := &Node{Value: value, op: op, parents: parents}
+// (used by ToDot) and inheriting the parents' tape.
+func newNode(op string, value *tensai.Tensor, parents ...*Node) *Node {
+	out := &Node{Value: value, op: op, parents: parents, tape: tapeOf(parents...)}
 	for _, p := range parents {
 		if p.requiresGrad {
 			out.requiresGrad = true
@@ -79,12 +193,21 @@ func newNode(op string, value *tensai.Matrix, parents ...*Node) *Node {
 	return out
 }
 
+// withBack replaces the node's backward closure with one that receives the
+// node itself, keeping op definitions compact.
+func (n *Node) withBack(fn func(out *Node)) *Node {
+	if n.requiresGrad {
+		n.backFn = func() { fn(n) }
+	}
+	return n
+}
+
 // Backward runs reverse-mode differentiation from n, which should be a
-// scalar (1x1) loss. Gradients accumulate into the Grad field of every
-// contributing Param node.
+// scalar (single-element) loss. Gradients accumulate into the Grad field of
+// every contributing Param node.
 func (n *Node) Backward() {
 	if len(n.Value.Data) != 1 {
-		panic(fmt.Sprintf("tensai: backward root must be scalar, got %dx%d", n.Value.Rows, n.Value.Cols))
+		panic(fmt.Sprintf("tensai: backward root must be scalar, got %s", shapeString(n.Value.Shape)))
 	}
 	var topo []*Node
 	visited := map[*Node]bool{}
@@ -110,260 +233,30 @@ func (n *Node) Backward() {
 	}
 }
 
-// MatMul returns the matrix product n * o.
-func (n *Node) MatMul(o *Node) *Node {
-	v, err := tensai.Dot(n.Value, o.Value)
-	if err != nil {
-		panic(err.Error())
-	}
-	out := newNode("matmul", v, n, o)
-	out.backFn = func() {
-		if n.requiresGrad {
-			d, _ := tensai.Dot(out.Grad, o.Value.T())
-			addInto(n.ensureGrad(), d)
-		}
-		if o.requiresGrad {
-			d, _ := tensai.Dot(n.Value.T(), out.Grad)
-			addInto(o.ensureGrad(), d)
-		}
-	}
-	return out
-}
-
-// Add returns the element-wise sum n + o. Shapes must match.
-func (n *Node) Add(o *Node) *Node {
-	v, err := tensai.Add(n.Value, o.Value)
-	if err != nil {
-		panic(err.Error())
-	}
-	return newNode("add", v, n, o).withBack(func(out *Node) {
-		if n.requiresGrad {
-			addInto(n.ensureGrad(), out.Grad)
-		}
-		if o.requiresGrad {
-			addInto(o.ensureGrad(), out.Grad)
-		}
-	})
-}
-
-// Sub returns the element-wise difference n - o. Shapes must match.
-func (n *Node) Sub(o *Node) *Node {
-	if n.Value.Rows != o.Value.Rows || n.Value.Cols != o.Value.Cols {
-		panic(fmt.Sprintf("tensai: sub shape mismatch: %dx%d vs %dx%d",
-			n.Value.Rows, n.Value.Cols, o.Value.Rows, o.Value.Cols))
-	}
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	for i := range v.Data {
-		v.Data[i] = n.Value.Data[i] - o.Value.Data[i]
-	}
-	return newNode("sub", v, n, o).withBack(func(out *Node) {
-		if n.requiresGrad {
-			addInto(n.ensureGrad(), out.Grad)
-		}
-		if o.requiresGrad {
-			g := o.ensureGrad()
-			for i, gv := range out.Grad.Data {
-				g.Data[i] -= gv
-			}
-		}
-	})
-}
-
-// MulElem returns the element-wise (Hadamard) product. Shapes must match.
-func (n *Node) MulElem(o *Node) *Node {
-	if n.Value.Rows != o.Value.Rows || n.Value.Cols != o.Value.Cols {
-		panic(fmt.Sprintf("tensai: mulelem shape mismatch: %dx%d vs %dx%d",
-			n.Value.Rows, n.Value.Cols, o.Value.Rows, o.Value.Cols))
-	}
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	for i := range v.Data {
-		v.Data[i] = n.Value.Data[i] * o.Value.Data[i]
-	}
-	return newNode("mulelem", v, n, o).withBack(func(out *Node) {
-		if n.requiresGrad {
-			g := n.ensureGrad()
-			for i, gv := range out.Grad.Data {
-				g.Data[i] += gv * o.Value.Data[i]
-			}
-		}
-		if o.requiresGrad {
-			g := o.ensureGrad()
-			for i, gv := range out.Grad.Data {
-				g.Data[i] += gv * n.Value.Data[i]
-			}
-		}
-	})
-}
-
-// Scale returns n multiplied by the scalar s.
-func (n *Node) Scale(s tensai.Float) *Node {
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	for i, x := range n.Value.Data {
-		v.Data[i] = s * x
-	}
-	return newNode("scale", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i, gv := range out.Grad.Data {
-			g.Data[i] += s * gv
-		}
-	})
-}
-
-// AddRow adds a 1xN row node to every row of n (bias broadcast).
-func (n *Node) AddRow(row *Node) *Node {
-	v, err := tensai.AddBias(n.Value, row.Value.Data)
-	if err != nil || row.Value.Rows != 1 {
-		panic(fmt.Sprintf("tensai: addrow expects 1x%d row, got %dx%d",
-			n.Value.Cols, row.Value.Rows, row.Value.Cols))
-	}
-	return newNode("addrow", v, n, row).withBack(func(out *Node) {
-		if n.requiresGrad {
-			addInto(n.ensureGrad(), out.Grad)
-		}
-		if row.requiresGrad {
-			g := row.ensureGrad()
-			for r := 0; r < out.Grad.Rows; r++ {
-				for c := 0; c < out.Grad.Cols; c++ {
-					g.Data[c] += out.Grad.Data[r*out.Grad.Cols+c]
-				}
-			}
-		}
-	})
-}
-
-// ReLU applies max(0, x) element-wise.
-func (n *Node) ReLU() *Node {
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	kernels.ReluFwd(v.Data, n.Value.Data)
-	return newNode("relu", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i, gv := range out.Grad.Data {
-			if n.Value.Data[i] > 0 {
-				g.Data[i] += gv
-			}
-		}
-	})
-}
-
-// Sigmoid applies 1/(1+e^-x) element-wise.
-func (n *Node) Sigmoid() *Node {
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	kernels.SigmoidFwd(v.Data, n.Value.Data)
-	return newNode("sigmoid", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i, gv := range out.Grad.Data {
-			y := v.Data[i]
-			g.Data[i] += gv * y * (1 - y)
-		}
-	})
-}
-
-// Tanh applies tanh(x) element-wise.
-func (n *Node) Tanh() *Node {
-	v := tensai.NewMatrix(n.Value.Rows, n.Value.Cols)
-	kernels.TanhFwd(v.Data, n.Value.Data)
-	return newNode("tanh", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i, gv := range out.Grad.Data {
-			y := v.Data[i]
-			g.Data[i] += gv * (1 - y*y)
-		}
-	})
-}
-
-// T returns the transpose of n.
-func (n *Node) T() *Node {
-	return newNode("transpose", n.Value.T(), n).withBack(func(out *Node) {
-		addInto(n.ensureGrad(), out.Grad.T())
-	})
-}
-
-// Softmax normalizes each row of n into a probability distribution.
-func (n *Node) Softmax() *Node {
-	cols := n.Value.Cols
-	v := tensai.NewMatrix(n.Value.Rows, cols)
-	for r := 0; r < n.Value.Rows; r++ {
-		row := n.Value.Data[r*cols : (r+1)*cols]
-		outRow := v.Data[r*cols : (r+1)*cols]
-		maxVal := row[0]
-		for _, x := range row {
-			if x > maxVal {
-				maxVal = x
-			}
-		}
-		kernels.ExpShift(outRow, row, maxVal)
-		var denom tensai.Float
-		for _, e := range outRow {
-			denom += e
-		}
-		kernels.ScaleSlice(outRow, 1/denom)
-	}
-	return newNode("softmax", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for r := 0; r < v.Rows; r++ {
-			y := v.Data[r*cols : (r+1)*cols]
-			gv := out.Grad.Data[r*cols : (r+1)*cols]
-			kernels.SoftmaxBwdAdd(g.Data[r*cols:(r+1)*cols], gv, y)
-		}
-	})
-}
-
-// Sum reduces n to a 1x1 scalar by summing all elements.
-func (n *Node) Sum() *Node {
-	v := tensai.NewMatrix(1, 1)
-	for _, x := range n.Value.Data {
-		v.Data[0] += x
-	}
-	return newNode("sum", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i := range g.Data {
-			g.Data[i] += out.Grad.Data[0]
-		}
-	})
-}
-
-// Mean reduces n to a 1x1 scalar averaging all elements.
-func (n *Node) Mean() *Node {
-	inv := 1 / tensai.Float(len(n.Value.Data))
-	return n.Sum().Scale(inv)
-}
-
-// MSELoss returns the scalar mean squared error against a constant target.
-func (n *Node) MSELoss(target *tensai.Matrix) *Node {
-	diff := n.Sub(Input(target))
-	return diff.MulElem(diff).Mean()
-}
-
-// SoftmaxCELoss returns the scalar softmax cross-entropy against integer
-// class labels (an Mx1 matrix of class indices), matching the
-// loss.SoftmaxCrossEntropy loss used by Sequential models.
-func (n *Node) SoftmaxCELoss(target *tensai.Matrix) *Node {
-	lossVal, grad, err := loss.SoftmaxCrossEntropy{}.Loss(n.Value, target)
-	if err != nil {
-		panic(err.Error())
-	}
-	v := tensai.NewMatrix(1, 1)
-	v.Data[0] = lossVal
-	return newNode("softmax_ce", v, n).withBack(func(out *Node) {
-		g := n.ensureGrad()
-		for i, gv := range grad.Data {
-			g.Data[i] += out.Grad.Data[0] * gv
-		}
-	})
-}
-
-// Scalar returns the value of a 1x1 node.
+// Scalar returns the value of a single-element node.
 func (n *Node) Scalar() tensai.Float {
 	if len(n.Value.Data) != 1 {
-		panic(fmt.Sprintf("tensai: scalar called on %dx%d node", n.Value.Rows, n.Value.Cols))
+		panic(fmt.Sprintf("tensai: scalar called on %s node", shapeString(n.Value.Shape)))
 	}
 	return n.Value.Data[0]
+}
+
+// shapeString renders a shape the way the docs and graphs do: 5x3, 2x4x8.
+func shapeString(shape []int) string {
+	if len(shape) == 0 {
+		return "scalar"
+	}
+	parts := make([]string, len(shape))
+	for i, d := range shape {
+		parts[i] = fmt.Sprint(d)
+	}
+	return strings.Join(parts, "x")
 }
 
 // Trainer owns the optimizer bookkeeping for a set of autograd parameters,
 // so a training step is just building the loss graph and calling Step.
 //
-//	trainer := tensai.NewTrainer(tensai.NewAdam(0.05), w1, b1, w2, b2)
+//	trainer := autograd.NewTrainer(optim.NewAdam(0.05), w1, b1, w2, b2)
 //	for step := 0; step < 2000; step++ {
 //		loss := forward(x).MSELoss(y)
 //		trainer.Step(loss)
@@ -392,24 +285,24 @@ func (t *Trainer) Step(loss *Node) tensai.Float {
 			// Parameter unused in this graph; its state simply sits out.
 			continue
 		}
-		t.ups[i].Step(p.Value, p.Grad, nil, nil)
+		// Optimizers update flat parameter buffers, so any rank works as
+		// long as value and gradient agree.
+		t.ups[i].Step(flatMatrix(p.Value), flatMatrix(p.Grad), nil, nil)
 	}
 	ZeroGrads(t.params...)
 	return loss.Scalar()
 }
 
-// withBack replaces the node's backward closure with one that receives the
-// node itself, keeping op definitions compact.
-func (n *Node) withBack(fn func(out *Node)) *Node {
-	if n.requiresGrad {
-		n.backFn = func() { fn(n) }
+// flatMatrix views a tensor's data as a 1 x N matrix for the optimizers,
+// which work element-wise and do not care about the shape.
+func flatMatrix(t *tensai.Tensor) *tensai.Matrix {
+	m, err := t.Reshape(1, len(t.Data))
+	if err != nil {
+		panic(err.Error())
 	}
-	return n
-}
-
-// addInto adds src into dst element-wise. Shapes must already match.
-func addInto(dst, src *tensai.Matrix) {
-	for i, v := range src.Data {
-		dst.Data[i] += v
+	mm, err := m.Matrix()
+	if err != nil {
+		panic(err.Error())
 	}
+	return mm
 }

--- a/autograd/autograd_test.go
+++ b/autograd/autograd_test.go
@@ -13,7 +13,7 @@ import (
 // checkParamGrad compares the analytic gradient of loss w.r.t. param against
 // finite differences. build must construct the graph fresh from the current
 // matrix contents and return (loss node, param node).
-func checkParamGrad(t *testing.T, param *tensai.Matrix, build func() (*Node, *Node), name string) {
+func checkParamGrad(t *testing.T, param *tensai.Tensor, build func() (*Node, *Node), name string) {
 	t.Helper()
 	loss, p := build()
 	// Param nodes may be shared across successive checks; Backward
@@ -47,14 +47,14 @@ func checkParamGrad(t *testing.T, param *tensai.Matrix, build func() (*Node, *No
 
 func TestAutogradOps(t *testing.T) {
 	rng := rand.New(rand.NewSource(31))
-	w := tensai.RandomMatrix(3, 4, rng)
-	x := tensai.RandomMatrix(5, 3, rng)
-	b := tensai.RandomMatrix(1, 4, rng)
-	other := tensai.RandomMatrix(5, 4, rng)
+	w := tensai.RandomMatrix(3, 4, rng).Tensor()
+	x := tensai.RandomMatrix(5, 3, rng).Tensor()
+	b := tensai.RandomMatrix(1, 4, rng).Tensor()
+	other := tensai.RandomMatrix(5, 4, rng).Tensor()
 
 	cases := []struct {
 		name  string
-		param *tensai.Matrix
+		param *tensai.Tensor
 		build func() (*Node, *Node)
 	}{
 		{"matmul", w, func() (*Node, *Node) {
@@ -86,9 +86,9 @@ func TestAutogradOps(t *testing.T) {
 
 func TestAutogradSoftmaxCE(t *testing.T) {
 	rng := rand.New(rand.NewSource(37))
-	w := tensai.RandomMatrix(3, 4, rng)
-	x := tensai.RandomMatrix(6, 3, rng)
-	target := tensai.NewMatrix(6, 1)
+	w := tensai.RandomMatrix(3, 4, rng).Tensor()
+	x := tensai.RandomMatrix(6, 3, rng).Tensor()
+	target := tensai.NewMatrix(6, 1).Tensor()
 	for i := range target.Data {
 		target.Data[i] = tensai.Float(rng.Intn(4))
 	}
@@ -100,9 +100,9 @@ func TestAutogradSoftmaxCE(t *testing.T) {
 
 func TestAutogradSharedParam(t *testing.T) {
 	// A parameter used twice must accumulate both contributions.
-	w := tensai.NewMatrix(2, 2)
+	w := tensai.NewTensor(2, 2)
 	w.Data = []tensai.Float{1, 2, 3, 4}
-	x := tensai.NewMatrix(1, 2)
+	x := tensai.NewTensor(1, 2)
 	x.Data = []tensai.Float{1, 1}
 	checkParamGrad(t, w, func() (*Node, *Node) {
 		p := Param(w)
@@ -134,7 +134,7 @@ func TestAutogradTrainsXOR(t *testing.T) {
 
 	var lossVal tensai.Float
 	for step := 0; step < 2000; step++ {
-		lossVal = trainer.Step(forward(inputs).MSELoss(targets))
+		lossVal = trainer.Step(forward(inputs).MSELoss(targets.Tensor()))
 	}
 	if lossVal > 0.01 {
 		t.Fatalf("autograd XOR failed to converge: loss=%g", lossVal)
@@ -173,8 +173,8 @@ func TestToDot(t *testing.T) {
 
 func TestAutogradTransposeAndSoftmax(t *testing.T) {
 	rng := rand.New(rand.NewSource(41))
-	w := tensai.RandomMatrix(3, 4, rng)
-	x := tensai.RandomMatrix(5, 3, rng)
+	w := tensai.RandomMatrix(3, 4, rng).Tensor()
+	x := tensai.RandomMatrix(5, 3, rng).Tensor()
 
 	checkParamGrad(t, w, func() (*Node, *Node) {
 		p := Param(w)
@@ -183,7 +183,7 @@ func TestAutogradTransposeAndSoftmax(t *testing.T) {
 
 	// Weighted sum keeps the softmax gradient non-trivial (a plain Sum of
 	// each row is constant 1 and would zero it out).
-	weights := tensai.RandomMatrix(5, 4, rng)
+	weights := tensai.RandomMatrix(5, 4, rng).Tensor()
 	checkParamGrad(t, w, func() (*Node, *Node) {
 		p := Param(w)
 		return Input(x).MatMul(p).Softmax().MulElem(Input(weights)).Sum(), p

--- a/autograd/bench_test.go
+++ b/autograd/bench_test.go
@@ -1,0 +1,65 @@
+package autograd
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/optim"
+)
+
+// benchModel is one transformer-ish block over a (batch, seq, model)
+// activation: embed, project, attend, project out, cross-entropy. It is the
+// shape the n-dimensional engine exists for, and big enough that its
+// buffers -- not its bookkeeping -- dominate what a step allocates.
+func benchModel(rng *rand.Rand) (params []*Node, loss func() *Node) {
+	const (
+		batch, seq, model, vocab = 8, 16, 64, 32
+	)
+	embed := Param(tensai.RandomMatrix(vocab, model, rng).Tensor())
+	wq := Param(tensai.RandomMatrix(model, model, rng).Tensor())
+	wk := Param(tensai.RandomMatrix(model, model, rng).Tensor())
+	wv := Param(tensai.RandomMatrix(model, model, rng).Tensor())
+	wOut := Param(tensai.RandomMatrix(model, vocab, rng).Tensor())
+	params = []*Node{embed, wq, wk, wv, wOut}
+
+	tokens := make([]int, batch*seq)
+	labels := make([]int, batch*seq)
+	for i := range tokens {
+		tokens[i] = rng.Intn(vocab)
+		labels[i] = rng.Intn(vocab)
+	}
+	loss = func() *Node {
+		x := embed.Embed(tokens, batch, seq).LayerNorm(nil, nil, 1e-5)
+		q, k, v := x.MatMul(wq), x.MatMul(wk), x.MatMul(wv)
+		att := q.MatMul(k.T()).Scale(0.125).Softmax()
+		return att.MatMul(v).MatMul(wOut).CrossEntropy(labels)
+	}
+	return params, loss
+}
+
+func BenchmarkStep(b *testing.B) {
+	params, loss := benchModel(rand.New(rand.NewSource(1)))
+	trainer := NewTrainer(optim.NewAdam(0.01), params...)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trainer.Step(loss())
+	}
+}
+
+// BenchmarkStepTaped is the same step with the buffers recycled.
+func BenchmarkStepTaped(b *testing.B) {
+	params, loss := benchModel(rand.New(rand.NewSource(1)))
+	trainer := NewTrainer(optim.NewAdam(0.01), params...)
+	tape := NewTape()
+	tape.Bind(params...)
+	trainer.Step(loss()) // fill the pool
+	tape.Reset()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trainer.Step(loss())
+		tape.Reset()
+	}
+}

--- a/autograd/dot.go
+++ b/autograd/dot.go
@@ -50,7 +50,7 @@ func (n *Node) ToDot() string {
 			}
 			attrs = `shape=box, style=filled, fillcolor="#EFEFEF"`
 		}
-		label += fmt.Sprintf("\\n%dx%d", x.Value.Rows, x.Value.Cols)
+		label += "\\n" + shapeString(x.Value.Shape)
 		fmt.Fprintf(&sb, "  n%d [label=\"%s\", %s];\n", id, label, attrs)
 
 		for _, p := range x.parents {

--- a/autograd/ops.go
+++ b/autograd/ops.go
@@ -1,0 +1,605 @@
+package autograd
+
+import (
+	"fmt"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/dims"
+	"github.com/mattn/tensai/internal/kernels"
+	"github.com/mattn/tensai/loss"
+)
+
+// The operations below all follow the same shape: run the forward pass on
+// the tensor kernels, then register a closure that turns the output
+// gradient into the operands'. Broadcasting is handled once, in accum,
+// which sums a gradient back over whatever axes an operand was stretched
+// along -- so every element-wise op below works for any pair of
+// broadcast-compatible shapes without knowing which one was broadcast.
+
+// MatMul multiplies two stacks of matrices: the last two axes are the
+// matrix dimensions and the leading axes broadcast, so (batch, m, k) times
+// (k, n) yields (batch, m, n).
+func (n *Node) MatMul(o *Node) *Node {
+	tp := tapeOf(n, o)
+	v := tp.tensor(matmulShape(n.Value.Shape, o.Value.Shape, gemmNN))
+	if err := tensai.MatMulInto(v, n.Value, o.Value); err != nil {
+		panic(err.Error())
+	}
+	return newNode("matmul", v, n, o).withBack(func(out *Node) {
+		// The two gradients are grad * b^T and a^T * grad. Both run on the
+		// transposed GEMM modes, so neither operand is copied into a
+		// transposed buffer first.
+		if n.requiresGrad {
+			d := tp.tensor(matmulShape(out.Grad.Shape, o.Value.Shape, gemmNT))
+			if err := tensai.MatMulNTInto(d, out.Grad, o.Value); err != nil {
+				panic(err.Error())
+			}
+			n.accum(d)
+		}
+		if o.requiresGrad {
+			d := tp.tensor(matmulShape(n.Value.Shape, out.Grad.Shape, gemmTN))
+			if err := tensai.MatMulTNInto(d, n.Value, out.Grad); err != nil {
+				panic(err.Error())
+			}
+			o.accum(d)
+		}
+	})
+}
+
+// Add returns the element-wise sum n + o, broadcasting the operands.
+func (n *Node) Add(o *Node) *Node {
+	tp := tapeOf(n, o)
+	v := tp.tensor(binShape(n.Value.Shape, o.Value.Shape))
+	if err := tensai.AddInto(v, n.Value, o.Value); err != nil {
+		panic(err.Error())
+	}
+	return newNode("add", v, n, o).withBack(func(out *Node) {
+		if n.requiresGrad {
+			n.accum(out.Grad)
+		}
+		if o.requiresGrad {
+			o.accum(out.Grad)
+		}
+	})
+}
+
+// Sub returns the element-wise difference n - o, broadcasting the operands.
+func (n *Node) Sub(o *Node) *Node {
+	tp := tapeOf(n, o)
+	v := tp.tensor(binShape(n.Value.Shape, o.Value.Shape))
+	if err := tensai.SubInto(v, n.Value, o.Value); err != nil {
+		panic(err.Error())
+	}
+	return newNode("sub", v, n, o).withBack(func(out *Node) {
+		if n.requiresGrad {
+			n.accum(out.Grad)
+		}
+		if o.requiresGrad {
+			o.accumScaled(out.Grad, -1)
+		}
+	})
+}
+
+// Mul returns the element-wise (Hadamard) product, broadcasting the
+// operands.
+func (n *Node) Mul(o *Node) *Node {
+	tp := tapeOf(n, o)
+	v := tp.tensor(binShape(n.Value.Shape, o.Value.Shape))
+	if err := tensai.MulInto(v, n.Value, o.Value); err != nil {
+		panic(err.Error())
+	}
+	return newNode("mul", v, n, o).withBack(func(out *Node) {
+		if n.requiresGrad {
+			d := tp.tensor(binShape(out.Grad.Shape, o.Value.Shape))
+			if err := tensai.MulInto(d, out.Grad, o.Value); err != nil {
+				panic(err.Error())
+			}
+			n.accum(d)
+		}
+		if o.requiresGrad {
+			d := tp.tensor(binShape(out.Grad.Shape, n.Value.Shape))
+			if err := tensai.MulInto(d, out.Grad, n.Value); err != nil {
+				panic(err.Error())
+			}
+			o.accum(d)
+		}
+	})
+}
+
+// MulElem is the former name of Mul, kept for the matrix-shaped API.
+func (n *Node) MulElem(o *Node) *Node { return n.Mul(o) }
+
+// Div returns the element-wise quotient n / o, broadcasting the operands.
+func (n *Node) Div(o *Node) *Node {
+	tp := tapeOf(n, o)
+	v := tp.tensor(binShape(n.Value.Shape, o.Value.Shape))
+	if err := tensai.DivInto(v, n.Value, o.Value); err != nil {
+		panic(err.Error())
+	}
+	return newNode("div", v, n, o).withBack(func(out *Node) {
+		if n.requiresGrad {
+			d := tp.tensor(binShape(out.Grad.Shape, o.Value.Shape))
+			if err := tensai.DivInto(d, out.Grad, o.Value); err != nil {
+				panic(err.Error())
+			}
+			n.accum(d)
+		}
+		if o.requiresGrad {
+			// d/db (a/b) = -a/b^2, and a/b^2 is the output over b again.
+			q := tp.tensor(binShape(out.Value.Shape, o.Value.Shape))
+			if err := tensai.DivInto(q, out.Value, o.Value); err != nil {
+				panic(err.Error())
+			}
+			d := tp.tensor(binShape(out.Grad.Shape, q.Shape))
+			if err := tensai.MulInto(d, out.Grad, q); err != nil {
+				panic(err.Error())
+			}
+			o.accumScaled(d, -1)
+		}
+	})
+}
+
+// Scale returns n multiplied by the scalar s.
+func (n *Node) Scale(s tensai.Float) *Node {
+	v := n.tape.tensor(n.Value.Shape) // overwritten by the copy below
+	copy(v.Data, n.Value.Data)
+	v.Scale(s)
+	return newNode("scale", v, n).withBack(func(out *Node) {
+		n.accumScaled(out.Grad, s)
+	})
+}
+
+// Neg returns -n.
+func (n *Node) Neg() *Node { return n.Scale(-1) }
+
+// AddRow adds a 1xN row node to every row of n. Add broadcasts on its own,
+// so this only pins down the intent (and the shape check) for the
+// two-dimensional API.
+func (n *Node) AddRow(row *Node) *Node {
+	if len(row.Value.Shape) != 2 || row.Value.Shape[0] != 1 {
+		panic(fmt.Sprintf("tensai: addrow expects a 1xN row, got %s", shapeString(row.Value.Shape)))
+	}
+	return n.Add(row)
+}
+
+// unary builds an element-wise op: fwd fills the output from the input, and
+// bwd accumulates the input gradient given (grad, input, output).
+func (n *Node) unary(op string, fwd func(dst, src []tensai.Float), bwd func(dst, grad, src, out []tensai.Float)) *Node {
+	// fwd writes every element, so the buffer needs no clearing.
+	v := n.tape.tensor(n.Value.Shape)
+	fwd(v.Data, n.Value.Data)
+	return newNode(op, v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		bwd(g.Data, out.Grad.Data, n.Value.Data, v.Data)
+	})
+}
+
+// ReLU applies max(0, x) element-wise.
+func (n *Node) ReLU() *Node {
+	return n.unary("relu", kernels.ReluFwd, func(dst, grad, src, _ []tensai.Float) {
+		for i, gv := range grad {
+			if src[i] > 0 {
+				dst[i] += gv
+			}
+		}
+	})
+}
+
+// LeakyReLU applies max(alpha*x, x) element-wise.
+func (n *Node) LeakyReLU(alpha tensai.Float) *Node {
+	return n.unary("leakyrelu", func(dst, src []tensai.Float) {
+		kernels.LeakyFwd(dst, src, alpha)
+	}, func(dst, grad, src, _ []tensai.Float) {
+		for i, gv := range grad {
+			if src[i] > 0 {
+				dst[i] += gv
+			} else {
+				dst[i] += alpha * gv
+			}
+		}
+	})
+}
+
+// Sigmoid applies 1/(1+e^-x) element-wise.
+func (n *Node) Sigmoid() *Node {
+	return n.unary("sigmoid", kernels.SigmoidFwd, func(dst, grad, _, out []tensai.Float) {
+		for i, gv := range grad {
+			y := out[i]
+			dst[i] += gv * y * (1 - y)
+		}
+	})
+}
+
+// Tanh applies tanh(x) element-wise.
+func (n *Node) Tanh() *Node {
+	return n.unary("tanh", kernels.TanhFwd, func(dst, grad, _, out []tensai.Float) {
+		for i, gv := range grad {
+			y := out[i]
+			dst[i] += gv * (1 - y*y)
+		}
+	})
+}
+
+// GELU applies the Gaussian error linear unit element-wise.
+func (n *Node) GELU() *Node {
+	return n.unary("gelu", kernels.GeluFwd, func(dst, grad, src, _ []tensai.Float) {
+		// GeluBwd writes rather than accumulates, so it needs a scratch row.
+		tmp := n.tape.buffer(len(grad))
+		kernels.GeluBwd(tmp, grad, src)
+		kernels.AddSlice(dst, tmp)
+	})
+}
+
+// Exp applies e^x element-wise.
+func (n *Node) Exp() *Node {
+	return n.unary("exp", func(dst, src []tensai.Float) {
+		for i, x := range src {
+			dst[i] = kernels.ExpF(x)
+		}
+	}, func(dst, grad, _, out []tensai.Float) {
+		for i, gv := range grad {
+			dst[i] += gv * out[i]
+		}
+	})
+}
+
+// Log applies the natural logarithm element-wise.
+func (n *Node) Log() *Node {
+	return n.unary("log", func(dst, src []tensai.Float) {
+		for i, x := range src {
+			dst[i] = kernels.LogF(x)
+		}
+	}, func(dst, grad, src, _ []tensai.Float) {
+		for i, gv := range grad {
+			dst[i] += gv / src[i]
+		}
+	})
+}
+
+// T returns n with its last two axes swapped: the matrix transpose of every
+// matrix in the stack.
+func (n *Node) T() *Node { return n.Transpose() }
+
+// Transpose permutes the axes of n; perm must list every axis exactly once.
+// With no arguments it swaps the last two axes.
+func (n *Node) Transpose(perm ...int) *Node {
+	v, err := n.Value.Transpose(perm...)
+	if err != nil {
+		panic(err.Error())
+	}
+	if len(perm) == 0 {
+		perm = swapLastTwo(len(n.Value.Shape))
+	}
+	inv := make([]int, len(perm))
+	for i, p := range perm {
+		inv[p] = i
+	}
+	return newNode("transpose", v, n).withBack(func(out *Node) {
+		d, err := out.Grad.Transpose(inv...)
+		if err != nil {
+			panic(err.Error())
+		}
+		n.accum(d)
+	})
+}
+
+// swapLastTwo returns the permutation that swaps the last two of n axes.
+func swapLastTwo(n int) []int {
+	perm := make([]int, n)
+	for i := range perm {
+		perm[i] = i
+	}
+	perm[n-2], perm[n-1] = perm[n-1], perm[n-2]
+	return perm
+}
+
+// Reshape returns n with a new shape; one dimension may be -1 and is
+// inferred. The value is a view sharing the input's buffer -- as elsewhere
+// in the engine, node values are read-only once built -- so this is the
+// cheap way in and out of the per-head layout attention wants.
+func (n *Node) Reshape(shape ...int) *Node {
+	v, err := n.Value.Reshape(shape...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return newNode("reshape", v, n).withBack(func(o *Node) {
+		d, err := o.Grad.Reshape(n.Value.Shape...)
+		if err != nil {
+			panic(err.Error())
+		}
+		n.accum(d)
+	})
+}
+
+// Softmax normalizes the last axis of n into a probability distribution.
+func (n *Node) Softmax() *Node {
+	shape := n.Value.Shape
+	d := shape[len(shape)-1]
+	v := n.tape.tensor(shape) // every element is written below
+	for pos := 0; pos < len(v.Data); pos += d {
+		row := n.Value.Data[pos : pos+d]
+		outRow := v.Data[pos : pos+d]
+		maxVal := row[0]
+		for _, x := range row {
+			if x > maxVal {
+				maxVal = x
+			}
+		}
+		kernels.ExpShift(outRow, row, maxVal)
+		var denom tensai.Float
+		for _, e := range outRow {
+			denom += e
+		}
+		kernels.ScaleSlice(outRow, 1/denom)
+	}
+	return newNode("softmax", v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		for pos := 0; pos < len(v.Data); pos += d {
+			kernels.SoftmaxBwdAdd(g.Data[pos:pos+d], out.Grad.Data[pos:pos+d], v.Data[pos:pos+d])
+		}
+	})
+}
+
+// Sum reduces n to a single-element node by summing every element.
+func (n *Node) Sum() *Node {
+	var total tensai.Float
+	for _, x := range n.Value.Data {
+		total += x
+	}
+	v := n.tape.tensor(scalarShape)
+	v.Data[0] = total
+	return newNode("sum", v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		gv := out.Grad.Data[0]
+		for i := range g.Data {
+			g.Data[i] += gv
+		}
+	})
+}
+
+// Mean reduces n to a single-element node averaging every element.
+func (n *Node) Mean() *Node {
+	return n.Sum().Scale(1 / tensai.Float(len(n.Value.Data)))
+}
+
+// axisSpan splits a shape around one axis into (outer, dim, inner) element
+// counts. A negative axis counts from the end, so -1 is the last axis.
+func axisSpan(shape []int, axis int) (int, int, int, int) {
+	a := axis
+	if a < 0 {
+		a += len(shape)
+	}
+	if a < 0 || a >= len(shape) {
+		panic(fmt.Sprintf("tensai: axis %d out of range for shape %s", axis, shapeString(shape)))
+	}
+	return dims.Prod(shape[:a]), shape[a], dims.Prod(shape[a+1:]), a
+}
+
+// SumAxis sums n along one axis. With keepDims the axis stays as a
+// length-1 dimension; otherwise it is dropped.
+func (n *Node) SumAxis(axis int, keepDims bool) *Node {
+	outer, dim, inner, a := axisSpan(n.Value.Shape, axis)
+	v := n.tape.zeros(reducedShape(n.Value.Shape, a, keepDims)) // accumulated into
+	for o := 0; o < outer; o++ {
+		dst := v.Data[o*inner : (o+1)*inner]
+		for d := 0; d < dim; d++ {
+			src := n.Value.Data[(o*dim+d)*inner : (o*dim+d+1)*inner]
+			kernels.AddSlice(dst, src)
+		}
+	}
+	return newNode("sumaxis", v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		for o := 0; o < outer; o++ {
+			src := out.Grad.Data[o*inner : (o+1)*inner]
+			for d := 0; d < dim; d++ {
+				kernels.AddSlice(g.Data[(o*dim+d)*inner:(o*dim+d+1)*inner], src)
+			}
+		}
+	})
+}
+
+// MeanAxis averages n along one axis, following SumAxis for keepDims.
+func (n *Node) MeanAxis(axis int, keepDims bool) *Node {
+	_, dim, _, _ := axisSpan(n.Value.Shape, axis)
+	return n.SumAxis(axis, keepDims).Scale(1 / tensai.Float(dim))
+}
+
+// reducedShape returns shape with axis a either dropped or kept as 1.
+func reducedShape(shape []int, a int, keepDims bool) []int {
+	out := make([]int, 0, len(shape))
+	for i, d := range shape {
+		switch {
+		case i != a:
+			out = append(out, d)
+		case keepDims:
+			out = append(out, 1)
+		}
+	}
+	if len(out) == 0 { // reducing a 1-D tensor without keepDims
+		out = append(out, 1)
+	}
+	return out
+}
+
+// LayerNorm normalizes the last axis of n to zero mean and unit variance,
+// then scales by gain and shifts by bias, either of which may be nil. Both
+// must hold one element per feature -- shape (d) or (1, d) -- and both may
+// be parameters, so a transformer block's normalization trains along with
+// the rest.
+func (n *Node) LayerNorm(gain, bias *Node, eps tensai.Float) *Node {
+	shape := n.Value.Shape
+	d := shape[len(shape)-1]
+	gamma := affineData(gain, d, 1, "gain")
+	beta := affineData(bias, d, 0, "bias")
+
+	rows := len(n.Value.Data) / d
+	tp := tapeOf(n, gain, bias)
+	v := tp.tensor(shape) // LnFwdRow writes every element
+	xhat := tp.buffer(len(n.Value.Data))
+	invStd := tp.buffer(rows)
+	for r := 0; r < rows; r++ {
+		lo, hi := r*d, (r+1)*d
+		invStd[r] = kernels.LnFwdRow(v.Data[lo:hi], xhat[lo:hi], n.Value.Data[lo:hi], gamma, beta, eps)
+	}
+
+	parents := []*Node{n}
+	for _, p := range []*Node{gain, bias} {
+		if p != nil {
+			parents = append(parents, p)
+		}
+	}
+	return newNode("layernorm", v, parents...).withBack(func(out *Node) {
+		dx := tp.buffer(d)
+		gradGamma, gradBeta := tp.zeros(featureShape(d)).Data, tp.zeros(featureShape(d)).Data
+		if gain != nil && gain.requiresGrad {
+			gradGamma = gain.ensureGrad().Data
+		}
+		if bias != nil && bias.requiresGrad {
+			gradBeta = bias.ensureGrad().Data
+		}
+		// The gain and bias gradients are wanted even when the normalized
+		// input is a constant, so dx is computed either way and simply
+		// dropped when nothing upstream needs it.
+		var g *tensai.Tensor
+		if n.requiresGrad {
+			g = n.ensureGrad()
+		}
+		for r := 0; r < rows; r++ {
+			lo, hi := r*d, (r+1)*d
+			// LnBwdRow writes dx and accumulates the parameter gradients.
+			kernels.LnBwdRow(dx, out.Grad.Data[lo:hi], xhat[lo:hi], gamma, gradGamma, gradBeta, invStd[r])
+			if g != nil {
+				kernels.AddSlice(g.Data[lo:hi], dx)
+			}
+		}
+	})
+}
+
+// affineData returns the per-feature data of a LayerNorm gain or bias node,
+// or a constant fill when the node is nil.
+func affineData(p *Node, d int, fill tensai.Float, what string) []tensai.Float {
+	if p == nil {
+		out := make([]tensai.Float, d)
+		for i := range out {
+			out[i] = fill
+		}
+		return out
+	}
+	if len(p.Value.Data) != d {
+		panic(fmt.Sprintf("tensai: layernorm %s has %d elements, want %d", what, len(p.Value.Data), d))
+	}
+	return p.Value.Data
+}
+
+// Embed looks ids up in n, a (vocab, dim) embedding table, and returns the
+// rows stacked in the given index shape: with shape (batch, seq) the result
+// is (batch, seq, dim). With no shape the result is (len(ids), dim).
+// Gradients scatter back into the table, so repeated ids accumulate.
+func (n *Node) Embed(ids []int, shape ...int) *Node {
+	if len(n.Value.Shape) != 2 {
+		panic(fmt.Sprintf("tensai: embed needs a (vocab, dim) table, got %s", shapeString(n.Value.Shape)))
+	}
+	vocab, d := n.Value.Shape[0], n.Value.Shape[1]
+	if len(shape) == 0 {
+		shape = []int{len(ids)}
+	}
+	if dims.Prod(shape) != len(ids) {
+		panic(fmt.Sprintf("tensai: embed has %d ids for index shape %s", len(ids), shapeString(shape)))
+	}
+	v := n.tape.tensor(append(append(make([]int, 0, len(shape)+1), shape...), d))
+	for i, id := range ids {
+		if id < 0 || id >= vocab {
+			panic(fmt.Sprintf("tensai: embed id %d out of range for vocab %d", id, vocab))
+		}
+		copy(v.Data[i*d:(i+1)*d], n.Value.Data[id*d:(id+1)*d])
+	}
+	return newNode("embed", v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		for i, id := range ids {
+			kernels.AddSlice(g.Data[id*d:(id+1)*d], out.Grad.Data[i*d:(i+1)*d])
+		}
+	})
+}
+
+// MSELoss returns the scalar mean squared error against a constant target
+// of the same shape.
+func (n *Node) MSELoss(target *tensai.Tensor) *Node {
+	if !dims.Same(n.Value.Shape, target.Shape) {
+		panic(fmt.Sprintf("tensai: mse target is %s, want %s",
+			shapeString(target.Shape), shapeString(n.Value.Shape)))
+	}
+	diff := n.Sub(Input(target))
+	return diff.Mul(diff).Mean()
+}
+
+// SoftmaxCELoss returns the scalar softmax cross-entropy of n's last axis
+// against integer class labels, matching the loss.SoftmaxCrossEntropy used
+// by Sequential models. n holds logits shaped (..., classes) and target
+// holds one class index per row of that stack, in any shape.
+func (n *Node) SoftmaxCELoss(target *tensai.Tensor) *Node {
+	shape := n.Value.Shape
+	classes := shape[len(shape)-1]
+	rows := len(n.Value.Data) / classes
+	if len(target.Data) != rows {
+		panic(fmt.Sprintf("tensai: softmax-ce target has %d labels, want %d", len(target.Data), rows))
+	}
+	logits := flatRows(n.Value, rows, classes)
+	labels := flatRows(target, rows, 1)
+	lossVal, grad, err := loss.SoftmaxCrossEntropy{}.Loss(logits, labels)
+	if err != nil {
+		panic(err.Error())
+	}
+	v := n.tape.tensor(scalarShape)
+	v.Data[0] = lossVal
+	return newNode("softmax_ce", v, n).withBack(func(out *Node) {
+		g := n.ensureGrad()
+		scale := out.Grad.Data[0]
+		for i, gv := range grad.Data {
+			g.Data[i] += scale * gv
+		}
+	})
+}
+
+// CrossEntropy is SoftmaxCELoss taking the labels as plain ints, which is
+// how token targets usually arrive.
+func (n *Node) CrossEntropy(labels []int) *Node {
+	m, err := tensai.NewMatrixFromInts(len(labels), 1, labels)
+	if err != nil {
+		panic(err.Error())
+	}
+	return n.SoftmaxCELoss(m.Tensor())
+}
+
+// flatRows views a tensor's data as a rows x cols matrix without copying.
+func flatRows(t *tensai.Tensor, rows, cols int) *tensai.Matrix {
+	r, err := t.Reshape(rows, cols)
+	if err != nil {
+		panic(err.Error())
+	}
+	m, err := r.Matrix()
+	if err != nil {
+		panic(err.Error())
+	}
+	return m
+}
+
+// scalarShape is the shape every single-element node has: reductions and
+// losses share it rather than each building its own.
+var scalarShape = []int{1, 1}
+
+// featureShape returns the one-axis shape of LayerNorm's per-feature
+// buffers.
+func featureShape(d int) []int { return []int{d} }
+
+// binShape returns the shape an element-wise op produces. Equal operands --
+// the common case -- share a shape header rather than building a new one.
+func binShape(a, b []int) []int {
+	if dims.Same(a, b) {
+		return a
+	}
+	shape, err := dims.Broadcast(a, b)
+	if err != nil {
+		panic(err.Error())
+	}
+	return shape
+}

--- a/autograd/serialize.go
+++ b/autograd/serialize.go
@@ -7,22 +7,47 @@ import (
 	"os"
 
 	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/dims"
 )
 
+// paramJSON is the on-disk form of one parameter. Two-dimensional
+// parameters keep the Rows/Cols encoding checkpoints written before the
+// engine went n-dimensional use, so those files still load (and still
+// round-trip byte for byte); anything else carries its full shape.
+type paramJSON struct {
+	Rows  int            `json:"Rows,omitempty"`
+	Cols  int            `json:"Cols,omitempty"`
+	Shape []int          `json:"Shape,omitempty"`
+	Data  []tensai.Float `json:"Data"`
+}
+
+// shape returns the parameter's shape in either encoding.
+func (p *paramJSON) shape() []int {
+	if len(p.Shape) > 0 {
+		return p.Shape
+	}
+	return []int{p.Rows, p.Cols}
+}
+
 type paramsSnapshot struct {
-	Params []*tensai.Matrix `json:"params"`
+	Params []paramJSON `json:"params"`
 }
 
 // SaveParams writes the values of autograd parameters as JSON, in the given
 // order. Pass the same parameter list a Trainer uses, e.g.
 // SaveParams(w, cell.Params()...).
 func SaveParams(w io.Writer, params ...*Node) error {
-	snap := paramsSnapshot{Params: make([]*tensai.Matrix, len(params))}
+	snap := paramsSnapshot{Params: make([]paramJSON, len(params))}
 	for i, p := range params {
 		if p == nil || p.Value == nil {
 			return fmt.Errorf("tensai: save params: parameter %d is nil", i)
 		}
-		snap.Params[i] = p.Value
+		t := p.Value
+		if len(t.Shape) == 2 {
+			snap.Params[i] = paramJSON{Rows: t.Shape[0], Cols: t.Shape[1], Data: t.Data}
+			continue
+		}
+		snap.Params[i] = paramJSON{Shape: t.Shape, Data: t.Data}
 	}
 	return json.NewEncoder(w).Encode(&snap)
 }
@@ -38,19 +63,22 @@ func LoadParams(r io.Reader, params ...*Node) error {
 		return fmt.Errorf("tensai: load params count mismatch: got %d, want %d",
 			len(snap.Params), len(params))
 	}
-	for i, m := range snap.Params {
-		if err := m.Validate(); err != nil {
-			return fmt.Errorf("tensai: load params %d: %w", i, err)
+	for i := range snap.Params {
+		saved := &snap.Params[i]
+		shape := saved.shape()
+		if len(saved.Data) != dims.Prod(shape) {
+			return fmt.Errorf("tensai: load params %d: %s has %d elements",
+				i, shapeString(shape), len(saved.Data))
 		}
 		p := params[i]
 		if p == nil || p.Value == nil {
 			return fmt.Errorf("tensai: load params: parameter %d is nil", i)
 		}
-		if p.Value.Rows != m.Rows || p.Value.Cols != m.Cols {
-			return fmt.Errorf("tensai: load params %d shape mismatch: got %dx%d, want %dx%d",
-				i, m.Rows, m.Cols, p.Value.Rows, p.Value.Cols)
+		if !dims.Same(p.Value.Shape, shape) {
+			return fmt.Errorf("tensai: load params %d shape mismatch: got %s, want %s",
+				i, shapeString(shape), shapeString(p.Value.Shape))
 		}
-		copy(p.Value.Data, m.Data)
+		copy(p.Value.Data, saved.Data)
 	}
 	return nil
 }

--- a/autograd/tape.go
+++ b/autograd/tape.go
@@ -1,0 +1,147 @@
+package autograd
+
+import (
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/dims"
+)
+
+// Tape recycles the buffers a graph allocates. A training step builds a
+// fresh graph every time -- that is what define-by-run means -- and throws
+// it away again, so without a tape every step asks the allocator for every
+// intermediate value and gradient it touches, and the collector takes them
+// back a moment later.
+//
+// Bind the parameters once, then call Reset at the end of each step:
+//
+//	tape := autograd.NewTape()
+//	tape.Bind(w1, b1, w2, b2)
+//	for step := 0; step < steps; step++ {
+//		trainer.Step(forward(x).MSELoss(y))
+//		tape.Reset()
+//	}
+//
+// Reset hands every buffer from that step back to the pool, so the next
+// step reuses the same memory. That makes the rule for using a tape a
+// simple one: after Reset, nothing from the finished step may be read --
+// no node's Value, no node's Grad. Parameter values are never recycled
+// (the tape only owns what operations produce), so the trained weights
+// themselves are always safe to keep. Copy anything else you need with
+// Clone before resetting.
+//
+// A Tape is not safe for concurrent use; give each training goroutine its
+// own.
+type Tape struct {
+	free map[int][][]tensai.Float
+	used [][]tensai.Float
+}
+
+// NewTape returns an empty tape.
+func NewTape() *Tape {
+	return &Tape{free: map[int][][]tensai.Float{}}
+}
+
+// Bind ties nodes to the tape. Every node built from them -- the whole
+// graph, since operations inherit the tape from their parents -- takes its
+// values and gradients from it. Bind the parameters once, outside the
+// training loop.
+func (t *Tape) Bind(nodes ...*Node) {
+	for _, n := range nodes {
+		n.tape = t
+	}
+}
+
+// Reset returns every buffer handed out since the last Reset to the pool.
+// Values and gradients from the finished step must not be read afterwards.
+func (t *Tape) Reset() {
+	if t == nil {
+		return
+	}
+	for _, buf := range t.used {
+		t.free[len(buf)] = append(t.free[len(buf)], buf)
+	}
+	t.used = t.used[:0]
+}
+
+// buffer returns a buffer of n elements. Its contents are whatever the
+// previous step left there, so only callers that write every element may
+// use it.
+func (t *Tape) buffer(n int) []tensai.Float {
+	if t == nil {
+		return make([]tensai.Float, n)
+	}
+	pool := t.free[n]
+	if len(pool) == 0 {
+		buf := make([]tensai.Float, n)
+		t.used = append(t.used, buf)
+		return buf
+	}
+	buf := pool[len(pool)-1]
+	t.free[n] = pool[:len(pool)-1]
+	t.used = append(t.used, buf)
+	return buf
+}
+
+// tensor returns a tensor of the given shape whose data is not cleared.
+// The shape is adopted, not copied: callers pass a shape they own or one
+// that belongs to a node whose shape is never mutated.
+func (t *Tape) tensor(shape []int) *tensai.Tensor {
+	if t == nil {
+		return &tensai.Tensor{Shape: shape, Data: make([]tensai.Float, dims.Prod(shape))}
+	}
+	return &tensai.Tensor{Shape: shape, Data: t.buffer(dims.Prod(shape))}
+}
+
+// zeros returns a cleared tensor of the given shape.
+func (t *Tape) zeros(shape []int) *tensai.Tensor {
+	out := t.tensor(shape)
+	clear(out.Data)
+	return out
+}
+
+// tapeOf returns the tape a result node inherits: the first one any parent
+// carries.
+func tapeOf(parents ...*Node) *Tape {
+	for _, p := range parents {
+		// LayerNorm passes an optional gain and bias, either of which may
+		// be nil.
+		if p != nil && p.tape != nil {
+			return p.tape
+		}
+	}
+	return nil
+}
+
+// matmulShape returns the shape of the stacked product tensai.MatMul,
+// MatMulTN or MatMulNT produces for these operands, so the output buffer
+// can come from the tape before the product runs. The kernels validate it
+// again, so a mistake here surfaces as an error rather than bad math.
+func matmulShape(a, b []int, mode gemmMode) []int {
+	na, nb := len(a), len(b)
+	var m, n int
+	switch mode {
+	case gemmTN:
+		m, n = a[na-1], b[nb-1]
+	case gemmNT:
+		m, n = a[na-2], b[nb-2]
+	default:
+		m, n = a[na-2], b[nb-1]
+	}
+	if na == 2 && nb == 2 {
+		return []int{m, n}
+	}
+	batch, err := dims.Broadcast(a[:na-2], b[:nb-2])
+	if err != nil {
+		panic(err.Error())
+	}
+	return append(batch, m, n)
+}
+
+// gemmMode names which operand of a product is transposed, mirroring the
+// three MatMul entry points in the root package.
+type gemmMode int
+
+const (
+	gemmNN gemmMode = iota // a * b
+	gemmTN                 // a^T * b
+	gemmNT                 // a * b^T
+)

--- a/autograd/tape_test.go
+++ b/autograd/tape_test.go
@@ -1,0 +1,195 @@
+package autograd
+
+import (
+	"math"
+	"math/rand"
+	"runtime"
+	"testing"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/optim"
+)
+
+// buildXOR returns a training step for the XOR network, along with its
+// parameters, so the same model can run with and without a tape.
+func buildXOR(t *testing.T, seed int64) (params []*Node, step func() tensai.Float) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	inputs, err := tensai.NewMatrixFromSlice(4, 2, []tensai.Float{0, 0, 0, 1, 1, 0, 1, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets, err := tensai.NewMatrixFromSlice(4, 1, []tensai.Float{0, 1, 1, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w1 := Param(tensai.RandomMatrix(2, 8, rng))
+	b1 := Param(tensai.NewMatrix(1, 8))
+	w2 := Param(tensai.RandomMatrix(8, 1, rng))
+	b2 := Param(tensai.NewMatrix(1, 1))
+	params = []*Node{w1, b1, w2, b2}
+	trainer := NewTrainer(optim.NewAdam(0.05), params...)
+	step = func() tensai.Float {
+		out := Input(inputs).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).AddRow(b2).Sigmoid()
+		return trainer.Step(out.MSELoss(targets.Tensor()))
+	}
+	return params, step
+}
+
+// TestTapeMatchesUntaped trains the same model twice, once with a tape and
+// once without: recycled buffers must not change a single weight.
+func TestTapeMatchesUntaped(t *testing.T) {
+	plain, plainStep := buildXOR(t, 5)
+	taped, tapedStep := buildXOR(t, 5)
+	tape := NewTape()
+	tape.Bind(taped...)
+
+	var plainLoss, tapedLoss tensai.Float
+	for i := 0; i < 300; i++ {
+		plainLoss = plainStep()
+		tapedLoss = tapedStep()
+		tape.Reset()
+	}
+	if plainLoss != tapedLoss {
+		t.Fatalf("loss differs: plain %g, taped %g", plainLoss, tapedLoss)
+	}
+	if plainLoss > 0.05 {
+		t.Fatalf("XOR did not converge: loss=%g", plainLoss)
+	}
+	for i := range plain {
+		for j, want := range plain[i].Value.Data {
+			if got := taped[i].Value.Data[j]; got != want {
+				t.Fatalf("param %d element %d: taped %g, plain %g", i, j, got, want)
+			}
+		}
+	}
+}
+
+// buildWide returns a training step for a network whose buffers dominate
+// its bookkeeping, which is where a tape pays.
+func buildWide(t *testing.T, seed int64) (params []*Node, step func() tensai.Float) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	x := tensai.RandomMatrix(32, 64, rng)
+	y := tensai.RandomMatrix(32, 16, rng).Tensor()
+	w1 := Param(tensai.RandomMatrix(64, 128, rng))
+	b1 := Param(tensai.NewMatrix(1, 128))
+	w2 := Param(tensai.RandomMatrix(128, 16, rng))
+	params = []*Node{w1, b1, w2}
+	trainer := NewTrainer(optim.NewAdam(0.01), params...)
+	step = func() tensai.Float {
+		out := Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2)
+		return trainer.Step(out.MSELoss(y))
+	}
+	return params, step
+}
+
+// TestTapeReusesBuffers checks that a reset tape hands the same memory back
+// out instead of allocating again.
+func TestTapeReusesBuffers(t *testing.T) {
+	_, plainStep := buildWide(t, 9)
+	taped, tapedStep := buildWide(t, 9)
+	tape := NewTape()
+	tape.Bind(taped...)
+
+	tapedStep() // the first step fills the pool
+	tape.Reset()
+
+	// Bytes, not object counts, are what the tape is for: the node and
+	// closure bookkeeping still allocates either way, but the buffers those
+	// nodes hold should stop coming from the heap.
+	plainBytes := bytesPerRun(20, func() { plainStep() })
+	tapedBytes := bytesPerRun(20, func() {
+		tapedStep()
+		tape.Reset()
+	})
+	if tapedBytes >= plainBytes/4 {
+		t.Errorf("tape did not cut allocation: %d B/step with, %d B/step without", tapedBytes, plainBytes)
+	}
+	t.Logf("%d B/step with the tape, %d B/step without", tapedBytes, plainBytes)
+
+	// The buffers themselves must come back, not just their sizes: the
+	// value of the same node in two successive steps shares one array.
+	w := Param(tensai.RandomMatrix(3, 4, rand.New(rand.NewSource(3))))
+	tape2 := NewTape()
+	tape2.Bind(w)
+	x := tensai.RandomMatrix(2, 3, rand.New(rand.NewSource(4)))
+	first := Input(x).MatMul(w)
+	tape2.Reset()
+	second := Input(x).MatMul(w)
+	if &first.Value.Data[0] != &second.Value.Data[0] {
+		t.Error("second step allocated a fresh buffer instead of reusing the first")
+	}
+}
+
+// TestTapeLeavesParamsAlone checks that binding a tape never recycles a
+// parameter's own value, which has to survive every Reset.
+func TestTapeLeavesParamsAlone(t *testing.T) {
+	w := Param(tensai.NewTensor(2, 2))
+	copy(w.Value.Data, []tensai.Float{1, 2, 3, 4})
+	tape := NewTape()
+	tape.Bind(w)
+	before := w.Value.Data
+
+	for i := 0; i < 5; i++ {
+		w.Mul(w).Sum().Backward()
+		ZeroGrads(w)
+		tape.Reset()
+	}
+	if &before[0] != &w.Value.Data[0] {
+		t.Fatal("parameter value was replaced")
+	}
+	for i, want := range []tensai.Float{1, 2, 3, 4} {
+		if w.Value.Data[i] != want {
+			t.Fatalf("parameter element %d = %g, want %g", i, w.Value.Data[i], want)
+		}
+	}
+}
+
+// TestTapeGradientsStayCorrect runs the numeric-gradient check on a taped
+// graph, so a recycled buffer that still held stale numbers would show up.
+func TestTapeGradientsStayCorrect(t *testing.T) {
+	rng := rand.New(rand.NewSource(29))
+	x := randTensor(rng, 2, 3, 4)
+	w := randTensor(rng, 4, 5)
+	weights := randTensor(rng, 2, 3, 5)
+	gain := randTensor(rng, 5)
+	tape := NewTape()
+
+	build := func() (*Node, *Node) {
+		p := Param(w)
+		tape.Bind(p)
+		out := Input(x).MatMul(p).LayerNorm(Input(gain), nil, 1e-5).GELU()
+		return out.Mul(Input(weights)).Sum(), p
+	}
+	// Run once and reset, so the check below runs on recycled buffers.
+	loss, p := build()
+	loss.Backward()
+	ZeroGrads(p)
+	tape.Reset()
+
+	checkParamGrad(t, w, build, "taped-graph")
+
+	// A scalar loss must still come out identical after a reset.
+	tape.Reset()
+	first, _ := build()
+	got := first.Scalar()
+	tape.Reset()
+	second, _ := build()
+	if math.Abs(float64(got-second.Scalar())) > 1e-6 {
+		t.Errorf("loss changed across a reset: %g then %g", got, second.Scalar())
+	}
+}
+
+// bytesPerRun reports the heap bytes one call of f allocates, averaged over
+// n runs.
+func bytesPerRun(n int, f func()) uint64 {
+	var before, after runtime.MemStats
+	f() // warm up, so first-run growth is not counted
+	runtime.ReadMemStats(&before)
+	for i := 0; i < n; i++ {
+		f()
+	}
+	runtime.ReadMemStats(&after)
+	return (after.TotalAlloc - before.TotalAlloc) / uint64(n)
+}

--- a/autograd/tensor_test.go
+++ b/autograd/tensor_test.go
@@ -1,0 +1,346 @@
+package autograd
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/kernels"
+	"github.com/mattn/tensai/optim"
+)
+
+// randTensor returns a tensor of the given shape with small normal values.
+func randTensor(rng *rand.Rand, shape ...int) *tensai.Tensor {
+	t := tensai.NewTensor(shape...)
+	for i := range t.Data {
+		t.Data[i] = tensai.Float(rng.NormFloat64()) * 0.5
+	}
+	return t
+}
+
+// posTensor returns a tensor whose values sit in [1, 2), so division and
+// logarithms stay well conditioned for a finite-difference check.
+func posTensor(rng *rand.Rand, shape ...int) *tensai.Tensor {
+	t := tensai.NewTensor(shape...)
+	for i := range t.Data {
+		t.Data[i] = 1 + tensai.Float(rng.Float64())
+	}
+	return t
+}
+
+// TestTensorOpGradients differentiates every n-dimensional op against
+// finite differences. Each case makes one tensor the parameter and reduces
+// the graph to a scalar; a plain Sum would be blind to any op whose row
+// gradient is constant, so the reductions are weighted where that matters.
+func TestTensorOpGradients(t *testing.T) {
+	rng := rand.New(rand.NewSource(2026))
+	x := randTensor(rng, 2, 3, 4)       // (batch, seq, model)
+	w := randTensor(rng, 4, 5)          // a shared projection
+	weights := randTensor(rng, 2, 3, 5) // weighting for the final reduction
+	bias := randTensor(rng, 1, 1, 5)    // broadcast over batch and sequence
+	denom := posTensor(rng, 1, 1, 5)
+	k := randTensor(rng, 2, 6, 4)
+	attnW := randTensor(rng, 2, 3, 6)
+	gain := randTensor(rng, 5)
+	shift := randTensor(rng, 5)
+	table := randTensor(rng, 7, 4)
+	xt := randTensor(rng, 3, 2, 4)    // weighting in the permuted layout
+	pooled := randTensor(rng, 2, 4)   // weighting for a reduced axis
+	numer := randTensor(rng, 1, 1, 5) // a dividend to differentiate
+	ids := []int{3, 0, 6, 0, 1, 5}    // a repeat, so the scatter must accumulate
+
+	cases := []struct {
+		name  string
+		param *tensai.Tensor
+		build func() (*Node, *Node)
+	}{
+		{"matmul-broadcast", w, func() (*Node, *Node) {
+			// (2,3,4) x (4,5): the weight is broadcast across the batch, so
+			// its gradient has to be summed back over that axis.
+			p := Param(w)
+			return Input(x).MatMul(p).Mul(Input(weights)).Sum(), p
+		}},
+		{"matmul-stacked", k, func() (*Node, *Node) {
+			// (2,3,4) x (2,4,6): a real batch of distinct matrices.
+			p := Param(k)
+			return Input(x).MatMul(p.T()).Mul(Input(attnW)).Sum(), p
+		}},
+		{"add-broadcast", bias, func() (*Node, *Node) {
+			p := Param(bias)
+			return Input(x).MatMul(Input(w)).Add(p).Tanh().Mul(Input(weights)).Sum(), p
+		}},
+		{"sub-broadcast", bias, func() (*Node, *Node) {
+			p := Param(bias)
+			return Input(weights).Sub(p).Mul(Input(weights)).Sum(), p
+		}},
+		{"mul-broadcast", bias, func() (*Node, *Node) {
+			p := Param(bias)
+			return Input(weights).Mul(p).Tanh().Sum(), p
+		}},
+		{"div-numerator", numer, func() (*Node, *Node) {
+			p := Param(numer)
+			return p.Div(Input(denom)).Mul(Input(weights)).Sum(), p
+		}},
+		{"div-denominator", denom, func() (*Node, *Node) {
+			p := Param(denom)
+			return Input(weights).Div(p).Mul(Input(weights)).Sum(), p
+		}},
+		{"scale-neg", w, func() (*Node, *Node) {
+			p := Param(w)
+			return Input(x).MatMul(p).Scale(0.75).Neg().Mul(Input(weights)).Sum(), p
+		}},
+		{"transpose-perm", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.Transpose(1, 0, 2).Mul(Input(xt)).Sum(), p
+		}},
+		{"reshape", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.Reshape(6, 4).MatMul(Input(w)).Reshape(2, 3, 5).Mul(Input(weights)).Sum(), p
+		}},
+		{"sumaxis", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.SumAxis(1, false).Mul(Input(pooled)).Sum(), p
+		}},
+		{"sumaxis-keepdims", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.SumAxis(-1, true).Tanh().Sum(), p
+		}},
+		{"meanaxis", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.MeanAxis(0, false).Tanh().Sum(), p
+		}},
+		{"softmax-lastaxis", w, func() (*Node, *Node) {
+			p := Param(w)
+			return Input(x).MatMul(p).Softmax().Mul(Input(weights)).Sum(), p
+		}},
+		{"gelu", w, func() (*Node, *Node) {
+			p := Param(w)
+			return Input(x).MatMul(p).GELU().Mul(Input(weights)).Sum(), p
+		}},
+		{"leakyrelu", w, func() (*Node, *Node) {
+			p := Param(w)
+			return Input(x).MatMul(p).LeakyReLU(0.1).Mul(Input(weights)).Sum(), p
+		}},
+		{"exp", w, func() (*Node, *Node) {
+			p := Param(w)
+			return Input(x).MatMul(p).Exp().Mul(Input(weights)).Sum(), p
+		}},
+		{"log", denom, func() (*Node, *Node) {
+			p := Param(denom)
+			return p.Log().Mul(Input(bias)).Sum(), p
+		}},
+		{"layernorm-input", x, func() (*Node, *Node) {
+			p := Param(x)
+			return p.MatMul(Input(w)).LayerNorm(nil, nil, 1e-5).Mul(Input(weights)).Sum(), p
+		}},
+		{"layernorm-gain", gain, func() (*Node, *Node) {
+			p := Param(gain)
+			return Input(x).MatMul(Input(w)).LayerNorm(p, nil, 1e-5).Mul(Input(weights)).Sum(), p
+		}},
+		{"layernorm-bias", shift, func() (*Node, *Node) {
+			p := Param(shift)
+			return Input(x).MatMul(Input(w)).LayerNorm(Input(gain), p, 1e-5).Mul(Input(weights)).Sum(), p
+		}},
+		{"embed", table, func() (*Node, *Node) {
+			p := Param(table)
+			return p.Embed(ids, 2, 3).Mul(Input(x)).Sum(), p
+		}},
+	}
+	for _, tc := range cases {
+		checkParamGrad(t, tc.param, tc.build, tc.name)
+	}
+}
+
+// TestTensorCrossEntropy checks the loss over a (batch, seq, vocab) logit
+// stack, which is the shape a language model produces.
+func TestTensorCrossEntropy(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	x := randTensor(rng, 2, 3, 4)
+	w := randTensor(rng, 4, 5)
+	labels := []int{0, 4, 2, 1, 3, 3}
+	checkParamGrad(t, w, func() (*Node, *Node) {
+		p := Param(w)
+		return Input(x).MatMul(p).CrossEntropy(labels), p
+	}, "cross-entropy-3d")
+}
+
+// TestBroadcastGradientReduction pins the reduction itself: a bias
+// broadcast over both leading axes must collect every element that used it.
+func TestBroadcastGradientReduction(t *testing.T) {
+	b := tensai.NewTensor(1, 1, 3)
+	p := Param(b)
+	x := tensai.NewTensor(2, 4, 3)
+	Input(x).Add(p).Sum().Backward()
+	for i, g := range p.Grad.Data {
+		if g != 8 { // 2 x 4 positions share each bias element
+			t.Errorf("bias grad %d = %g, want 8", i, g)
+		}
+	}
+}
+
+// TestEmbedAccumulatesRepeats checks that a token appearing twice gets both
+// gradients scattered into the same table row.
+func TestEmbedAccumulatesRepeats(t *testing.T) {
+	table := tensai.NewTensor(3, 2)
+	p := Param(table)
+	p.Embed([]int{1, 1, 2}).Sum().Backward()
+	want := []tensai.Float{0, 0, 2, 2, 1, 1}
+	for i, g := range p.Grad.Data {
+		if g != want[i] {
+			t.Errorf("table grad %d = %g, want %g", i, g, want[i])
+		}
+	}
+}
+
+// TestLayerNormMatchesDefinition checks the forward pass against the plain
+// definition of the statistics it normalizes by.
+func TestLayerNormMatchesDefinition(t *testing.T) {
+	rng := rand.New(rand.NewSource(13))
+	x := randTensor(rng, 2, 3, 4)
+	out := Input(x).LayerNorm(nil, nil, 1e-5)
+	for r := 0; r < 6; r++ {
+		row := out.Value.Data[r*4 : (r+1)*4]
+		var mean, sq tensai.Float
+		for _, v := range row {
+			mean += v
+		}
+		mean /= 4
+		for _, v := range row {
+			sq += v * v
+		}
+		if math.Abs(float64(mean)) > 1e-4 {
+			t.Errorf("row %d mean = %g, want 0", r, mean)
+		}
+		if math.Abs(float64(sq/4-1)) > 1e-3 {
+			t.Errorf("row %d variance = %g, want 1", r, sq/4)
+		}
+	}
+}
+
+// TestTensorParamsRoundTrip saves and reloads parameters of mixed rank.
+func TestTensorParamsRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(17))
+	params := []*Node{
+		Param(randTensor(rng, 2, 3, 4)),
+		Param(randTensor(rng, 5)),
+		Param(tensai.RandomMatrix(3, 2, rng)),
+	}
+	var buf bytes.Buffer
+	if err := SaveParams(&buf, params...); err != nil {
+		t.Fatal(err)
+	}
+	saved := buf.String()
+	// Rank-2 parameters keep the Rows/Cols encoding older checkpoints use.
+	if !strings.Contains(saved, `"Rows":3,"Cols":2`) {
+		t.Errorf("2-D parameter lost its Rows/Cols encoding:\n%s", saved)
+	}
+	if !strings.Contains(saved, `"Shape":[2,3,4]`) {
+		t.Errorf("3-D parameter lost its shape:\n%s", saved)
+	}
+
+	restored := []*Node{
+		Param(tensai.NewTensor(2, 3, 4)),
+		Param(tensai.NewTensor(5)),
+		Param(tensai.NewMatrix(3, 2)),
+	}
+	if err := LoadParams(strings.NewReader(saved), restored...); err != nil {
+		t.Fatal(err)
+	}
+	for i, p := range params {
+		for j, v := range p.Value.Data {
+			if restored[i].Value.Data[j] != v {
+				t.Fatalf("param %d element %d: got %g, want %g", i, j, restored[i].Value.Data[j], v)
+			}
+		}
+	}
+
+	// A rank mismatch must be rejected rather than silently reinterpreted.
+	if err := LoadParams(strings.NewReader(saved), Param(tensai.NewTensor(24))); err == nil {
+		t.Error("loading a 3-D parameter into a 1-D one should fail")
+	}
+}
+
+// TestLegacyParamsLoad reads the Rows/Cols encoding written before the
+// engine went n-dimensional.
+func TestLegacyParamsLoad(t *testing.T) {
+	const old = `{"params":[{"Rows":2,"Cols":2,"Data":[1,2,3,4]}]}`
+	p := Param(tensai.NewMatrix(2, 2))
+	if err := LoadParams(strings.NewReader(old), p); err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []tensai.Float{1, 2, 3, 4} {
+		if p.Value.Data[i] != want {
+			t.Errorf("element %d = %g, want %g", i, p.Value.Data[i], want)
+		}
+	}
+}
+
+// TestAttentionTrainsBatched trains a single-head attention block written
+// directly in the n-dimensional API -- batched matmul, causal mask,
+// per-token cross-entropy -- on a copy task: every position must predict
+// the token at the first position. Getting there requires the gradient to
+// flow through the attention weights, not just the projections.
+func TestAttentionTrainsBatched(t *testing.T) {
+	rng := rand.New(rand.NewSource(23))
+	const (
+		batch, seq, model, vocab = 4, 4, 16, 5
+	)
+	tokens := make([]int, batch*seq)
+	labels := make([]int, batch*seq)
+	for b := 0; b < batch; b++ {
+		for s := 0; s < seq; s++ {
+			tokens[b*seq+s] = rng.Intn(vocab)
+		}
+		for s := 0; s < seq; s++ {
+			labels[b*seq+s] = tokens[b*seq] // always the first token
+		}
+	}
+
+	embed := Param(randTensor(rng, vocab, model))
+	wq := Param(randTensor(rng, model, model))
+	wk := Param(randTensor(rng, model, model))
+	wv := Param(randTensor(rng, model, model))
+	wOut := Param(randTensor(rng, model, vocab))
+	scale := 1 / kernels.SqrtF(tensai.Float(model))
+
+	// Causal mask: -inf above the diagonal, broadcast over the batch.
+	mask := tensai.NewTensor(1, seq, seq)
+	for i := 0; i < seq; i++ {
+		for j := i + 1; j < seq; j++ {
+			mask.Data[i*seq+j] = tensai.Float(math.Inf(-1))
+		}
+	}
+
+	forward := func() *Node {
+		x := embed.Embed(tokens, batch, seq) // (batch, seq, model)
+		q, kk, v := x.MatMul(wq), x.MatMul(wk), x.MatMul(wv)
+		att := q.MatMul(kk.T()).Scale(scale).Add(Input(mask)).Softmax()
+		return att.MatMul(v).MatMul(wOut)
+	}
+
+	trainer := NewTrainer(optim.NewAdam(0.05), embed, wq, wk, wv, wOut)
+	var lossVal tensai.Float
+	for step := 0; step < 400; step++ {
+		lossVal = trainer.Step(forward().CrossEntropy(labels))
+	}
+	if lossVal > 0.1 {
+		t.Fatalf("batched attention failed to learn the copy task: loss=%g", lossVal)
+	}
+
+	logits := forward()
+	for i, want := range labels {
+		row := logits.Value.Data[i*vocab : (i+1)*vocab]
+		best := 0
+		for j, v := range row {
+			if v > row[best] {
+				best = j
+			}
+		}
+		if best != want {
+			t.Errorf("position %d: predicted %d, want %d", i, best, want)
+		}
+	}
+}

--- a/docs/guide/autograd.ja.md
+++ b/docs/guide/autograd.ja.md
@@ -1,6 +1,6 @@
 # 自動微分
 
-モデルが Sequential の型にはまらないとき (重み共有、カスタム損失、変わったアーキテクチャ) は、計算を直接組み立ててリバースモード自動微分に勾配を導出させます。エンジンは micrograd スタイル: 行列上の `Node` の動的グラフで、define-by-run、使い捨てです。
+モデルが Sequential の型にはまらないとき (重み共有、カスタム損失、変わったアーキテクチャ) は、計算を直接組み立ててリバースモード自動微分に勾配を導出させます。エンジンは micrograd スタイル: n 次元テンソル上の `Node` の動的グラフで、define-by-run、使い捨てです。`Node` が持つ値は `Tensor` なので、要素ごとの演算はブロードキャストし、`MatMul` は行列のスタックを掛けます。リーフを作るところでは `Matrix` をゼロコピーの 2 次元ビューとして受け取るので、以下の 2 次元のコードは今までどおりです。
 
 ## Param、Input、Trainer
 
@@ -11,7 +11,7 @@ w2 := autograd.Param(tensai.RandomMatrix(8, 1, rng))
 trainer := autograd.NewTrainer(optim.NewAdam(0.05), w1, b1, w2)
 
 for step := 0; step < 2000; step++ {
-	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y)
+	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y.Tensor())
 	trainer.Step(loss) // backward + 更新 + 勾配ゼロ化。損失値を返す
 }
 ```
@@ -20,9 +20,29 @@ for step := 0; step < 2000; step++ {
 
 ## 使える演算
 
-`MatMul`, `Add`, `Sub`, `MulElem`, `Scale`, `AddRow`, `T`, `Softmax`, `ReLU`, `Sigmoid`, `Tanh`, `Sum`, `Mean`, `MSELoss`, `SoftmaxCELoss`。
+`MatMul` (バッチ対応、先頭軸はブロードキャスト), `Add`, `Sub`, `Mul`/`MulElem`, `Div`, `Scale`, `Neg`, `AddRow`, `T`/`Transpose`, `Reshape`, `Softmax` (最終軸), `Sum`, `Mean`, `SumAxis`/`MeanAxis`, `LayerNorm`, `Embed`, `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, `GELU`, `Exp`, `Log`, `MSELoss`, `SoftmaxCELoss`, `CrossEntropy`。要素ごとの演算は NumPy 流にブロードキャストし、勾配は引き伸ばされた軸ぶんだけ合計されて戻ります。
 
 グラフはステップごとに動的に構築され、使い捨てです。形状の不一致はグラフ構築時に panic します。すべての演算の勾配はテストスイートで数値微分と照合されています。
+
+## Tape によるバッファ再利用
+
+グラフはステップごとに組み立てて捨てるので、既定では中間値と勾配のすべてを毎ステップ確保し直します。`Tape` はそれを再利用します。パラメータを一度 Bind して、ステップの最後に Reset するだけです:
+
+```go
+tape := autograd.NewTape()
+tape.Bind(w1, b1, w2, b2) // op は親から tape を引き継ぐ
+
+for step := 0; step < steps; step++ {
+	trainer.Step(forward(x).MSELoss(y))
+	tape.Reset() // このステップのバッファをプールに返す
+}
+```
+
+規則は学習ループが元々守っているもの 1 つだけです: **`Reset` の後、終わったステップの値を読んではいけません** — `Value` も `Grad` もです。パラメータの値は再利用されない (tape が持つのは op が作ったものだけ) ので、学習した重みはいつでも保持して安全です。それ以外を残したいときは Reset の前にコピーしてください。`Tape` は並行利用できないので、学習ゴルーチンごとに 1 つ持たせます。
+
+32 ステップを展開する `_example/charrnn` では、1 学習ステップの確保量が 22MB から 0.75MB に減り、実時間も約 1/4 短くなります。
+
+同じ再利用は 1 段下でも使えます。`MatMulInto`, `MatMulTNInto`, `MatMulNTInto`, `AddInto`, `SubInto`, `MulInto`, `DivInto` は、行列に対する `DotInto` と同じように、呼び出し側が持つテンソルに書き込みます。
 
 ## グラフの可視化
 
@@ -48,7 +68,7 @@ for step := 0; step < epochs; step++ {
 		h, c = cell.Step(autograd.Input(x), h, c)
 	}
 	logits := h.MatMul(wOut).AddRow(bOut)
-	trainer.Step(logits.SoftmaxCELoss(labels))
+	trainer.Step(logits.CrossEntropy(labels)) // labels はクラス番号の []int
 }
 ```
 

--- a/docs/guide/autograd.md
+++ b/docs/guide/autograd.md
@@ -1,6 +1,6 @@
 # Automatic Differentiation
 
-When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients. The engine is micrograd-style: a dynamically built graph of `Node`s over matrices, define-by-run, single-use.
+When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients. The engine is micrograd-style: a dynamically built graph of `Node`s over n-dimensional tensors, define-by-run, single-use. A `Node` holds a `Tensor`, so element-wise ops broadcast and `MatMul` multiplies stacks of matrices; a `Matrix` is taken as a zero-copy 2-D view wherever a leaf is built, so the two-dimensional code below reads the same as it always did.
 
 ## Params, Inputs, and the Trainer
 
@@ -11,7 +11,7 @@ w2 := autograd.Param(tensai.RandomMatrix(8, 1, rng))
 trainer := autograd.NewTrainer(optim.NewAdam(0.05), w1, b1, w2)
 
 for step := 0; step < 2000; step++ {
-	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y)
+	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y.Tensor())
 	trainer.Step(loss) // backward + update + zero grads, returns the loss value
 }
 ```
@@ -20,9 +20,29 @@ for step := 0; step < 2000; step++ {
 
 ## Available ops
 
-`MatMul`, `Add`, `Sub`, `MulElem`, `Scale`, `AddRow`, `T`, `Softmax`, `ReLU`, `Sigmoid`, `Tanh`, `Sum`, `Mean`, `MSELoss`, and `SoftmaxCELoss`.
+`MatMul` (batched, with broadcast leading axes), `Add`, `Sub`, `Mul`/`MulElem`, `Div`, `Scale`, `Neg`, `AddRow`, `T`/`Transpose`, `Reshape`, `Softmax` (last axis), `Sum`, `Mean`, `SumAxis`/`MeanAxis`, `LayerNorm`, `Embed`, `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, `GELU`, `Exp`, `Log`, `MSELoss`, `SoftmaxCELoss`, and `CrossEntropy`. Element-wise ops broadcast NumPy-style, and a gradient is summed back over whatever axes an operand was stretched along.
 
 Graphs are built dynamically per step and are single-use. Shape mismatches panic during graph construction. Every op's gradient is verified against finite differences in the test suite.
+
+## Reusing buffers with a tape
+
+A graph is built and thrown away every step, so by default every step asks the allocator for every intermediate value and gradient it touches. A `Tape` recycles them. Bind the parameters once, then reset it at the end of each step:
+
+```go
+tape := autograd.NewTape()
+tape.Bind(w1, b1, w2, b2) // ops inherit the tape from their parents
+
+for step := 0; step < steps; step++ {
+	trainer.Step(forward(x).MSELoss(y))
+	tape.Reset() // hands this step's buffers back to the pool
+}
+```
+
+The rule is the one a training loop already follows: **after `Reset`, nothing from the finished step may be read** — no node's `Value`, no node's `Grad`. Parameter values are never recycled (the tape only owns what operations produce), so trained weights are always safe to keep; copy anything else before resetting. A `Tape` is not safe for concurrent use, so give each training goroutine its own.
+
+On `_example/charrnn`, which unrolls 32 time steps per iteration, the tape takes a training step from 22 MB of allocation to 0.75 MB and cuts about a quarter off its wall time.
+
+The same reuse is available one layer down: `MatMulInto`, `MatMulTNInto`, `MatMulNTInto`, `AddInto`, `SubInto`, `MulInto` and `DivInto` write into a tensor you already own, the way `DotInto` does for matrices.
 
 ## Visualizing the graph
 
@@ -48,7 +68,7 @@ for step := 0; step < epochs; step++ {
 		h, c = cell.Step(autograd.Input(x), h, c)
 	}
 	logits := h.MatMul(wOut).AddRow(bOut)
-	trainer.Step(logits.SoftmaxCELoss(labels))
+	trainer.Step(logits.CrossEntropy(labels)) // labels is a []int of class indices
 }
 ```
 

--- a/docs/guide/tensors.ja.md
+++ b/docs/guide/tensors.ja.md
@@ -50,6 +50,8 @@ out, _ := tensai.MatMul(scores, v)                // バッチ全体の attentio
 
 バッチ `MatMul` 内部の行列ごとの積は `Dot` と同じカーネルで走り、バッチ方向に並列化されます。
 
+`MatMulTN` と `MatMulNT` は片方を転置した積 (`a^T * b` と `a * b^T`) です。どちらも両オペランドを行方向に読み、転置コピーを作りません。自動微分の逆伝播や attention の `q * k^T` が欲しいのはこの形です。それぞれに `Into` 形 (`MatMulInto`, `MatMulTNInto`, `MatMulNTInto`、および `AddInto`/`SubInto`/`MulInto`/`DivInto`) があり、呼び出し側が持つテンソルに書き込むので、学習ループから確保を無くせます。
+
 ### ブロードキャスト規則
 
 形状は末尾の軸から前へ向かって比較されます。NumPy とまったく同じで、2 つの軸は等しいか一方が 1 のとき互換で、足りない先頭の軸は 1 とみなされます。結果は各軸の大きい方の長さになります。

--- a/docs/guide/tensors.md
+++ b/docs/guide/tensors.md
@@ -50,6 +50,8 @@ out, _ := tensai.MatMul(scores, v)                // attention for the whole bat
 
 The per-matrix products inside a batched `MatMul` run on the same kernel as `Dot`, parallelized across the batch.
 
+`MatMulTN` and `MatMulNT` are the same product with one operand transposed — `a^T * b` and `a * b^T`. They read both operands row-wise and never build a transposed copy, which is what the autograd backward pass and attention's `q * k^T` want. Each also has an `Into` form (`MatMulInto`, `MatMulTNInto`, `MatMulNTInto`, and `AddInto`/`SubInto`/`MulInto`/`DivInto`) that writes into a tensor you already own, so a training loop can stop allocating altogether.
+
 ### Broadcasting rules
 
 Shapes are compared from the trailing axis backwards, exactly as in NumPy: two axes are compatible when they are equal or one of them is 1, and missing leading axes count as 1. The result takes the larger extent on every axis.

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -24,7 +24,7 @@ pred, _ := net.Predict(inputs)
 - **行列と N 次元テンソル** — float32 の `Matrix` と任意ランクの `Tensor`。NumPy 流のブロードキャスト、バッチ `MatMul`、ゼロコピーの `Reshape` とビュー
 - **レイヤー** — `Embedding`, `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `LayerNorm`, `Dropout` と、`ReLU`, `LeakyReLU`, `GELU`, `Sigmoid`, `Tanh`, `Softmax`
 - **学習** — `Sequential` モデルの `Compile` → `Fit` / `FitStep` → `Predict`、3 種類の損失関数、モーメンタム `SGD` / `Adam` / `AdamW`、データセットユーティリティ。MLP の 1 ステップは約 29 アロケーションで回ります
-- **自動微分** — micrograd スタイルの行列上のリバースモードエンジン。その上に `rnn.Cell`, `rnn.LSTMCell`, `rnn.SelfAttention` が乗り、BPTT はただの Go のループです
+- **自動微分** — micrograd スタイルの n 次元テンソル上のリバースモードエンジン。ブロードキャスト演算、バッチ `MatMul`、`LayerNorm`、`Embed`、`CrossEntropy` がすべて微分されるので、(batch, seq, model) の attention ブロックを直接書けます。`Tape` がステップのバッファを再利用し、charrnn の例では 1 ステップの確保量が 22MB から 0.75MB になります。その上に `rnn.Cell`, `rnn.LSTMCell`, `rnn.SelfAttention` が乗り、BPTT はただの Go のループです
 - **SIMD アクセラレーション** — Go の実験的な `simd/archsimd` パッケージで書かれた AVX2 カーネル。`GOEXPERIMENT=simd` でビルドし、それ以外のビルドは自動的にポータブル実装へフォールバックします
 - **WebGPU バックエンド** — `-tags wgpu` でバッチ `MatMul`、attention、量子化されたトランスフォーマーのデコード 1 ステップ丸ごとを wgpu-native の届く GPU 上で実行。`purego` 経由なので cgo 不要
 - **int8 / int4 量子化** — メモリ帯域に到達する weight-only 量子化 matmul、gpt-oss 用の MXFP4 も

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Despite its size, tensai reaches surprisingly far: the same kernels that train a
 - **Matrices and N-d tensors** — float32 `Matrix` and rank-N `Tensor` with NumPy-style broadcasting, batched `MatMul`, zero-copy `Reshape` and views
 - **Layers** — `Embedding`, `Dense`, `Conv2D`, `MaxPool2D`, `BatchNorm`, `LayerNorm`, `Dropout`, plus `ReLU`, `LeakyReLU`, `GELU`, `Sigmoid`, `Tanh`, and `Softmax`
 - **Training** — `Sequential` models with `Compile` → `Fit` / `FitStep` → `Predict`, three loss functions, momentum `SGD` / `Adam` / `AdamW`, and dataset utilities; a full MLP step runs in ~29 allocations
-- **Autograd** — a micrograd-style reverse-mode engine over matrices, with `rnn.Cell`, `rnn.LSTMCell`, and `rnn.SelfAttention` built on top; backpropagation through time is a plain Go loop
+- **Autograd** — a micrograd-style reverse-mode engine over n-dimensional tensors: broadcasting arithmetic, batched `MatMul`, `LayerNorm`, `Embed`, and `CrossEntropy` all differentiate, so an attention block over (batch, seq, model) is written directly. A `Tape` recycles a step's buffers, which takes the charrnn example from 22MB of allocation per step to 0.75MB. `rnn.Cell`, `rnn.LSTMCell`, and `rnn.SelfAttention` are built on top; backpropagation through time is a plain Go loop
 - **SIMD acceleration** — AVX2 kernels written with Go's experimental `simd/archsimd` package; build with `GOEXPERIMENT=simd`, and every other build uses the portable fallbacks automatically
 - **WebGPU backend** — `-tags wgpu` runs batched `MatMul`, attention, and a full quantized transformer decode step on any GPU wgpu-native reaches, through `purego` with no cgo
 - **int8 / int4 quantization** — weight-only quantized matmuls that reach memory bandwidth, plus MXFP4 for gpt-oss

--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -19,8 +19,13 @@ func TanhFwd(dst, src []float32)                 { tanhFwdGeneric(dst, src) }
 func TanhBwd(dst, grad, y []float32)             { tanhBwdGeneric(dst, grad, y) }
 func ExpShift(dst, src []float32, shift float32) { expShiftGeneric(dst, src, shift) }
 func AddSlice(dst, src []float32)                { addSliceGeneric(dst, src) }
-func ScaleSlice(dst []float32, s float32)        { scaleSliceGeneric(dst, s) }
-func SoftmaxBwdAdd(dst, grad, y []float32)       { softmaxBwdAddGeneric(dst, grad, y) }
+
+func AddSlices(dst, x, y []float32)        { addSlicesGeneric(dst, x, y) }
+func SubSlices(dst, x, y []float32)        { subSlicesGeneric(dst, x, y) }
+func MulSlices(dst, x, y []float32)        { mulSlicesGeneric(dst, x, y) }
+func DivSlices(dst, x, y []float32)        { divSlicesGeneric(dst, x, y) }
+func ScaleSlice(dst []float32, s float32)  { scaleSliceGeneric(dst, s) }
+func SoftmaxBwdAdd(dst, grad, y []float32) { softmaxBwdAddGeneric(dst, grad, y) }
 func AdamStep(w, g, m, v []float32, beta1, beta2, rc1, rc2, lr, eps, wd float32) {
 	adamStepGeneric(w, g, m, v, beta1, beta2, rc1, rc2, lr, eps, wd)
 }

--- a/internal/kernels/dispatch_simd.go
+++ b/internal/kernels/dispatch_simd.go
@@ -194,6 +194,49 @@ func ExpShift(dst, src []float32, shift float32) {
 	})
 }
 
+// AddSlices, SubSlices, MulSlices and DivSlices compute dst = x op y, the
+// element-wise ops the tensor package broadcasts with. mapSlices2 already
+// takes a separate destination, so each is one vector body.
+func AddSlices(dst, x, y []float32) {
+	if !simd.HasAVX2 {
+		addSlicesGeneric(dst, x, y)
+		return
+	}
+	mapSlices2(dst, x, y, func(a, b archsimd.Float32x8) archsimd.Float32x8 {
+		return a.Add(b)
+	})
+}
+
+func SubSlices(dst, x, y []float32) {
+	if !simd.HasAVX2 {
+		subSlicesGeneric(dst, x, y)
+		return
+	}
+	mapSlices2(dst, x, y, func(a, b archsimd.Float32x8) archsimd.Float32x8 {
+		return a.Sub(b)
+	})
+}
+
+func MulSlices(dst, x, y []float32) {
+	if !simd.HasAVX2 {
+		mulSlicesGeneric(dst, x, y)
+		return
+	}
+	mapSlices2(dst, x, y, func(a, b archsimd.Float32x8) archsimd.Float32x8 {
+		return a.Mul(b)
+	})
+}
+
+func DivSlices(dst, x, y []float32) {
+	if !simd.HasAVX2 {
+		divSlicesGeneric(dst, x, y)
+		return
+	}
+	mapSlices2(dst, x, y, func(a, b archsimd.Float32x8) archsimd.Float32x8 {
+		return a.Div(b)
+	})
+}
+
 func AddSlice(dst, src []float32) {
 	if !simd.HasAVX2 {
 		addSliceGeneric(dst, src)

--- a/internal/kernels/kernels.go
+++ b/internal/kernels/kernels.go
@@ -111,6 +111,34 @@ func expShiftGeneric(dst, src []float32, shift float32) {
 	}
 }
 
+// binSlicesGeneric computes dst = x op y for the four element-wise binary
+// ops the tensors broadcast with. They are separate loops rather than one
+// loop over a function value: the row is often short, and an indirect call
+// per element costs more than the arithmetic does.
+func addSlicesGeneric(dst, x, y []float32) {
+	for i := range dst {
+		dst[i] = x[i] + y[i]
+	}
+}
+
+func subSlicesGeneric(dst, x, y []float32) {
+	for i := range dst {
+		dst[i] = x[i] - y[i]
+	}
+}
+
+func mulSlicesGeneric(dst, x, y []float32) {
+	for i := range dst {
+		dst[i] = x[i] * y[i]
+	}
+}
+
+func divSlicesGeneric(dst, x, y []float32) {
+	for i := range dst {
+		dst[i] = x[i] / y[i]
+	}
+}
+
 // addSliceGeneric computes dst += src.
 func addSliceGeneric(dst, src []float32) {
 	for i, v := range src {

--- a/internal/kernels/kernels_test.go
+++ b/internal/kernels/kernels_test.go
@@ -311,3 +311,41 @@ func BenchmarkSoftmaxBackward4096(b *testing.B) {
 		SoftmaxBwdAdd(dst, grad, y)
 	}
 }
+
+// TestBinarySlices checks the element-wise binary kernels against the
+// scalar definition, including the masked tail and the canary just past the
+// destination.
+func TestBinarySlices(t *testing.T) {
+	ops := []struct {
+		name string
+		fn   func(dst, x, y []float32)
+		want func(a, b float32) float32
+	}{
+		{"add", AddSlices, func(a, b float32) float32 { return a + b }},
+		{"sub", SubSlices, func(a, b float32) float32 { return a - b }},
+		{"mul", MulSlices, func(a, b float32) float32 { return a * b }},
+		{"div", DivSlices, func(a, b float32) float32 { return a / b }},
+	}
+	for _, op := range ops {
+		for _, n := range []int{1, 3, 7, 8, 9, 31, 64} {
+			x := make([]float32, n)
+			y := make([]float32, n)
+			for i := range x {
+				x[i] = float32(i) - 3
+				y[i] = float32(i)*0.5 + 1 // never zero, so div stays finite
+			}
+			dst := make([]float32, n+1)
+			dst[n] = 42 // canary just past the writable range
+			op.fn(dst[:n], x, y)
+			if dst[n] != 42 {
+				t.Fatalf("%s n=%d: kernel wrote past the slice end", op.name, n)
+			}
+			for i := range x {
+				want := op.want(x[i], y[i])
+				if diff := float64(dst[i] - want); diff > 1e-6 || diff < -1e-6 {
+					t.Fatalf("%s n=%d: dst[%d]=%g want %g", op.name, n, i, dst[i], want)
+				}
+			}
+		}
+	}
+}

--- a/ndtensor.go
+++ b/ndtensor.go
@@ -38,6 +38,29 @@ func NewTensorFromSlice(data []Float, shape ...int) (*Tensor, error) {
 	return t, nil
 }
 
+// newTensorShape wraps a shape slice the caller has just built and will not
+// touch again, skipping the copy NewTensor makes. Every tensor produced by
+// an operation goes through here: at these sizes a second small allocation
+// per op is a measurable share of the garbage a training step makes.
+func newTensorShape(shape []int) *Tensor {
+	return &Tensor{Shape: shape, Data: make([]Float, dims.Prod(shape))}
+}
+
+// Clone returns a copy of t that shares nothing with it: the way to keep a
+// value that would otherwise be recycled or overwritten.
+func (t *Tensor) Clone() *Tensor {
+	out := NewTensor(t.Shape...)
+	copy(out.Data, t.Data)
+	return out
+}
+
+// ZerosLike returns a zero tensor with the same shape as t. The two share
+// the shape header, which every operation treats as read-only, so the
+// result costs one allocation instead of two.
+func (t *Tensor) ZerosLike() *Tensor {
+	return &Tensor{Shape: t.Shape, Data: make([]Float, len(t.Data))}
+}
+
 // contiguousStrides returns the row-major element strides of a shape.
 func contiguousStrides(shape []int) []int {
 	s := make([]int, len(shape))
@@ -135,19 +158,140 @@ func (t *Tensor) Validate() error {
 	return nil
 }
 
-// tensorBinOp applies fn element-wise over the broadcast of a and b.
-func tensorBinOp(a, b *Tensor, fn func(x, y Float) Float) (*Tensor, error) {
+// binKind names the element-wise binary ops tensors broadcast with. The
+// ops are dispatched per row rather than per element: a row is handed to a
+// vector kernel whole, so the arithmetic runs 8 lanes wide instead of
+// paying an indirect call per element.
+type binKind int
+
+const (
+	binAdd binKind = iota
+	binSub
+	binMul
+	binDiv
+)
+
+// rows computes dst = x op y over a whole row.
+func (k binKind) rows(dst, x, y []Float) {
+	switch k {
+	case binAdd:
+		kernels.AddSlices(dst, x, y)
+	case binSub:
+		kernels.SubSlices(dst, x, y)
+	case binMul:
+		kernels.MulSlices(dst, x, y)
+	default:
+		kernels.DivSlices(dst, x, y)
+	}
+}
+
+// rowScalarY computes dst = x op y with y broadcast along the row.
+func (k binKind) rowScalarY(dst, x []Float, y Float) {
+	switch k {
+	case binAdd:
+		for i, v := range x {
+			dst[i] = v + y
+		}
+	case binSub:
+		for i, v := range x {
+			dst[i] = v - y
+		}
+	case binMul:
+		for i, v := range x {
+			dst[i] = v * y
+		}
+	default:
+		for i, v := range x {
+			dst[i] = v / y
+		}
+	}
+}
+
+// rowScalarX computes dst = x op y with x broadcast along the row.
+func (k binKind) rowScalarX(dst []Float, x Float, y []Float) {
+	switch k {
+	case binAdd:
+		for i, v := range y {
+			dst[i] = x + v
+		}
+	case binSub:
+		for i, v := range y {
+			dst[i] = x - v
+		}
+	case binMul:
+		for i, v := range y {
+			dst[i] = x * v
+		}
+	default:
+		for i, v := range y {
+			dst[i] = x / v
+		}
+	}
+}
+
+// scalar computes one element.
+func (k binKind) scalar(x, y Float) Float {
+	switch k {
+	case binAdd:
+		return x + y
+	case binSub:
+		return x - y
+	case binMul:
+		return x * y
+	default:
+		return x / y
+	}
+}
+
+// tensorBinOp applies op element-wise over the broadcast of a and b.
+func tensorBinOp(a, b *Tensor, kind binKind) (*Tensor, error) {
+	if dims.Same(a.Shape, b.Shape) {
+		// Equal shapes are the common case and need no broadcast plan at
+		// all: one kernel call over the whole buffer.
+		out := a.ZerosLike()
+		kind.rows(out.Data, a.Data, b.Data)
+		return out, nil
+	}
 	shape, err := dims.Broadcast(a.Shape, b.Shape)
 	if err != nil {
 		return nil, err
 	}
-	out := NewTensor(shape...)
-	if dims.Same(a.Shape, shape) && dims.Same(b.Shape, shape) {
-		for i := range out.Data {
-			out.Data[i] = fn(a.Data[i], b.Data[i])
+	out := newTensorShape(shape)
+	binBroadcast(out, a, b, shape, kind)
+	return out, nil
+}
+
+// AddInto, SubInto, MulInto and DivInto write a op b into an existing
+// tensor instead of allocating one, the way DotInto does for products. out
+// must already have the broadcast shape of the two operands; a training
+// loop that hands the same buffers back every step never allocates here.
+func AddInto(out, a, b *Tensor) error { return tensorBinOpInto(out, a, b, binAdd) }
+func SubInto(out, a, b *Tensor) error { return tensorBinOpInto(out, a, b, binSub) }
+func MulInto(out, a, b *Tensor) error { return tensorBinOpInto(out, a, b, binMul) }
+func DivInto(out, a, b *Tensor) error { return tensorBinOpInto(out, a, b, binDiv) }
+
+func tensorBinOpInto(out, a, b *Tensor, kind binKind) error {
+	if dims.Same(a.Shape, b.Shape) {
+		if !dims.Same(out.Shape, a.Shape) {
+			return fmt.Errorf("tensai: binop output shape %v, want %v", out.Shape, a.Shape)
 		}
-		return out, nil
+		kind.rows(out.Data, a.Data, b.Data)
+		return nil
 	}
+	shape, err := dims.Broadcast(a.Shape, b.Shape)
+	if err != nil {
+		return err
+	}
+	if !dims.Same(out.Shape, shape) {
+		return fmt.Errorf("tensai: binop output shape %v, want %v", out.Shape, shape)
+	}
+	binBroadcast(out, a, b, shape, kind)
+	return nil
+}
+
+// binBroadcast walks the broadcast of a and b, writing each output row with
+// the row kernel of the op.
+func binBroadcast(out, a, b *Tensor, shape []int, kind binKind) {
 	as := dims.BroadcastStrides(a.Shape, shape)
 	bs := dims.BroadcastStrides(b.Shape, shape)
 	// Walk the output row-major: the innermost axis runs as a tight loop
@@ -162,22 +306,13 @@ func tensorBinOp(a, b *Tensor, fn func(x, y Float) Float) (*Tensor, error) {
 		dst := out.Data[pos : pos+n]
 		switch {
 		case asl == 1 && bsl == 1:
-			av, bv := a.Data[offA:offA+n], b.Data[offB:offB+n]
-			for i := range dst {
-				dst[i] = fn(av[i], bv[i])
-			}
+			kind.rows(dst, a.Data[offA:offA+n], b.Data[offB:offB+n])
 		case asl == 1:
-			av, bv := a.Data[offA:offA+n], b.Data[offB]
-			for i := range dst {
-				dst[i] = fn(av[i], bv)
-			}
+			kind.rowScalarY(dst, a.Data[offA:offA+n], b.Data[offB])
 		case bsl == 1:
-			av, bv := a.Data[offA], b.Data[offB:offB+n]
-			for i := range dst {
-				dst[i] = fn(av, bv[i])
-			}
+			kind.rowScalarX(dst, a.Data[offA], b.Data[offB:offB+n])
 		default: // both broadcast, so n == 1
-			dst[0] = fn(a.Data[offA], b.Data[offB])
+			dst[0] = kind.scalar(a.Data[offA], b.Data[offB])
 		}
 		for d := last - 1; d >= 0; d-- {
 			idx[d]++
@@ -191,28 +326,27 @@ func tensorBinOp(a, b *Tensor, fn func(x, y Float) Float) (*Tensor, error) {
 			offB -= bs[d] * shape[d]
 		}
 	}
-	return out, nil
 }
 
 // Add returns t + o element-wise with broadcasting.
 func (t *Tensor) Add(o *Tensor) (*Tensor, error) {
-	return tensorBinOp(t, o, func(x, y Float) Float { return x + y })
+	return tensorBinOp(t, o, binAdd)
 }
 
 // Sub returns t - o element-wise with broadcasting.
 func (t *Tensor) Sub(o *Tensor) (*Tensor, error) {
-	return tensorBinOp(t, o, func(x, y Float) Float { return x - y })
+	return tensorBinOp(t, o, binSub)
 }
 
 // Mul returns t * o element-wise with broadcasting.
 func (t *Tensor) Mul(o *Tensor) (*Tensor, error) {
-	return tensorBinOp(t, o, func(x, y Float) Float { return x * y })
+	return tensorBinOp(t, o, binMul)
 }
 
 // Div returns t / o element-wise with broadcasting, with IEEE semantics for
 // division by zero.
 func (t *Tensor) Div(o *Tensor) (*Tensor, error) {
-	return tensorBinOp(t, o, func(x, y Float) Float { return x / y })
+	return tensorBinOp(t, o, binDiv)
 }
 
 // Transpose returns a copy of the tensor with its axes permuted; perm must
@@ -225,11 +359,7 @@ func (t *Tensor) Transpose(perm ...int) (*Tensor, error) {
 		if n < 2 {
 			return nil, fmt.Errorf("tensai: transpose needs at least 2 axes, shape %v", t.Shape)
 		}
-		perm = make([]int, n)
-		for i := range perm {
-			perm[i] = i
-		}
-		perm[n-2], perm[n-1] = perm[n-1], perm[n-2]
+		return t.swapLastTwo(), nil
 	}
 	if len(perm) != n {
 		return nil, fmt.Errorf("tensai: transpose permutation %v does not match shape %v", perm, t.Shape)
@@ -241,6 +371,9 @@ func (t *Tensor) Transpose(perm ...int) (*Tensor, error) {
 		}
 		seen[p] = true
 	}
+	if isLastTwoSwap(perm) {
+		return t.swapLastTwo(), nil
+	}
 	outShape := make([]int, n)
 	strides := contiguousStrides(t.Shape)
 	src := make([]int, n) // stride in t along each output axis
@@ -248,7 +381,7 @@ func (t *Tensor) Transpose(perm ...int) (*Tensor, error) {
 		outShape[i] = t.Shape[p]
 		src[i] = strides[p]
 	}
-	out := NewTensor(outShape...)
+	out := newTensorShape(outShape)
 	last := n - 1
 	nLast, sLast := outShape[last], src[last]
 	idx := make([]int, n)
@@ -277,61 +410,219 @@ func (t *Tensor) Transpose(perm ...int) (*Tensor, error) {
 	return out, nil
 }
 
+// swapLastTwo transposes every matrix in the stack -- the last two axes --
+// with the cache-tiled kernel Matrix.T uses, rather than the strided walk
+// a general permutation needs.
+func (t *Tensor) swapLastTwo() *Tensor {
+	n := len(t.Shape)
+	rows, cols := t.Shape[n-2], t.Shape[n-1]
+	outShape := append(append(make([]int, 0, n), t.Shape[:n-2]...), cols, rows)
+	out := newTensorShape(outShape)
+	size := rows * cols
+	for off := 0; off < len(t.Data); off += size {
+		transposeData(out.Data[off:off+size], t.Data[off:off+size], rows, cols)
+	}
+	return out
+}
+
+// isLastTwoSwap reports whether perm leaves every axis in place but the
+// last two, which it swaps.
+func isLastTwoSwap(perm []int) bool {
+	n := len(perm)
+	if n < 2 {
+		return false
+	}
+	for i := 0; i < n-2; i++ {
+		if perm[i] != i {
+			return false
+		}
+	}
+	return perm[n-2] == n-1 && perm[n-1] == n-2
+}
+
+// gemmMode selects which operand of a stacked product is transposed.
+// Backward passes need all three: the forward product, the input gradient
+// (a * b^T) and the weight gradient (a^T * b). Naming them here means none
+// of them has to materialize a transposed copy first.
+type gemmMode int
+
+const (
+	gemmNN gemmMode = iota // a * b
+	gemmTN                 // a^T * b
+	gemmNT                 // a * b^T
+)
+
+// gemmInto runs one matrix product of the given mode, splitting it across
+// CPUs when it is large enough.
+func gemmInto(out, a, b *Matrix, mode gemmMode) error {
+	switch mode {
+	case gemmTN:
+		return DotTAInto(out, a, b)
+	case gemmNT:
+		return DotTBInto(out, a, b)
+	default:
+		return DotInto(out, a, b)
+	}
+}
+
+// gemmRows runs one matrix product of the given mode on the calling
+// goroutine; the batched path parallelizes across matrices instead.
+func gemmRows(out, a, b *Matrix, mode gemmMode) {
+	switch mode {
+	case gemmTN:
+		clear(out.Data) // dotTARows accumulates into out
+		dotTARows(out, a, b, 0, a.Cols)
+	case gemmNT:
+		dotTBRows(out, a, b, 0, a.Rows)
+	default:
+		dotRows(out, a, b, 0, a.Rows)
+	}
+}
+
 // MatMul multiplies two stacks of matrices: the last two axes of each
 // operand are the matrix dimensions and the leading axes broadcast like the
 // element-wise ops, so a (batch..., m, k) tensor times a (batch..., k, n)
 // tensor yields (batch..., m, n). Both operands need at least 2 axes. The
 // per-matrix products run on the same kernel as Dot, parallelized across
 // the batch.
-func MatMul(a, b *Tensor) (*Tensor, error) {
+func MatMul(a, b *Tensor) (*Tensor, error) { return matmulStack(a, b, gemmNN) }
+
+// MatMulTN multiplies the transpose of every matrix in a by the matching
+// matrix in b: a is (batch..., k, m), b is (batch..., k, n), and the result
+// is (batch..., m, n). This is the weight gradient of a matmul, computed
+// without transposing a first.
+func MatMulTN(a, b *Tensor) (*Tensor, error) { return matmulStack(a, b, gemmTN) }
+
+// MatMulNT multiplies every matrix in a by the transpose of the matching
+// matrix in b: a is (batch..., m, k), b is (batch..., n, k), and the result
+// is (batch..., m, n). This is the input gradient of a matmul, and also the
+// q * k^T of attention, computed without transposing b first.
+func MatMulNT(a, b *Tensor) (*Tensor, error) { return matmulStack(a, b, gemmNT) }
+
+// MatMulInto, MatMulTNInto and MatMulNTInto write the product into an
+// existing tensor rather than allocating one, like DotInto one rank down.
+// out must already have the product's shape.
+func MatMulInto(out, a, b *Tensor) error   { return matmulStackInto(out, a, b, gemmNN) }
+func MatMulTNInto(out, a, b *Tensor) error { return matmulStackInto(out, a, b, gemmTN) }
+func MatMulNTInto(out, a, b *Tensor) error { return matmulStackInto(out, a, b, gemmNT) }
+
+// gemmDims holds the per-matrix geometry of a stacked product: the logical
+// product is (m, k) * (k, n), while aRows/aCols and bRows/bCols are how the
+// operands are actually stored (swapped for a transposed mode).
+type gemmDims struct {
+	m, k, n                    int
+	aRows, aCols, bRows, bCols int
+}
+
+// gemmResolve works out that geometry and checks the inner dimensions.
+func gemmResolve(a, b *Tensor, mode gemmMode) (gemmDims, error) {
 	na, nb := len(a.Shape), len(b.Shape)
 	if na < 2 || nb < 2 {
-		return nil, fmt.Errorf("tensai: matmul needs at least 2 axes: %v * %v", a.Shape, b.Shape)
+		return gemmDims{}, fmt.Errorf("tensai: matmul needs at least 2 axes: %v * %v", a.Shape, b.Shape)
 	}
-	m, k := a.Shape[na-2], a.Shape[na-1]
-	if b.Shape[nb-2] != k {
-		return nil, fmt.Errorf("tensai: matmul shape mismatch: %v * %v", a.Shape, b.Shape)
+	d := gemmDims{
+		aRows: a.Shape[na-2], aCols: a.Shape[na-1],
+		bRows: b.Shape[nb-2], bCols: b.Shape[nb-1],
 	}
-	n := b.Shape[nb-1]
+	switch mode {
+	case gemmTN:
+		d.k, d.m, d.n = d.aRows, d.aCols, d.bCols
+		if d.bRows != d.k {
+			return gemmDims{}, fmt.Errorf("tensai: matmul shape mismatch: (%v)^T * %v", a.Shape, b.Shape)
+		}
+	case gemmNT:
+		d.m, d.k, d.n = d.aRows, d.aCols, d.bRows
+		if d.bCols != d.k {
+			return gemmDims{}, fmt.Errorf("tensai: matmul shape mismatch: %v * (%v)^T", a.Shape, b.Shape)
+		}
+	default:
+		d.m, d.k, d.n = d.aRows, d.aCols, d.bCols
+		if d.bRows != d.k {
+			return gemmDims{}, fmt.Errorf("tensai: matmul shape mismatch: %v * %v", a.Shape, b.Shape)
+		}
+	}
+	return d, nil
+}
+
+// matmulStack is the shared body of the three allocating products above.
+func matmulStack(a, b *Tensor, mode gemmMode) (*Tensor, error) {
+	d, err := gemmResolve(a, b, mode)
+	if err != nil {
+		return nil, err
+	}
+	na, nb := len(a.Shape), len(b.Shape)
+	if na == 2 && nb == 2 {
+		out := newTensorShape([]int{d.m, d.n})
+		return out, gemmExec(out, a, b, d, mode, nil)
+	}
 	batch, err := dims.Broadcast(a.Shape[:na-2], b.Shape[:nb-2])
 	if err != nil {
 		return nil, err
 	}
-	out := NewTensor(append(append([]int(nil), batch...), m, n)...)
+	out := newTensorShape(append(append(make([]int, 0, len(batch)+2), batch...), d.m, d.n))
+	return out, gemmExec(out, a, b, d, mode, batch)
+}
+
+// matmulStackInto is the same product written into a caller-owned tensor.
+func matmulStackInto(out, a, b *Tensor, mode gemmMode) error {
+	d, err := gemmResolve(a, b, mode)
+	if err != nil {
+		return err
+	}
+	na, nb := len(a.Shape), len(b.Shape)
+	no := len(out.Shape)
+	if no < 2 || out.Shape[no-2] != d.m || out.Shape[no-1] != d.n {
+		return fmt.Errorf("tensai: matmul output shape %v, want (..., %d, %d)", out.Shape, d.m, d.n)
+	}
+	var batch []int
+	if na > 2 || nb > 2 {
+		if batch, err = dims.Broadcast(a.Shape[:na-2], b.Shape[:nb-2]); err != nil {
+			return err
+		}
+		if !dims.Same(out.Shape[:no-2], batch) {
+			return fmt.Errorf("tensai: matmul output shape %v, want batch %v", out.Shape, batch)
+		}
+	} else if no != 2 {
+		return fmt.Errorf("tensai: matmul output shape %v, want (%d, %d)", out.Shape, d.m, d.n)
+	}
+	return gemmExec(out, a, b, d, mode, batch)
+}
+
+// gemmExec runs the product. batch is nil when both operands are plain
+// matrices; otherwise it is the broadcast shape of the leading axes.
+func gemmExec(out, a, b *Tensor, d gemmDims, mode gemmMode, batch []int) error {
+	view := func(rows, cols int, data []Float) *Matrix {
+		return &Matrix{Rows: rows, Cols: cols, Data: data}
+	}
 	batches := dims.Prod(batch)
 	if batches == 1 {
-		// A single product: let DotInto split its rows across CPUs.
-		am := &Matrix{Rows: m, Cols: k, Data: a.Data}
-		bm := &Matrix{Rows: k, Cols: n, Data: b.Data}
-		om := &Matrix{Rows: m, Cols: n, Data: out.Data}
-		if err := DotInto(om, am, bm); err != nil {
-			return nil, err
-		}
-		return out, nil
+		// One product: let the kernel split its rows across CPUs.
+		return gemmInto(view(d.m, d.n, out.Data),
+			view(d.aRows, d.aCols, a.Data), view(d.bRows, d.bCols, b.Data), mode)
 	}
 	// Strides are in whole matrices; broadcast batch axes advance by 0.
+	na, nb := len(a.Shape), len(b.Shape)
 	as := dims.BroadcastStrides(a.Shape[:na-2], batch)
 	bs := dims.BroadcastStrides(b.Shape[:nb-2], batch)
-	sizeA, sizeB, sizeO := m*k, k*n, m*n
+	sizeA, sizeB, sizeO := d.aRows*d.aCols, d.bRows*d.bCols, d.m*d.n
 	run := func(lo, hi int) {
 		for bi := lo; bi < hi; bi++ {
 			offA, offB := 0, 0
-			for d, rem := len(batch)-1, bi; d >= 0; d-- {
-				i := rem % batch[d]
-				rem /= batch[d]
-				offA += i * as[d]
-				offB += i * bs[d]
+			for ax, rem := len(batch)-1, bi; ax >= 0; ax-- {
+				i := rem % batch[ax]
+				rem /= batch[ax]
+				offA += i * as[ax]
+				offB += i * bs[ax]
 			}
-			am := &Matrix{Rows: m, Cols: k, Data: a.Data[offA*sizeA : (offA+1)*sizeA]}
-			bm := &Matrix{Rows: k, Cols: n, Data: b.Data[offB*sizeB : (offB+1)*sizeB]}
-			om := &Matrix{Rows: m, Cols: n, Data: out.Data[bi*sizeO : (bi+1)*sizeO]}
-			dotRows(om, am, bm, 0, m)
+			gemmRows(view(d.m, d.n, out.Data[bi*sizeO:(bi+1)*sizeO]),
+				view(d.aRows, d.aCols, a.Data[offA*sizeA:(offA+1)*sizeA]),
+				view(d.bRows, d.bCols, b.Data[offB*sizeB:(offB+1)*sizeB]), mode)
 		}
 	}
-	workers := dotWorkerCount(batches, sizeA, n)
+	workers := dotWorkerCount(batches, sizeA, d.n)
 	if workers == 1 {
 		run(0, batches)
-		return out, nil
+		return nil
 	}
 	chunk := (batches + workers - 1) / workers
 	var wg sync.WaitGroup
@@ -347,5 +638,5 @@ func MatMul(a, b *Tensor) (*Tensor, error) {
 		}(lo, hi)
 	}
 	wg.Wait()
-	return out, nil
+	return nil
 }

--- a/ndtensor_test.go
+++ b/ndtensor_test.go
@@ -325,3 +325,80 @@ func TestTensorReshapeAndViews(t *testing.T) {
 		t.Fatal("expected validate error")
 	}
 }
+
+// TestMatMulTransposedModes checks the two transposed products against the
+// same result built with an explicit Transpose, for plain and batched
+// shapes and for a broadcast operand.
+func TestMatMulTransposedModes(t *testing.T) {
+	rng := rand.New(rand.NewSource(97))
+	cases := []struct {
+		a, b []int
+	}{
+		{[]int{4, 3}, []int{4, 5}},       // a^T * b, plain
+		{[]int{2, 4, 3}, []int{2, 4, 5}}, // batched
+		{[]int{2, 3, 4, 3}, []int{4, 5}}, // broadcast b
+		{[]int{4, 3}, []int{2, 4, 5}},    // broadcast a
+	}
+	for _, c := range cases {
+		a, b := randTensor(rng, c.a...), randTensor(rng, c.b...)
+		at, err := a.Transpose()
+		if err != nil {
+			t.Fatalf("transpose %v: %v", c.a, err)
+		}
+		want, err := MatMul(at, b)
+		if err != nil {
+			t.Fatalf("matmul %v^T*%v: %v", c.a, c.b, err)
+		}
+		got, err := MatMulTN(a, b)
+		if err != nil {
+			t.Fatalf("matmul TN %v*%v: %v", c.a, c.b, err)
+		}
+		tensorsClose(t, got, want, 1e-4)
+	}
+
+	ntCases := []struct {
+		a, b []int
+	}{
+		{[]int{4, 3}, []int{5, 3}},
+		{[]int{2, 4, 3}, []int{2, 5, 3}},
+		{[]int{2, 3, 4, 3}, []int{5, 3}},
+		{[]int{4, 3}, []int{2, 5, 3}},
+	}
+	for _, c := range ntCases {
+		a, b := randTensor(rng, c.a...), randTensor(rng, c.b...)
+		bt, err := b.Transpose()
+		if err != nil {
+			t.Fatalf("transpose %v: %v", c.b, err)
+		}
+		want, err := MatMul(a, bt)
+		if err != nil {
+			t.Fatalf("matmul %v*%v^T: %v", c.a, c.b, err)
+		}
+		got, err := MatMulNT(a, b)
+		if err != nil {
+			t.Fatalf("matmul NT %v*%v: %v", c.a, c.b, err)
+		}
+		tensorsClose(t, got, want, 1e-4)
+	}
+
+	// Mismatched inner dimensions must be rejected, not silently reshaped.
+	if _, err := MatMulTN(randTensor(rng, 4, 3), randTensor(rng, 5, 2)); err == nil {
+		t.Error("MatMulTN with mismatched rows should fail")
+	}
+	if _, err := MatMulNT(randTensor(rng, 4, 3), randTensor(rng, 5, 2)); err == nil {
+		t.Error("MatMulNT with mismatched columns should fail")
+	}
+}
+
+// TestTensorClone checks that a clone shares no memory with its source.
+func TestTensorClone(t *testing.T) {
+	rng := rand.New(rand.NewSource(5))
+	a := randTensor(rng, 2, 3, 4)
+	b := a.Clone()
+	tensorsClose(t, b, a, 0)
+	b.Data[0] += 1
+	b.Shape[0] = 1
+	if a.Data[0] == b.Data[0] || a.Shape[0] != 2 {
+		t.Error("clone shares storage with the original")
+	}
+}

--- a/rnn/rnn.go
+++ b/rnn/rnn.go
@@ -41,7 +41,7 @@ func (c *Cell) Step(x, h *autograd.Node) *autograd.Node {
 
 // InitState returns a zero hidden state for the given batch size.
 func (c *Cell) InitState(batch int) *autograd.Node {
-	return autograd.Input(tensai.NewMatrix(batch, c.Wh.Value.Rows))
+	return autograd.Input(tensai.NewMatrix(batch, c.Wh.Value.Shape[0]))
 }
 
 // Params returns the cell's trainable parameters, for NewTrainer.
@@ -94,7 +94,7 @@ func (c *LSTMCell) Step(x, h, cell *autograd.Node) (*autograd.Node, *autograd.No
 
 // InitState returns zero (hidden, cell) states for the given batch size.
 func (c *LSTMCell) InitState(batch int) (*autograd.Node, *autograd.Node) {
-	hidden := c.Whf.Value.Rows
+	hidden := c.Whf.Value.Shape[0]
 	return autograd.Input(tensai.NewMatrix(batch, hidden)), autograd.Input(tensai.NewMatrix(batch, hidden))
 }
 
@@ -111,7 +111,7 @@ func (c *LSTMCell) Params() []*autograd.Node {
 // Attention computes scaled dot-product attention softmax(q*k^T/sqrt(d))*v
 // for a single sequence, where q, k, v are (seqLen x d) nodes.
 func Attention(q, k, v *autograd.Node) *autograd.Node {
-	scale := 1 / kernels.SqrtF(tensai.Float(k.Value.Cols))
+	scale := 1 / kernels.SqrtF(tensai.Float(k.Value.Shape[1]))
 	return q.MatMul(k.T()).Scale(scale).Softmax().MatMul(v)
 }
 

--- a/rnn/rnn_test.go
+++ b/rnn/rnn_test.go
@@ -14,7 +14,7 @@ import (
 // checkParamGrad compares the analytic gradient of loss w.r.t. param against
 // finite differences. build must construct the graph fresh from the current
 // matrix contents and return (loss node, param node).
-func checkParamGrad(t *testing.T, param *tensai.Matrix, build func() (*autograd.Node, *autograd.Node), name string) {
+func checkParamGrad(t *testing.T, param *tensai.Tensor, build func() (*autograd.Node, *autograd.Node), name string) {
 	t.Helper()
 	loss, p := build()
 	// Param nodes may be shared across successive checks; Backward
@@ -154,7 +154,7 @@ func TestRNNLearnsParity(t *testing.T) {
 
 	var lossVal tensai.Float
 	for step := 0; step < 800; step++ {
-		lossVal = trainer.Step(forward().SoftmaxCELoss(targets))
+		lossVal = trainer.Step(forward().SoftmaxCELoss(targets.Tensor()))
 	}
 	if lossVal > 0.1 {
 		t.Fatalf("RNN failed to learn parity: loss=%g", lossVal)
@@ -176,7 +176,7 @@ func TestSaveLoadParams(t *testing.T) {
 	cell := NewLSTMCell(3, 5, rng)
 	x := tensai.RandomMatrix(4, 3, rng)
 
-	forward := func(c *LSTMCell) *tensai.Matrix {
+	forward := func(c *LSTMCell) *tensai.Tensor {
 		h, s := c.InitState(4)
 		h, _ = c.Step(autograd.Input(x), h, s)
 		return h.Value

--- a/tensor.go
+++ b/tensor.go
@@ -170,6 +170,13 @@ func DotTAInto(out, a, b *Matrix) error {
 	}
 	clear(out.Data) // dotTARows accumulates
 	workers := dotWorkerCount(a.Cols, a.Rows, b.Cols)
+	if workers == 1 {
+		// Small products stay on this goroutine: waking workers for them
+		// costs more than the arithmetic, and a training step runs
+		// thousands of small products.
+		dotTARows(out, a, b, 0, a.Cols)
+		return nil
+	}
 	chunk := (a.Cols + workers - 1) / workers
 	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {
@@ -204,6 +211,48 @@ func dotTARowsGeneric(out, a, b *Matrix, lo, hi int) {
 				outRow[c] += av * bv
 			}
 		}
+	}
+}
+
+// DotTBInto computes out = a * b^T, the product every backward pass needs
+// for the left operand of a matmul. a is (m, k) and b is (n, k): both
+// operands are read row-wise, so the whole product runs on the vectorized
+// row-dot kernel and no transpose is materialized.
+func DotTBInto(out, a, b *Matrix) error {
+	if a.Cols != b.Cols {
+		return fmt.Errorf("tensai: dottb shape mismatch: %dx%d * (%dx%d)^T", a.Rows, a.Cols, b.Rows, b.Cols)
+	}
+	if out.Rows != a.Rows || out.Cols != b.Rows {
+		return fmt.Errorf("tensai: dottb output shape mismatch: got %dx%d, want %dx%d",
+			out.Rows, out.Cols, a.Rows, b.Rows)
+	}
+	workers := dotWorkerCount(a.Rows, a.Cols, b.Rows)
+	if workers == 1 {
+		dotTBRows(out, a, b, 0, a.Rows)
+		return nil
+	}
+	chunk := (a.Rows + workers - 1) / workers
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		lo, hi := w*chunk, (w+1)*chunk
+		if hi > a.Rows {
+			hi = a.Rows
+		}
+		wg.Add(1)
+		go func(lo, hi int) {
+			defer wg.Done()
+			dotTBRows(out, a, b, lo, hi)
+		}(lo, hi)
+	}
+	wg.Wait()
+	return nil
+}
+
+// dotTBRows computes rows lo..hi of out = a * b^T. Each output row is one
+// row of a dotted against every row of b, which is what DotVecs does.
+func dotTBRows(out, a, b *Matrix, lo, hi int) {
+	for r := lo; r < hi; r++ {
+		kernels.DotVecs(b.Data, a.Data[r*a.Cols:(r+1)*a.Cols], out.Data[r*out.Cols:(r+1)*out.Cols])
 	}
 }
 
@@ -273,9 +322,7 @@ func Add(a, b *Matrix) (*Matrix, error) {
 		return nil, fmt.Errorf("tensai: add shape mismatch: %dx%d vs %dx%d", a.Rows, a.Cols, b.Rows, b.Cols)
 	}
 	out := NewMatrix(a.Rows, a.Cols)
-	for i := range a.Data {
-		out.Data[i] = a.Data[i] + b.Data[i]
-	}
+	kernels.AddSlices(out.Data, a.Data, b.Data)
 	return out, nil
 }
 
@@ -286,9 +333,8 @@ func AddBias(a *Matrix, bias []Float) (*Matrix, error) {
 	}
 	out := NewMatrix(a.Rows, a.Cols)
 	for r := 0; r < a.Rows; r++ {
-		for c := 0; c < a.Cols; c++ {
-			out.Data[r*a.Cols+c] = a.Data[r*a.Cols+c] + bias[c]
-		}
+		lo, hi := r*a.Cols, (r+1)*a.Cols
+		kernels.AddSlices(out.Data[lo:hi], a.Data[lo:hi], bias)
 	}
 	return out, nil
 }


### PR DESCRIPTION
Node values and gradients are tensors now, so element-wise ops broadcast and MatMul multiplies stacks of matrices, with a Matrix still accepted wherever a leaf is built as a zero-copy view. Div, Neg, Transpose, Reshape, SumAxis/MeanAxis, LayerNorm, Embed, GELU, LeakyReLU, Exp, Log and CrossEntropy come with it, each checked against finite differences, along with a batched single-head attention block that trains in the tests.

Backward passes no longer materialize transposed copies: MatMulTN and MatMulNT (DotTBInto behind the latter) read both operands row-wise instead. Element-wise tensor arithmetic runs on new AddSlices/SubSlices/MulSlices/DivSlices kernels rather than a call per element, and the last-two-axis transpose uses the tiled kernel Matrix.T already had.

autograd.Tape recycles the buffers a step allocates: bind the parameters once, reset after each step. A charrnn training step goes from 27.8MB and 365ms to 0.75MB and 259ms. The old matrix-shaped code keeps working, apart from Node.Value.Rows/Cols becoming Shape and the loss methods taking a Tensor; old parameter checkpoints still load.