### PR TITLE
Add a character-level transformer example and rewrite the autograd guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ _example/spiral     Runnable 3-class spiral classification example
 _example/iris       Runnable Iris classification example
 _example/mnist      Runnable MNIST classifier (-model dense, cnn, or knn) with save/load
 _example/charrnn    Character-level LSTM text generation on the autograd engine
+_example/tinygpt    Character-level transformer (multi-head causal attention) trained from scratch
 _example/plasma     Demoscene-style terminal plasma rendered by a neural network
 _example/dot        Graphviz DOT export of the z = x + y graph
 _example/tensor     Tour of the n-d Tensor: broadcasting, batched MatMul, attention
@@ -278,6 +279,29 @@ for step := 0; step < epochs; step++ {
 
 `rnn.SelfAttention` operates on one `(seqLen x inSize)` sequence node: `attn.Forward(x)` computes `softmax(Q*K^T/sqrt(d))*V` with learned projections; the raw `rnn.Attention(q, k, v)` form is also exposed.
 
+Batches and heads are written directly on the n-dimensional engine instead: the per-head split is a `Reshape` plus a `Transpose`, and every score in the batch is one `MatMul`.
+
+```go
+heads := func(t *autograd.Node) *autograd.Node { // (batch, seq, model) -> (batch, head, seq, headDim)
+	return t.Reshape(batch, seq, nHeads, headDim).Transpose(0, 2, 1, 3)
+}
+q, k, v := heads(x.MatMul(wq)), heads(x.MatMul(wk)), heads(x.MatMul(wv))
+att := q.MatMul(k.T()).Scale(scale).Add(causalMask).Softmax() // (batch, head, seq, seq)
+y := att.MatMul(v).Transpose(0, 2, 1, 3).Reshape(batch, seq, model).MatMul(wo)
+```
+
+`_example/tinygpt` is that block inside a working character-level transformer — token and position embeddings, two pre-norm blocks, a GELU feed-forward, and next-character cross-entropy. 106k parameters, about a minute of training with the AVX2 build, after which it writes the corpus back:
+
+```
+$ GOEXPERIMENT=simd go run ./_example/tinygpt
+corpus: 1660 chars, vocab: 43, parameters: 106496
+iter    1: loss=4.7166
+iter 1000: loss=0.2258
+
+generated:
+Alice was beginning to get very tired of sitting by her sister on the bank, and look, aving nothing to do: once or twice coat-pocket, and looker a with ouble of of getting up and picgung to a daisies, when suddenly  a White Rabbit with pink eyes  ran close by her.
+```
+
 Autograd parameters are saved and restored positionally with `autograd.SaveParamsFile("cell.json", cell.Params()...)` / `autograd.LoadParamsFile("cell.json", cell.Params()...)` — build the same cell, then load.
 
 ### N-d tensors: broadcasting and batched MatMul
@@ -409,6 +433,7 @@ go run ./_example/fizzbuzz
 go run ./_example/spiral
 go run ./_example/iris
 go run ./_example/charrnn
+GOEXPERIMENT=simd go run ./_example/tinygpt      # trains a small transformer, ~1 minute
 go run ./_example/plasma
 go run ./_example/tensor
 GOEXPERIMENT=simd go run ./_example/gpt2          # downloads the GPT-2 checkpoint (~550MB) on first run

--- a/_example/tinygpt/main.go
+++ b/_example/tinygpt/main.go
@@ -1,0 +1,281 @@
+// Command tinygpt trains a small character-level transformer -- token and
+// position embeddings, pre-norm blocks with multi-head causal attention and
+// a GELU feed-forward, a final norm and an output projection -- and then
+// generates text from it.
+//
+// Everything below is written directly against the n-dimensional autograd
+// engine: activations are (batch, sequence, model) tensors, the per-head
+// split is a Reshape plus a Transpose, and every attention score in the
+// batch is one batched MatMul. The gradients come from the engine, so the
+// model is only its forward pass.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"strings"
+
+	tensai "github.com/mattn/tensai"
+	"github.com/mattn/tensai/autograd"
+	"github.com/mattn/tensai/optim"
+)
+
+const (
+	seqLen    = 32 // tokens the model sees at once
+	dModel    = 64
+	nHeads    = 4
+	headDim   = dModel / nHeads
+	dFF       = 4 * dModel
+	nBlocks   = 2
+	batchSize = 8
+	eps       = 1e-5
+)
+
+// block is one pre-norm transformer block.
+type block struct {
+	ln1g, ln1b     *autograd.Node // (dModel)
+	wq, wk, wv, wo *autograd.Node // (dModel, dModel)
+	ln2g, ln2b     *autograd.Node // (dModel)
+	w1             *autograd.Node // (dModel, dFF)
+	w2             *autograd.Node // (dFF, dModel)
+}
+
+func newBlock(rng *rand.Rand) *block {
+	return &block{
+		ln1g: autograd.Param(ones(dModel)),
+		ln1b: autograd.Param(tensai.NewTensor(dModel)),
+		wq:   autograd.Param(tensai.RandomMatrix(dModel, dModel, rng)),
+		wk:   autograd.Param(tensai.RandomMatrix(dModel, dModel, rng)),
+		wv:   autograd.Param(tensai.RandomMatrix(dModel, dModel, rng)),
+		wo:   autograd.Param(tensai.RandomMatrix(dModel, dModel, rng)),
+		ln2g: autograd.Param(ones(dModel)),
+		ln2b: autograd.Param(tensai.NewTensor(dModel)),
+		w1:   autograd.Param(tensai.RandomMatrix(dModel, dFF, rng)),
+		w2:   autograd.Param(tensai.RandomMatrix(dFF, dModel, rng)),
+	}
+}
+
+func (b *block) params() []*autograd.Node {
+	return []*autograd.Node{b.ln1g, b.ln1b, b.wq, b.wk, b.wv, b.wo, b.ln2g, b.ln2b, b.w1, b.w2}
+}
+
+// heads splits the model axis into heads and moves them in front of the
+// sequence, turning (batch, seq, model) into (batch, head, seq, headDim) so
+// that one MatMul attends every head of every sequence at once.
+func heads(x *autograd.Node, batch int) *autograd.Node {
+	return x.Reshape(batch, seqLen, nHeads, headDim).Transpose(0, 2, 1, 3)
+}
+
+// forward runs one block over a (batch, seq, model) activation. mask is the
+// causal (1, 1, seq, seq) constant.
+func (b *block) forward(x, mask *autograd.Node, batch int) *autograd.Node {
+	h := x.LayerNorm(b.ln1g, b.ln1b, eps)
+	q, k, v := heads(h.MatMul(b.wq), batch), heads(h.MatMul(b.wk), batch), heads(h.MatMul(b.wv), batch)
+
+	// (batch, head, seq, seq) scores, masked so a position only sees what
+	// came before it, then the weighted sum of the values.
+	att := q.MatMul(k.T()).Scale(1 / float32(math.Sqrt(headDim))).Add(mask).Softmax()
+	merged := att.MatMul(v).Transpose(0, 2, 1, 3).Reshape(batch, seqLen, dModel)
+	x = x.Add(merged.MatMul(b.wo))
+
+	h = x.LayerNorm(b.ln2g, b.ln2b, eps)
+	return x.Add(h.MatMul(b.w1).GELU().MatMul(b.w2))
+}
+
+// model is the whole network.
+type model struct {
+	tok        *autograd.Node // (vocab, dModel)
+	pos        *autograd.Node // (1, seq, dModel)
+	blocks     []*block
+	lnfg, lnfb *autograd.Node // (dModel)
+	wOut       *autograd.Node // (dModel, vocab)
+	mask       *autograd.Node // (1, 1, seq, seq)
+	tape       *autograd.Tape
+	vocab      []rune
+	index      map[rune]int
+}
+
+func newModel(vocab []rune, rng *rand.Rand) *model {
+	m := &model{
+		tok:   autograd.Param(tensai.RandomMatrix(len(vocab), dModel, rng)),
+		pos:   autograd.Param(reshape(tensai.RandomMatrix(seqLen, dModel, rng).Tensor(), 1, seqLen, dModel)),
+		lnfg:  autograd.Param(ones(dModel)),
+		lnfb:  autograd.Param(tensai.NewTensor(dModel)),
+		wOut:  autograd.Param(tensai.RandomMatrix(dModel, len(vocab), rng)),
+		mask:  autograd.Input(causalMask(seqLen)),
+		vocab: vocab,
+		index: make(map[rune]int, len(vocab)),
+	}
+	for i, r := range vocab {
+		m.index[r] = i
+	}
+	for i := 0; i < nBlocks; i++ {
+		m.blocks = append(m.blocks, newBlock(rng))
+	}
+	return m
+}
+
+func (m *model) params() []*autograd.Node {
+	ps := []*autograd.Node{m.tok, m.pos, m.lnfg, m.lnfb, m.wOut}
+	for _, b := range m.blocks {
+		ps = append(ps, b.params()...)
+	}
+	return ps
+}
+
+// forward maps batch*seqLen token ids to (batch, seq, vocab) logits.
+func (m *model) forward(tokens []int, batch int) *autograd.Node {
+	x := m.tok.Embed(tokens, batch, seqLen).Add(m.pos) // the position row broadcasts over the batch
+	for _, b := range m.blocks {
+		x = b.forward(x, m.mask, batch)
+	}
+	return x.LayerNorm(m.lnfg, m.lnfb, eps).MatMul(m.wOut)
+}
+
+// batchAt draws random windows out of the text: each row predicts the next
+// character at every position.
+func (m *model) batchAt(text []rune, rng *rand.Rand) (tokens, labels []int) {
+	tokens = make([]int, 0, batchSize*seqLen)
+	labels = make([]int, 0, batchSize*seqLen)
+	for i := 0; i < batchSize; i++ {
+		p := rng.Intn(len(text) - seqLen - 1)
+		for t := 0; t < seqLen; t++ {
+			tokens = append(tokens, m.index[text[p+t]])
+			labels = append(labels, m.index[text[p+t+1]])
+		}
+	}
+	return tokens, labels
+}
+
+// generate continues the seed text one character at a time. The window is
+// always seqLen tokens wide, so the position embedding always lines up.
+func (m *model) generate(seed []rune, n int, temperature float32, rng *rand.Rand) string {
+	window := make([]int, seqLen)
+	for i, r := range seed[len(seed)-seqLen:] {
+		window[i] = m.index[r]
+	}
+	var sb strings.Builder
+	vocab := len(m.vocab)
+	for i := 0; i < n; i++ {
+		logits := m.forward(window, 1).Scale(1 / temperature).Softmax().Value
+		// The next character is the distribution at the last position. It
+		// is read before the tape recycles the buffer it lives in.
+		next := sample(logits.Data[(seqLen-1)*vocab:], rng)
+		m.tape.Reset()
+		sb.WriteRune(m.vocab[next])
+		copy(window, window[1:])
+		window[seqLen-1] = next
+	}
+	return sb.String()
+}
+
+func sample(probs []tensai.Float, rng *rand.Rand) int {
+	x := float32(rng.Float64())
+	for i, p := range probs {
+		x -= p
+		if x <= 0 {
+			return i
+		}
+	}
+	return len(probs) - 1
+}
+
+// causalMask is zero on and below the diagonal and -Inf above it, so
+// softmax gives future positions no weight at all.
+func causalMask(n int) *tensai.Tensor {
+	mask := tensai.NewTensor(1, 1, n, n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			mask.Data[i*n+j] = tensai.Float(math.Inf(-1))
+		}
+	}
+	return mask
+}
+
+func ones(n int) *tensai.Tensor {
+	t := tensai.NewTensor(n)
+	for i := range t.Data {
+		t.Data[i] = 1
+	}
+	return t
+}
+
+func reshape(t *tensai.Tensor, shape ...int) *tensai.Tensor {
+	out, err := t.Reshape(shape...)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func vocabOf(text []rune) []rune {
+	seen := map[rune]bool{}
+	var vocab []rune
+	for _, r := range text {
+		if !seen[r] {
+			seen[r] = true
+			vocab = append(vocab, r)
+		}
+	}
+	return vocab
+}
+
+func main() {
+	iters := flag.Int("iters", 1000, "training steps")
+	lr := flag.Float64("lr", 0.003, "Adam learning rate")
+	temp := flag.Float64("temp", 0.8, "sampling temperature")
+	n := flag.Int("n", 400, "characters to generate")
+	seed := flag.Int64("seed", 7, "random seed")
+	flag.Parse()
+
+	text := []rune(corpus)
+	vocab := vocabOf(text)
+	rng := rand.New(rand.NewSource(*seed))
+	m := newModel(vocab, rng)
+
+	params := m.params()
+	var count int
+	for _, p := range params {
+		count += len(p.Value.Data)
+	}
+	fmt.Printf("corpus: %d chars, vocab: %d, parameters: %d\n", len(text), len(vocab), count)
+
+	trainer := autograd.NewTrainer(optim.NewAdam(tensai.Float(*lr)), params...)
+	// Every step builds a fresh graph and drops it; the tape hands the last
+	// step's buffers back instead of allocating them again.
+	tape := autograd.NewTape()
+	tape.Bind(params...)
+	m.tape = tape
+
+	for it := 1; it <= *iters; it++ {
+		tokens, labels := m.batchAt(text, rng)
+		lossVal := trainer.Step(m.forward(tokens, batchSize).CrossEntropy(labels))
+		tape.Reset()
+		if it == 1 || it%50 == 0 {
+			fmt.Printf("iter %4d: loss=%.4f\n", it, lossVal)
+		}
+	}
+
+	if len(text) < seqLen {
+		fmt.Fprintln(os.Stderr, "tinygpt: corpus shorter than the context window")
+		os.Exit(1)
+	}
+	prompt := text[:seqLen]
+	fmt.Printf("\nprompt: %q\n\ngenerated:\n%s\n", string(prompt),
+		string(prompt)+m.generate(prompt, *n, float32(*temp), rand.New(rand.NewSource(*seed+1))))
+}
+
+// The opening of "Alice's Adventures in Wonderland" by Lewis Carroll
+// (public domain), the same text _example/charrnn learns.
+const corpus = `Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, "and what is the use of a book," thought Alice "without pictures or conversations?"
+
+So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.
+
+There was nothing so very remarkable in that; nor did Alice think it so very much out of the way to hear the Rabbit say to itself, "Oh dear! Oh dear! I shall be late!" (when she thought it over afterwards, it occurred to her that she ought to have wondered at this, but at the time it all seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket, and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she ran across the field after it, and fortunately was just in time to see it pop down a large rabbit-hole under the hedge.
+
+In another moment down went Alice after it, never once considering how in the world she was to get out again.
+
+The rabbit-hole went straight on like a tunnel for some way, and then dipped suddenly down, so suddenly that Alice had not a moment to think about stopping herself before she found herself falling down a very deep well.`

--- a/docs/examples.ja.md
+++ b/docs/examples.ja.md
@@ -12,6 +12,7 @@
 | iris | `go run ./_example/iris` | Iris の分類 |
 | mnist | `go run ./_example/mnist` | MNIST 分類器 (`-model dense`, `cnn`, `knn`) と保存/読込 |
 | charrnn | `go run ./_example/charrnn` | 自動微分エンジン上の文字レベル LSTM テキスト生成 |
+| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | n 次元自動微分エンジンでゼロから学習する文字レベル transformer |
 | plasma | `go run ./_example/plasma` | ニューラルネットワークが描くターミナルプラズマ — 生きた SIMD ベンチマーク |
 | dot | `go run ./_example/dot` | z = x + y グラフの Graphviz DOT エクスポート |
 | tensor | `go run ./_example/tensor` | N 次元 Tensor ツアー: ブロードキャスト、バッチ MatMul、attention |
@@ -36,6 +37,10 @@ go run ./_example/mnist -model cnn -export mnist.tflite  # TFLite へエクス�
 ## charrnn
 
 埋め込みのパブリックドメインテキストで文字レベル LSTM を学習し、`SaveParamsFile` でパラメータを保存し、新しいモデルに復元して、再読込したパラメータからサンプルを生成します。
+
+## tinygpt
+
+charrnn と同じ埋め込みテキストで、小さな文字レベル transformer (トークン埋め込みと位置埋め込み、4 ヘッドの因果 attention と GELU の feed-forward を持つ pre-norm ブロック 2 段、最終 norm と出力射影) を学習し、そこからサンプリングします。パラメータは約 106k、`GOEXPERIMENT=simd` で 1 分ほど学習すれば、コーパスの文をそのまま再現するようになります。モデル全体が n 次元自動微分エンジンで書かれています: 活性は `(batch, sequence, model)` のテンソル、ヘッド分割は `Reshape` と `Transpose`、各ステップのバッファは `Tape` が再利用します。フラグは `-iters`, `-lr`, `-temp`, `-n`, `-seed`。
 
 ## plasma
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ Every example is runnable from the repository root with `go run`:
 | iris | `go run ./_example/iris` | Iris classification |
 | mnist | `go run ./_example/mnist` | MNIST classifier (`-model dense`, `cnn`, or `knn`) with save/load |
 | charrnn | `go run ./_example/charrnn` | Character-level LSTM text generation on the autograd engine |
+| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | Character-level transformer trained from scratch on the n-d autograd engine |
 | plasma | `go run ./_example/plasma` | Terminal plasma rendered by a neural network — a live SIMD benchmark |
 | dot | `go run ./_example/dot` | Graphviz DOT export of the z = x + y graph |
 | tensor | `go run ./_example/tensor` | Tour of the n-d Tensor: broadcasting, batched MatMul, attention |
@@ -36,6 +37,10 @@ On the 5000-sample subset the k-NN baseline scores ~91% against ~92% for the MLP
 ## charrnn
 
 Trains a character-level LSTM on an embedded public-domain text, saves the parameters with `SaveParamsFile`, restores them into a fresh model, and generates a sample from the reloaded parameters.
+
+## tinygpt
+
+Trains a small character-level transformer -- token and position embeddings, two pre-norm blocks with four-head causal attention and a GELU feed-forward, a final norm and an output projection -- on the same embedded text charrnn uses, then samples from it. About 106k parameters and a minute of training with `GOEXPERIMENT=simd`, after which it reproduces whole sentences of the corpus. The whole model is written against the n-dimensional autograd engine: activations are `(batch, sequence, model)` tensors, the per-head split is a `Reshape` plus a `Transpose`, and a `Tape` recycles each step's buffers. Flags: `-iters`, `-lr`, `-temp`, `-n`, `-seed`.
 
 ## plasma
 

--- a/docs/guide/autograd.ja.md
+++ b/docs/guide/autograd.ja.md
@@ -1,6 +1,8 @@
 # 自動微分
 
-モデルが Sequential の型にはまらないとき (重み共有、カスタム損失、変わったアーキテクチャ) は、計算を直接組み立ててリバースモード自動微分に勾配を導出させます。エンジンは micrograd スタイル: n 次元テンソル上の `Node` の動的グラフで、define-by-run、使い捨てです。`Node` が持つ値は `Tensor` なので、要素ごとの演算はブロードキャストし、`MatMul` は行列のスタックを掛けます。リーフを作るところでは `Matrix` をゼロコピーの 2 次元ビューとして受け取るので、以下の 2 次元のコードは今までどおりです。
+モデルが Sequential の型にはまらないとき (重み共有、カスタム損失、変わったアーキテクチャ) は、計算を直接組み立ててリバースモード自動微分に勾配を導出させます。エンジンは micrograd スタイル: `Node` の動的グラフで、define-by-run、使い捨てです。
+
+`Node` が持つ値は n 次元の `Tensor` です。つまり `(rows, cols)` の行列に効く演算がそのまま `(batch, sequence, model)` の活性にも効きます。要素ごとの演算は NumPy 流にブロードキャストし、`MatMul` は行列のスタックをまとめて掛けます。リーフを作るところでは `Matrix` をゼロコピーの 2 次元ビューとして受け取るので、2 次元のコードは今までどおりに読めます。
 
 ## Param、Input、Trainer
 
@@ -12,17 +14,59 @@ trainer := autograd.NewTrainer(optim.NewAdam(0.05), w1, b1, w2)
 
 for step := 0; step < 2000; step++ {
 	loss := autograd.Input(x).MatMul(w1).AddRow(b1).Tanh().MatMul(w2).Sigmoid().MSELoss(y.Tensor())
-	trainer.Step(loss) // backward + 更新 + 勾配ゼロ化。損失値を返す
+	trainer.Step(loss) // 逆伝播 + 更新 + 勾配クリア、損失値を返す
 }
 ```
 
-`Param` は勾配を追跡して更新すべき行列を、`Input` はデータをラップします。手動で制御したければ部品はすべて公開されています: `loss.Backward()`, `p.Grad`, `autograd.ZeroGrads(params...)`。
+`Param` は勾配を追跡して更新する値、`Input` はデータを包みます。どちらも `*tensai.Matrix` と `*tensai.Tensor` の両方を受け取ります。行列は同じ配列を共有する 2 次元テンソルビューになるので、行列から作ったパラメータはその行列を更新し続けます。
 
-## 使える演算
+手動で回したいときの部品も公開されています: `loss.Backward()`、`p.Grad`、`autograd.ZeroGrads(params...)`。`Backward` は要素が 1 つのノードから始まり、`Grad` に**加算**します。学習ステップの最後に勾配をクリアするのはそのためです (`Trainer.Step` がやってくれます)。
 
-`MatMul` (バッチ対応、先頭軸はブロードキャスト), `Add`, `Sub`, `Mul`/`MulElem`, `Div`, `Scale`, `Neg`, `AddRow`, `T`/`Transpose`, `Reshape`, `Softmax` (最終軸), `Sum`, `Mean`, `SumAxis`/`MeanAxis`, `LayerNorm`, `Embed`, `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, `GELU`, `Exp`, `Log`, `MSELoss`, `SoftmaxCELoss`, `CrossEntropy`。要素ごとの演算は NumPy 流にブロードキャストし、勾配は引き伸ばされた軸ぶんだけ合計されて戻ります。
+ノードの `Value` と `Grad` は `*tensai.Tensor` です。`Shape()` で形状、`Matrix()` で 2 次元ノードの行列ビュー、`Scalar()` で 1 要素ノードの値が取れ、`Named("w1")` は `ToDot` 用のラベルです。
 
-グラフはステップごとに動的に構築され、使い捨てです。形状の不一致はグラフ構築時に panic します。すべての演算の勾配はテストスイートで数値微分と照合されています。
+## 演算
+
+| 演算 | 形状 |
+| --- | --- |
+| `MatMul(o)` | `(…, m, k) * (…, k, n)` → `(…, m, n)`。先頭の軸はブロードキャストするので、2 次元の重み 1 枚がバッチ全体に効きます |
+| `Add`, `Sub`, `Mul` (`MulElem`), `Div` | 要素ごと、NumPy 流のブロードキャスト |
+| `Scale(s)`, `Neg()` | スカラー倍 |
+| `AddRow(row)` | `(m, n) + (1, n)`。`Add` が元々ブロードキャストするので、意図を明示するだけの形です |
+| `T()`, `Transpose(perm...)` | 最後の 2 軸を入れ替え / 全軸を並べ替え |
+| `Reshape(shape...)` | 1 つだけ `-1` を書けます。バッファは共有します |
+| `Softmax()` | 最終軸に対して |
+| `LayerNorm(gain, bias, eps)` | 最終軸に対して。`gain` と `bias` は特徴量ごとに 1 要素で、`nil` でも学習対象でも構いません |
+| `Embed(ids, shape...)` | `(vocab, d)` のテーブルと `len(ids)` 個の添字 → `shape…, d`。同じ id が複数あれば逆伝播で加算されます |
+| `Sum()`, `Mean()` | 全体を 1 要素に集約 |
+| `SumAxis(axis, keepDims)`, `MeanAxis(axis, keepDims)` | 1 軸を集約。負の軸は末尾から数えます |
+| `ReLU()`, `LeakyReLU(a)`, `Sigmoid()`, `Tanh()`, `GELU()`, `Exp()`, `Log()` | 要素ごと |
+| `MSELoss(target)`, `SoftmaxCELoss(target)`, `CrossEntropy(labels []int)` | スカラー損失。交差エントロピーは最終軸をクラスとして読みます |
+
+グラフはステップごとに動的に組み立てる使い捨てです。形状の不一致はエラーではなく構築時の panic になります。エラーを返すとチェーンが書けなくなりますし、形状違いはプログラミングのミスだからです。すべての演算の勾配は、テストで数値微分と突き合わせて検証しています。
+
+## ブロードキャスト
+
+要素ごとの演算は末尾の軸を揃え、長さ 1 の軸を引き伸ばします。`(1, 1, d)` のバイアスが `(batch, seq, d)` の活性に足せるのはこのためです。勾配は逆向きに同じ規則に従い、**引き伸ばした軸ぶんだけ合計されて戻ります**。バイアスも、特徴量ごとの `LayerNorm` の gain も、バッチで共有した重みも、それを使った全位置の寄与を特別扱いなしに集められるのはこの一点のおかげです。
+
+## Attention の組み立て
+
+マルチヘッド attention は reshape と transpose とバッチ積 2 回です:
+
+```go
+// x は (batch, seq, model)、wq, wk, wv, wo は (model, model)。
+heads := func(t *autograd.Node) *autograd.Node {
+	// (batch, seq, model) -> (batch, head, seq, headDim)
+	return t.Reshape(batch, seq, nHeads, headDim).Transpose(0, 2, 1, 3)
+}
+q, k, v := heads(x.MatMul(wq)), heads(x.MatMul(wk)), heads(x.MatMul(wv))
+
+// 全シーケンス・全ヘッドのスコア (batch, head, seq, seq) を一度に。
+att := q.MatMul(k.T()).Scale(1 / float32(math.Sqrt(headDim))).Add(mask).Softmax()
+
+y := att.MatMul(v).Transpose(0, 2, 1, 3).Reshape(batch, seq, model).MatMul(wo)
+```
+
+`mask` は `(1, 1, seq, seq)` の定数 `Input` で、対角と下側が `0`、上側が `math.Inf(-1)` です。バッチとヘッドにブロードキャストされ、softmax が未来の位置に重みを与えなくなります。`_example/tinygpt` はこれをそのまま使った文字単位の transformer (pre-norm ブロック、GELU の feed-forward、次文字の交差エントロピー) で、1 分ほどで 1 ページ分のテキストを覚えます。
 
 ## Tape によるバッファ再利用
 
@@ -38,7 +82,7 @@ for step := 0; step < steps; step++ {
 }
 ```
 
-規則は学習ループが元々守っているもの 1 つだけです: **`Reset` の後、終わったステップの値を読んではいけません** — `Value` も `Grad` もです。パラメータの値は再利用されない (tape が持つのは op が作ったものだけ) ので、学習した重みはいつでも保持して安全です。それ以外を残したいときは Reset の前にコピーしてください。`Tape` は並行利用できないので、学習ゴルーチンごとに 1 つ持たせます。
+規則は学習ループが元々守っているもの 1 つだけです: **`Reset` の後、終わったステップの値を読んではいけません** — `Value` も `Grad` もです。パラメータの値は再利用されない (tape が持つのは op が作ったものだけ) ので、学習した重みはいつでも保持して安全です。それ以外を残したいときは `Clone` でコピーしてから Reset してください。`Tape` は並行利用できないので、学習ゴルーチンごとに 1 つ持たせます。
 
 32 ステップを展開する `_example/charrnn` では、1 学習ステップの確保量が 22MB から 0.75MB に減り、実時間も約 1/4 短くなります。
 
@@ -46,7 +90,7 @@ for step := 0; step < steps; step++ {
 
 ## グラフの可視化
 
-`loss.ToDot()` は Graphviz DOT を返します (葉には `.Named("w1")` でラベルを付けられます):
+`loss.ToDot()` は Graphviz の DOT を返します (リーフには `.Named("w1")` でラベルを付けます):
 
 ```bash
 go run ./_example/dot | dot -Tsvg > graph.svg
@@ -54,7 +98,7 @@ go run ./_example/dot | dot -Tsvg > graph.svg
 
 ## リカレントネットワーク
 
-`rnn.Cell` と `rnn.LSTMCell` は自動微分エンジンの上に組まれているので、シーケンスの展開はただの Go のループで、BPTT (通時的誤差逆伝播) は勝手についてきます:
+`rnn.Cell` と `rnn.LSTMCell` は自動微分エンジンの上に乗っているので、系列の展開はただの Go のループで、BPTT は自動で付いてきます:
 
 ```go
 cell := rnn.NewLSTMCell(inSize, hidden, rng)
@@ -64,7 +108,7 @@ trainer := autograd.NewTrainer(optim.NewAdam(0.01), append(cell.Params(), wOut, 
 
 for step := 0; step < epochs; step++ {
 	h, c := cell.InitState(batch)
-	for _, x := range steps { // タイムステップごとに 1 つの (batch x inSize) 行列
+	for _, x := range steps { // 1 時刻あたり (batch x inSize) の行列 1 枚
 		h, c = cell.Step(autograd.Input(x), h, c)
 	}
 	logits := h.MatMul(wOut).AddRow(bOut)
@@ -72,18 +116,18 @@ for step := 0; step < epochs; step++ {
 }
 ```
 
-`_example/charrnn` は埋め込みのパブリックドメインテキストで文字レベル LSTM を学習し、再読込したパラメータからサンプルを生成します。
+`_example/charrnn` は埋め込んだパブリックドメインのテキストで文字単位の LSTM を学習し、読み直したパラメータから文章を生成します。
 
-## Attention
-
-`rnn.SelfAttention` は 1 つの `(seqLen x inSize)` シーケンスノードに作用します。`attn.Forward(x)` が学習可能な射影つきで `softmax(Q*K^T/sqrt(d))*V` を計算します。素の `rnn.Attention(q, k, v)` も公開されています。
+`rnn.SelfAttention` はシングルヘッド・1 系列版です。`attn.Forward(x)` が `(seqLen, inSize)` のノードに対して学習済み射影付きの `softmax(Q*K^T/sqrt(d))*V` を計算し、素の `rnn.Attention(q, k, v)` も公開されています。バッチとヘッドが要るときは上のブロックを書いてください。
 
 ## パラメータの保存
 
-自動微分のパラメータは位置ベースに保存・復元します:
+自動微分のパラメータは順番で保存・復元します:
 
 ```go
 autograd.SaveParamsFile("cell.json", cell.Params()...)
-// 同じセルを組んでから
+// 同じセルを組み立ててから
 autograd.LoadParamsFile("cell.json", cell.Params()...)
 ```
+
+任意のランクのパラメータが往復します。2 次元のものは以前のチェックポイントと同じエンコーディングを保つので、エンジンが n 次元になる前に書いたファイルもそのまま読めます。

--- a/docs/guide/autograd.md
+++ b/docs/guide/autograd.md
@@ -1,6 +1,8 @@
 # Automatic Differentiation
 
-When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients. The engine is micrograd-style: a dynamically built graph of `Node`s over n-dimensional tensors, define-by-run, single-use. A `Node` holds a `Tensor`, so element-wise ops broadcast and `MatMul` multiplies stacks of matrices; a `Matrix` is taken as a zero-copy 2-D view wherever a leaf is built, so the two-dimensional code below reads the same as it always did.
+When a model doesn't fit the Sequential mold (weight sharing, custom losses, exotic architectures), build the computation directly and let reverse-mode autodiff derive the gradients. The engine is micrograd-style: a dynamically built graph of `Node`s, define-by-run, single-use.
+
+A `Node` holds an n-dimensional `Tensor`, so the same ops that run on a `(rows, cols)` matrix run on a `(batch, sequence, model)` activation: element-wise arithmetic broadcasts NumPy-style and `MatMul` multiplies whole stacks of matrices. A `Matrix` is taken as a zero-copy 2-D view wherever a leaf is built, so two-dimensional code reads the way it always did.
 
 ## Params, Inputs, and the Trainer
 
@@ -16,13 +18,55 @@ for step := 0; step < 2000; step++ {
 }
 ```
 
-`Param` wraps a matrix whose gradient should be tracked and updated; `Input` wraps data. For manual control, the pieces are still public: `loss.Backward()`, `p.Grad`, and `autograd.ZeroGrads(params...)`.
+`Param` wraps a value whose gradient should be tracked and updated; `Input` wraps data. Both accept a `*tensai.Matrix` or a `*tensai.Tensor` — a matrix becomes a 2-D tensor view sharing the same backing array, so a parameter built from a matrix keeps updating that matrix.
 
-## Available ops
+For manual control, the pieces are public: `loss.Backward()`, `p.Grad`, and `autograd.ZeroGrads(params...)`. `Backward` starts from a single-element node and **accumulates** into `Grad`, which is why a training step clears the gradients afterwards (`Trainer.Step` does it for you).
 
-`MatMul` (batched, with broadcast leading axes), `Add`, `Sub`, `Mul`/`MulElem`, `Div`, `Scale`, `Neg`, `AddRow`, `T`/`Transpose`, `Reshape`, `Softmax` (last axis), `Sum`, `Mean`, `SumAxis`/`MeanAxis`, `LayerNorm`, `Embed`, `ReLU`, `LeakyReLU`, `Sigmoid`, `Tanh`, `GELU`, `Exp`, `Log`, `MSELoss`, `SoftmaxCELoss`, and `CrossEntropy`. Element-wise ops broadcast NumPy-style, and a gradient is summed back over whatever axes an operand was stretched along.
+On a node, `Value` and `Grad` are `*tensai.Tensor`. `Shape()` returns the shape, `Matrix()` returns a matrix view of a 2-D node, `Scalar()` reads a single-element node, and `Named("w1")` labels a leaf for `ToDot`.
 
-Graphs are built dynamically per step and are single-use. Shape mismatches panic during graph construction. Every op's gradient is verified against finite differences in the test suite.
+## Ops
+
+| Op | Shapes |
+| --- | --- |
+| `MatMul(o)` | `(…, m, k) * (…, k, n)` → `(…, m, n)`; the leading axes broadcast, so one 2-D weight applies to a whole batch |
+| `Add`, `Sub`, `Mul` (`MulElem`), `Div` | element-wise, NumPy broadcasting |
+| `Scale(s)`, `Neg()` | element-wise by a scalar |
+| `AddRow(row)` | `(m, n) + (1, n)`; `Add` already broadcasts, this only states the intent |
+| `T()`, `Transpose(perm...)` | swap the last two axes / permute every axis |
+| `Reshape(shape...)` | one dimension may be `-1`; shares the buffer |
+| `Softmax()` | over the last axis |
+| `LayerNorm(gain, bias, eps)` | over the last axis; `gain` and `bias` hold one element per feature and may be `nil` or trainable |
+| `Embed(ids, shape...)` | `(vocab, d)` table plus `len(ids)` indices → `shape…, d`; repeated ids accumulate on backward |
+| `Sum()`, `Mean()` | reduce everything to one element |
+| `SumAxis(axis, keepDims)`, `MeanAxis(axis, keepDims)` | reduce one axis; a negative axis counts from the end |
+| `ReLU()`, `LeakyReLU(a)`, `Sigmoid()`, `Tanh()`, `GELU()`, `Exp()`, `Log()` | element-wise |
+| `MSELoss(target)`, `SoftmaxCELoss(target)`, `CrossEntropy(labels []int)` | scalar losses; the cross-entropies read the last axis as classes |
+
+Graphs are built dynamically per step and are single-use. Shape mismatches panic during construction rather than returning an error: chaining would be unusable otherwise, and a wrong shape is a programming mistake. Every op's gradient is verified against finite differences in the test suite.
+
+## Broadcasting
+
+An element-wise op aligns shapes at their trailing axes and stretches any axis of length 1, so a `(1, 1, d)` bias adds to a `(batch, seq, d)` activation. Gradients follow the same rule in reverse: whatever axes an operand was stretched along, its gradient is summed back over. That is why a bias, a per-feature `LayerNorm` gain, and a weight shared across a batch all collect the contributions of every position that used them without any special case in the op.
+
+## Building attention
+
+Multi-head attention is a reshape, a transpose, and two batched products:
+
+```go
+// x is (batch, seq, model); wq, wk, wv, wo are (model, model).
+heads := func(t *autograd.Node) *autograd.Node {
+	// (batch, seq, model) -> (batch, head, seq, headDim)
+	return t.Reshape(batch, seq, nHeads, headDim).Transpose(0, 2, 1, 3)
+}
+q, k, v := heads(x.MatMul(wq)), heads(x.MatMul(wk)), heads(x.MatMul(wv))
+
+// (batch, head, seq, seq) scores for every head of every sequence at once.
+att := q.MatMul(k.T()).Scale(1 / float32(math.Sqrt(headDim))).Add(mask).Softmax()
+
+y := att.MatMul(v).Transpose(0, 2, 1, 3).Reshape(batch, seq, model).MatMul(wo)
+```
+
+`mask` is a constant `Input` of shape `(1, 1, seq, seq)` holding `0` on and below the diagonal and `math.Inf(-1)` above it, broadcast over batch and head; softmax then gives future positions no weight. `_example/tinygpt` puts exactly this into a working character-level transformer — pre-norm blocks, a GELU feed-forward, and next-character cross-entropy — that memorizes a page of text in about a minute.
 
 ## Reusing buffers with a tape
 
@@ -38,7 +82,7 @@ for step := 0; step < steps; step++ {
 }
 ```
 
-The rule is the one a training loop already follows: **after `Reset`, nothing from the finished step may be read** — no node's `Value`, no node's `Grad`. Parameter values are never recycled (the tape only owns what operations produce), so trained weights are always safe to keep; copy anything else before resetting. A `Tape` is not safe for concurrent use, so give each training goroutine its own.
+The rule is the one a training loop already follows: **after `Reset`, nothing from the finished step may be read** — no node's `Value`, no node's `Grad`. Parameter values are never recycled (the tape only owns what operations produce), so trained weights are always safe to keep; copy anything else with `Clone` before resetting. A `Tape` is not safe for concurrent use, so give each training goroutine its own.
 
 On `_example/charrnn`, which unrolls 32 time steps per iteration, the tape takes a training step from 22 MB of allocation to 0.75 MB and cuts about a quarter off its wall time.
 
@@ -74,9 +118,7 @@ for step := 0; step < epochs; step++ {
 
 `_example/charrnn` trains a character-level LSTM on an embedded public-domain text and generates samples from the reloaded parameters.
 
-## Attention
-
-`rnn.SelfAttention` operates on one `(seqLen x inSize)` sequence node: `attn.Forward(x)` computes `softmax(Q*K^T/sqrt(d))*V` with learned projections. The raw `rnn.Attention(q, k, v)` form is also exposed.
+`rnn.SelfAttention` is the single-head, one-sequence form: `attn.Forward(x)` computes `softmax(Q*K^T/sqrt(d))*V` on a `(seqLen, inSize)` node with learned projections, and the raw `rnn.Attention(q, k, v)` is also exposed. For batches and heads, write the block above.
 
 ## Saving parameters
 
@@ -87,3 +129,5 @@ autograd.SaveParamsFile("cell.json", cell.Params()...)
 // build the same cell, then
 autograd.LoadParamsFile("cell.json", cell.Params()...)
 ```
+
+Parameters of any rank round-trip; two-dimensional ones keep the encoding earlier checkpoints used, so files written before the engine went n-dimensional still load.


### PR DESCRIPTION
_example/tinygpt trains a small GPT from scratch on the text charrnn uses: token and position embeddings, two pre-norm blocks with four-head causal attention and a GELU feed-forward, a final norm and an output projection. It is written directly against the n-dimensional engine — activations are (batch, sequence, model) tensors, the per-head split is a Reshape plus a Transpose, every score in the batch is one MatMul, and a Tape recycles each step's buffers. 106k parameters and about a minute of training with the AVX2 build, after which it writes whole sentences of the corpus back.

The autograd guide now covers the n-dimensional API in both languages: what a leaf accepts, a table of every op with its shape rule, how broadcasting runs in reverse through the gradients, and the attention block above.