### PR TITLE
Compare GEMM kernels over rotated rounds

### DIFF
--- a/gpu/wgpu_gemm_ab_test.go
+++ b/gpu/wgpu_gemm_ab_test.go
@@ -10,7 +10,9 @@ import (
 
 // BenchmarkGemmWide compares the vec4-load kernel against the scalar-load
 // one in a single process, alternating between them: this machine drifts
-// enough between runs that separate ones cannot tell a 10% difference.
+// enough between runs that separate ones cannot tell a 10% difference, and
+// enough within one that the first variant of a group looks slower than it
+// is.
 func BenchmarkGemmWide(b *testing.B) {
 	g, err := Open()
 	if err != nil {
@@ -27,9 +29,9 @@ func BenchmarkGemmWide(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		run := func(off bool) func(*testing.B) {
+		run := func(scalar bool) func(*testing.B) {
 			return func(b *testing.B) {
-				noWideGemm = off
+				noWideGemm = scalar
 				defer func() { noWideGemm = false }()
 				for i := 0; i < b.N; i++ {
 					out, err := x.MatMul(w)
@@ -44,10 +46,13 @@ func BenchmarkGemmWide(b *testing.B) {
 				}
 			}
 		}
-		b.Run(fmt.Sprintf("scalar/%d", size), run(true))
-		b.Run(fmt.Sprintf("vec4/%d", size), run(false))
-		b.Run(fmt.Sprintf("scalar2/%d", size), run(true))
-		b.Run(fmt.Sprintf("vec4b/%d", size), run(false))
+		// Three rounds: whichever variant runs first in a group pays for
+		// the clock ramping up, so compare each variant's best round
+		// rather than neighbouring numbers.
+		for round := 0; round < 3; round++ {
+			b.Run(fmt.Sprintf("wide/%d/%d", size, round), run(false))
+			b.Run(fmt.Sprintf("scalar/%d/%d", size, round), run(true))
+		}
 		x.Free()
 		w.Free()
 	}


### PR DESCRIPTION
The A/B benchmark ran each variant once, in a fixed order. On this machine the first sub-benchmark of a group pays for the clock ramping up, which is worth more than the difference being measured: the same pair can read either way depending on which goes first. It now runs three rounds and the comparison is between each variant's best one.

Re-measured that way, the vec4 tile loads are worth 1.15x at 1024 and 2048 cubes and nothing at 512 — the 1.7x at 512 reported when they landed was the ordering, not the kernel.

Also tried and dropped, with the same harness: double buffering the tiles (1.23x at 512, 0.97x at 2048 — a wash, and 90 lines), one kernel for all three modes with a uniform branch instead of three specialised ones (10-20% worse from 1024 up), a 128x128 block with an 8x8 register tile (the accumulators spill again), and a 32-deep k tile (no change).