### PR TITLE
Train tinygpt on the GPU with -gpu

### DIFF
--- a/_example/tinygpt/main.go
+++ b/_example/tinygpt/main.go
@@ -8,6 +8,18 @@
 // split is a Reshape plus a Transpose, and every attention score in the
 // batch is one batched MatMul. The gradients come from the engine, so the
 // model is only its forward pass.
+//
+// With -gpu (and a wgpu build) the whole block trains on the device --
+// values, gradients and the Adam update all stay there, and only the loss
+// comes back each step. Whether that is faster depends on the shape: at the
+// default size the tensors are too small to keep a GPU busy and the AVX2
+// kernels win, while a wider model crosses over. On an AMD 780M:
+//
+//	                                        CPU        -gpu
+//	default (model 64, batch 8, seq 32)     23ms/step  62ms/step
+//	-model 256 -heads 8 -batch 16 -seq 64  282ms/step 173ms/step
+//
+// The losses are identical either way, which is the point of the check.
 package main
 
 import (
@@ -17,13 +29,19 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	tensai "github.com/mattn/tensai"
 	"github.com/mattn/tensai/autograd"
+	"github.com/mattn/tensai/gpu"
 	"github.com/mattn/tensai/optim"
 )
 
-const (
+// The shape of the model. They are variables rather than constants so the
+// flags can scale it: the CPU wins at the default size, where the tensors
+// are too small to keep a GPU busy, and the device pulls ahead as the model
+// grows -- see the -gpu flag below.
+var (
 	seqLen    = 32 // tokens the model sees at once
 	dModel    = 64
 	nHeads    = 4
@@ -31,8 +49,9 @@ const (
 	dFF       = 4 * dModel
 	nBlocks   = 2
 	batchSize = 8
-	eps       = 1e-5
 )
+
+const eps = 1e-5
 
 // block is one pre-norm transformer block.
 type block struct {
@@ -77,7 +96,7 @@ func (b *block) forward(x, mask *autograd.Node, batch int) *autograd.Node {
 
 	// (batch, head, seq, seq) scores, masked so a position only sees what
 	// came before it, then the weighted sum of the values.
-	att := q.MatMul(k.T()).Scale(1 / float32(math.Sqrt(headDim))).Add(mask).Softmax()
+	att := q.MatMul(k.T()).Scale(1 / float32(math.Sqrt(float64(headDim)))).Add(mask).Softmax()
 	merged := att.MatMul(v).Transpose(0, 2, 1, 3).Reshape(batch, seqLen, dModel)
 	x = x.Add(merged.MatMul(b.wo))
 
@@ -229,7 +248,18 @@ func main() {
 	temp := flag.Float64("temp", 0.8, "sampling temperature")
 	n := flag.Int("n", 400, "characters to generate")
 	seed := flag.Int64("seed", 7, "random seed")
+	useGPU := flag.Bool("gpu", false, "train on the GPU (needs -tags wgpu24 or wgpu)")
+	flag.IntVar(&dModel, "model", dModel, "model width")
+	flag.IntVar(&nHeads, "heads", nHeads, "attention heads")
+	flag.IntVar(&nBlocks, "blocks", nBlocks, "transformer blocks")
+	flag.IntVar(&batchSize, "batch", batchSize, "sequences per step")
+	flag.IntVar(&seqLen, "seq", seqLen, "tokens the model sees at once")
 	flag.Parse()
+	if dModel%nHeads != 0 {
+		fmt.Fprintf(os.Stderr, "tinygpt: model width %d is not divisible by %d heads\n", dModel, nHeads)
+		os.Exit(1)
+	}
+	headDim, dFF = dModel/nHeads, 4*dModel
 
 	text := []rune(corpus)
 	vocab := vocabOf(text)
@@ -247,9 +277,22 @@ func main() {
 	// Every step builds a fresh graph and drops it; the tape hands the last
 	// step's buffers back instead of allocating them again.
 	tape := autograd.NewTape()
+	if *useGPU {
+		// With a device the whole block stays there: values, gradients and
+		// the Adam update. Only the loss comes back each step.
+		dev, err := gpu.Open(gpu.HighPerformance)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tinygpt: %v\n", err)
+			os.Exit(1)
+		}
+		defer dev.Close()
+		tape.UseDevice(dev)
+		fmt.Printf("training on %s\n", dev.Name())
+	}
 	tape.Bind(params...)
 	m.tape = tape
 
+	start := time.Now()
 	for it := 1; it <= *iters; it++ {
 		tokens, labels := m.batchAt(text, rng)
 		lossVal := trainer.Step(m.forward(tokens, batchSize).CrossEntropy(labels))
@@ -258,6 +301,9 @@ func main() {
 			fmt.Printf("iter %4d: loss=%.4f\n", it, lossVal)
 		}
 	}
+	took := time.Since(start)
+	fmt.Printf("trained %d steps in %v (%.1fms/step)\n",
+		*iters, took.Round(time.Millisecond), float64(took.Milliseconds())/float64(*iters))
 
 	if len(text) < seqLen {
 		fmt.Fprintln(os.Stderr, "tinygpt: corpus shorter than the context window")

--- a/docs/examples.ja.md
+++ b/docs/examples.ja.md
@@ -12,7 +12,7 @@
 | iris | `go run ./_example/iris` | Iris の分類 |
 | mnist | `go run ./_example/mnist` | MNIST 分類器 (`-model dense`, `cnn`, `knn`) と保存/読込 |
 | charrnn | `go run ./_example/charrnn` | 自動微分エンジン上の文字レベル LSTM テキスト生成 |
-| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | n 次元自動微分エンジンでゼロから学習する文字レベル transformer |
+| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | n 次元自動微分エンジンでゼロから学習する文字レベル transformer (`-gpu` でデバイス学習) |
 | plasma | `go run ./_example/plasma` | ニューラルネットワークが描くターミナルプラズマ — 生きた SIMD ベンチマーク |
 | dot | `go run ./_example/dot` | z = x + y グラフの Graphviz DOT エクスポート |
 | tensor | `go run ./_example/tensor` | N 次元 Tensor ツアー: ブロードキャスト、バッチ MatMul、attention |
@@ -40,7 +40,9 @@ go run ./_example/mnist -model cnn -export mnist.tflite  # TFLite へエクス�
 
 ## tinygpt
 
-charrnn と同じ埋め込みテキストで、小さな文字レベル transformer (トークン埋め込みと位置埋め込み、4 ヘッドの因果 attention と GELU の feed-forward を持つ pre-norm ブロック 2 段、最終 norm と出力射影) を学習し、そこからサンプリングします。パラメータは約 106k、`GOEXPERIMENT=simd` で 1 分ほど学習すれば、コーパスの文をそのまま再現するようになります。モデル全体が n 次元自動微分エンジンで書かれています: 活性は `(batch, sequence, model)` のテンソル、ヘッド分割は `Reshape` と `Transpose`、各ステップのバッファは `Tape` が再利用します。フラグは `-iters`, `-lr`, `-temp`, `-n`, `-seed`。
+charrnn と同じ埋め込みテキストで、小さな文字レベル transformer (トークン埋め込みと位置埋め込み、4 ヘッドの因果 attention と GELU の feed-forward を持つ pre-norm ブロック 2 段、最終 norm と出力射影) を学習し、そこからサンプリングします。パラメータは約 106k、`GOEXPERIMENT=simd` で 1 分ほど学習すれば、コーパスの文をそのまま再現するようになります。モデル全体が n 次元自動微分エンジンで書かれています: 活性は `(batch, sequence, model)` のテンソル、ヘッド分割は `Reshape` と `Transpose`、各ステップのバッファは `Tape` が再利用します。フラグは `-iters`, `-lr`, `-temp`, `-n`, `-seed`、それに形を変える `-model`, `-heads`, `-blocks`, `-batch`, `-seq`。
+
+`-gpu` (wgpu ビルド時) はブロック全体をデバイスで学習します。値も勾配も Adam の更新もデバイスに留まり、毎ステップ帰ってくるのは損失だけです。速くなるかは形次第で、既定のサイズではテンソルが小さすぎて GPU が埋まらず AVX2 カーネルが勝ち、モデルを広げるとクロスオーバーします。AMD 780M では既定サイズで 23ms/step に対し `-gpu` が 62ms/step、`-model 256 -heads 8 -batch 16 -seq 64` では 282ms に対し 173ms でした。損失はどちらでも桁まで一致します。
 
 ## plasma
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,7 +12,7 @@ Every example is runnable from the repository root with `go run`:
 | iris | `go run ./_example/iris` | Iris classification |
 | mnist | `go run ./_example/mnist` | MNIST classifier (`-model dense`, `cnn`, or `knn`) with save/load |
 | charrnn | `go run ./_example/charrnn` | Character-level LSTM text generation on the autograd engine |
-| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | Character-level transformer trained from scratch on the n-d autograd engine |
+| tinygpt | `GOEXPERIMENT=simd go run ./_example/tinygpt` | Character-level transformer trained from scratch on the n-d autograd engine (`-gpu` trains on the device) |
 | plasma | `go run ./_example/plasma` | Terminal plasma rendered by a neural network — a live SIMD benchmark |
 | dot | `go run ./_example/dot` | Graphviz DOT export of the z = x + y graph |
 | tensor | `go run ./_example/tensor` | Tour of the n-d Tensor: broadcasting, batched MatMul, attention |
@@ -40,7 +40,9 @@ Trains a character-level LSTM on an embedded public-domain text, saves the param
 
 ## tinygpt
 
-Trains a small character-level transformer -- token and position embeddings, two pre-norm blocks with four-head causal attention and a GELU feed-forward, a final norm and an output projection -- on the same embedded text charrnn uses, then samples from it. About 106k parameters and a minute of training with `GOEXPERIMENT=simd`, after which it reproduces whole sentences of the corpus. The whole model is written against the n-dimensional autograd engine: activations are `(batch, sequence, model)` tensors, the per-head split is a `Reshape` plus a `Transpose`, and a `Tape` recycles each step's buffers. Flags: `-iters`, `-lr`, `-temp`, `-n`, `-seed`.
+Trains a small character-level transformer -- token and position embeddings, two pre-norm blocks with four-head causal attention and a GELU feed-forward, a final norm and an output projection -- on the same embedded text charrnn uses, then samples from it. About 106k parameters and a minute of training with `GOEXPERIMENT=simd`, after which it reproduces whole sentences of the corpus. The whole model is written against the n-dimensional autograd engine: activations are `(batch, sequence, model)` tensors, the per-head split is a `Reshape` plus a `Transpose`, and a `Tape` recycles each step's buffers. Flags: `-iters`, `-lr`, `-temp`, `-n`, `-seed`, plus `-model`, `-heads`, `-blocks`, `-batch` and `-seq` to change the shape.
+
+`-gpu` (on a wgpu build) trains the whole block on the device: values, gradients and the Adam update stay there and only the loss comes back each step. Whether it is faster depends on the shape — at the default size the tensors are too small to keep a GPU busy and the AVX2 kernels win, while a wider model crosses over. On an AMD 780M, 23ms/step against 62ms with `-gpu` at the default size, and 282ms against 173ms at `-model 256 -heads 8 -batch 16 -seq 64`. The losses match to the digit either way.
 
 ## plasma
 


### PR DESCRIPTION
The device path had no example to run it: the transformer block that stays resident lived only in the gpu package's tests. tinygpt now takes -gpu, which opens a device and hands it to the tape, and -model, -heads, -blocks, -batch and -seq to change the shape it trains.

That combination is the honest demonstration, because the answer depends on the shape. On an AMD 780M the default size runs 23ms/step on the CPU and 62ms with -gpu — the tensors are too small to keep the device busy — and -model 256 -heads 8 -batch 16 -seq 64 runs 282ms against 173ms. The losses are identical either way.