### PR TITLE
Keep a device buffer's shape in step with its node

### DIFF
--- a/autograd/device.go
+++ b/autograd/device.go
@@ -176,12 +176,24 @@ func (n *Node) syncGrad() {
 	n.grad = g
 }
 
-// devNode wraps a device buffer as a graph node on the same tape.
+// devNode wraps a device buffer as a graph node on the same tape. The
+// buffer's own shape is made to agree with the node's: a kernel is free to
+// hand back a flatter view of the same elements -- an embedding lookup
+// returns (rows, dim) for what the graph calls (batch, seq, dim) -- and the
+// next device op reads the buffer's shape, not the node's, so letting the
+// two drift apart quietly reshapes the graph.
 func devNode(op string, v *gpu.Tensor, shape []int, parents ...*Node) *Node {
+	tp := tapeOf(parents...)
+	if !dims.Same(v.Shape(), shape) {
+		if view, err := v.View(0, shape...); err == nil {
+			tp.track(v) // the view borrows the buffer; the owner still frees it
+			v = view
+		}
+	}
 	out := &Node{
 		op:      op,
 		parents: parents,
-		tape:    tapeOf(parents...),
+		tape:    tp,
 		dev:     v,
 		shapeOf: append([]int(nil), shape...),
 	}
@@ -190,7 +202,7 @@ func devNode(op string, v *gpu.Tensor, shape []int, parents ...*Node) *Node {
 			out.requiresGrad = true
 		}
 	}
-	out.tape.track(v)
+	tp.track(v)
 	return out
 }
 

--- a/gpu/wgpu_autograd_test.go
+++ b/gpu/wgpu_autograd_test.go
@@ -275,3 +275,76 @@ func TestGPUResidentTransformer(t *testing.T) {
 		}
 	}
 }
+
+// TestGPUResidentShapes pins the shapes a resident chain reports. A kernel
+// may hand back a flatter view of the same elements -- the embedding lookup
+// returns (rows, dim) for what the graph calls (batch, seq, dim) -- and the
+// next device op reads the buffer's shape, so a mismatch quietly reshapes
+// everything downstream. It surfaced as a broadcast failure two operations
+// later, which is why the shapes are checked here step by step.
+func TestGPUResidentShapes(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+
+	const batch, seq, dim, vocab = 2, 4, 8, 5
+	rng := rand.New(rand.NewSource(311))
+	table := autograd.Param(randTensor(rng, vocab, dim))
+	pos := autograd.Param(randTensor(rng, 1, seq, dim))
+	w := autograd.Param(randTensor(rng, dim, dim))
+	tape := autograd.NewTape()
+	tape.UseDevice(g)
+	tape.Bind(table, pos, w)
+	defer tape.Reset()
+
+	tokens := make([]int, batch*seq)
+	for i := range tokens {
+		tokens[i] = rng.Intn(vocab)
+	}
+	steps := []struct {
+		name string
+		node *autograd.Node
+		want []int
+	}{}
+	x := table.Embed(tokens, batch, seq)
+	steps = append(steps, struct {
+		name string
+		node *autograd.Node
+		want []int
+	}{"embed", x, []int{batch, seq, dim}})
+	h := x.Add(pos)
+	steps = append(steps, struct {
+		name string
+		node *autograd.Node
+		want []int
+	}{"add", h, []int{batch, seq, dim}})
+	y := h.MatMul(w)
+	steps = append(steps, struct {
+		name string
+		node *autograd.Node
+		want []int
+	}{"matmul", y, []int{batch, seq, dim}})
+	sum := x.Add(y) // the residual that fails when a shape drifted
+	steps = append(steps, struct {
+		name string
+		node *autograd.Node
+		want []int
+	}{"residual", sum, []int{batch, seq, dim}})
+
+	for _, s := range steps {
+		if !s.node.Resident() {
+			t.Errorf("%s left the device", s.name)
+		}
+		got := s.node.Shape()
+		if len(got) != len(s.want) {
+			t.Fatalf("%s shape %v, want %v", s.name, got, s.want)
+		}
+		for i := range s.want {
+			if got[i] != s.want[i] {
+				t.Fatalf("%s shape %v, want %v", s.name, got, s.want)
+			}
+		}
+		if v := s.node.Value(); len(v.Shape) != len(s.want) {
+			t.Fatalf("%s downloaded shape %v, want %v", s.name, v.Shape, s.want)
+		}
+	}
+}


### PR DESCRIPTION
A kernel may hand back a flatter view of the same elements: the embedding lookup returns (rows, dim) for what the graph calls (batch, seq, dim). The node recorded the shape it meant, but the next device op reads the buffer's own shape, so from there on the graph was quietly reshaped — and it surfaced two operations later as `cannot broadcast [8 32 64] with [256 64]` when a residual tried to add the attention output back.

devNode now views a buffer whose shape disagrees with the node's, so the two can never drift. The regression test walks an embed, a broadcast add and a product, checking the shape at each step and again after downloading.

Reported from running _example/tinygpt -gpu, which the fix makes work.