### PR TITLE
Build a Sequential as an autograd graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Optimizers** - momentum `SGD`, `Adam`, and `AdamW` (decoupled weight decay)
 - **k-NN baseline** - a `knn.Classifier` whose distance matrix runs on the same SIMD matmul kernel; useful as a no-training baseline next to the networks
 - **Dataset utilities** - `Dataset` pairs inputs with targets and provides `Shuffle`, train/test `Split` (copy-free views), buffer-reusing mini-batch iteration with `Batches`, and `Standardize`/`StandardizeWith`
-- **Sequential models** - stack layers and run `Compile` -> `Fit` / `FitStep` -> `Predict`
+- **Sequential models** - stack layers and run `Compile` -> `Fit` / `FitStep` -> `Predict`; `Graph()` builds the same model as an autograd graph instead, which trains the very same weights and can run on a GPU
 - **Automatic differentiation** - a micrograd-style reverse-mode autograd engine over n-dimensional tensors (`Param` / `Input` / `Backward`), for models that don't fit the Sequential mold. Values are `Tensor`s, so the same ops run on (batch, seq, model) activations: broadcasting element-wise arithmetic, batched `MatMul`, `Transpose`/`Reshape`, last-axis `Softmax`, axis reductions, `LayerNorm`, embedding `Embed`, and `CrossEntropy` all carry gradients, and a `Matrix` is still accepted anywhere a leaf is built. `ToDot` renders the computation graph for Graphviz
 - **Recurrence and attention** - `rnn.Cell`, `rnn.LSTMCell`, and single-head `rnn.SelfAttention` built on the autograd engine, with backpropagation through time handled automatically
 - **Serialization** - `Save`/`Load` (and `SaveFile`/`LoadFile`) round-trip trained Sequential parameters as JSON, including BatchNorm running statistics; `SaveParams`/`LoadParams` do the same for autograd parameters (RNN/LSTM/attention cells)

--- a/docs/guide/training.ja.md
+++ b/docs/guide/training.ja.md
@@ -76,6 +76,29 @@ net.LoadFile("model.json")
 
 Go の外へのデプロイには TFLite / ONNX エクスポートがあります — [モデルフォーマット](../formats.md)参照。
 
+## Sequential を自動微分エンジンで学習する
+
+`Fit` は各層の Forward と Backward を回します。CPU では最速で、最初からある道です。`net.Graph()` は同じモデルを autograd グラフとして組み立てます:
+
+```go
+g, err := net.Graph()
+trainer := autograd.NewTrainer(optim.NewAdam(0.01), g.Params()...)
+tape := autograd.NewTape()
+tape.UseDevice(dev) // 任意。GPU ガイド参照
+tape.Bind(g.Params()...)
+
+for step := 0; step < steps; step++ {
+	loss, _ := g.Loss(g.Forward(autograd.Input(x)), y)
+	trainer.Step(loss)
+	tape.Reset()
+}
+g.Sync() // デバイス上の重みを層に書き戻す
+```
+
+パラメータは層が持っている行列そのものなので、グラフで学習することはモデルを学習することです。`Predict` も `Save` もエクスポートもそのまま動き、グラフの順伝播は `Predict` と float32 の丸め誤差の範囲で一致します。増えるのは GPU です — グラフは tape が送った先で走りますが、手書きのスタックはそうはいきません。
+
+Dense、活性化、LayerNorm、Conv2D、MaxPool2D にはグラフ形があります。Dropout・BatchNorm・Embedding はまだ無く、それらを含むモデルは `Fit` と違う学習を黙って行うのではなくエラーになります。
+
 ## 低アロケーション学習
 
 レイヤーは順伝播/逆伝播のスクラッチバッファを学習ステップをまたいで再利用するので、MLP の 1 ステップは約 29 アロケーションで済み、GC は学習ループの外に留まります。`Predict` は常に新しくアロケートした結果を返すので、予測は保持しても安全です。

--- a/docs/guide/training.md
+++ b/docs/guide/training.md
@@ -76,6 +76,29 @@ The architecture itself is not serialized — reconstruct the same layer stack a
 
 For deployment beyond Go, trained models export to TFLite and ONNX — see [Model Formats](../formats.md).
 
+## Training a Sequential on the autograd engine
+
+`Fit` runs the layers' own Forward and Backward, which is the fastest path on a CPU and the only one that has been there from the start. `net.Graph()` builds the same model as an autograd graph instead:
+
+```go
+g, err := net.Graph()
+trainer := autograd.NewTrainer(optim.NewAdam(0.01), g.Params()...)
+tape := autograd.NewTape()
+tape.UseDevice(dev) // optional; see the GPU guide
+tape.Bind(g.Params()...)
+
+for step := 0; step < steps; step++ {
+	loss, _ := g.Loss(g.Forward(autograd.Input(x)), y)
+	trainer.Step(loss)
+	tape.Reset()
+}
+g.Sync() // brings a device's weights back into the layers
+```
+
+The parameters are the layers' own matrices, so training through the graph trains the model: `Predict`, `Save` and the exports keep working, and the graph's forward pass matches `Predict` to float32 rounding. What it adds is the GPU -- a graph runs wherever a tape sends it, which the hand-written stack cannot.
+
+Dense, the activations, LayerNorm, Conv2D and MaxPool2D have graph forms. Dropout, BatchNorm and Embedding do not yet, and a model holding one is refused rather than trained differently than it would be by `Fit`.
+
 ## Low-allocation training
 
 Layers reuse their forward/backward scratch buffers across training steps, so a full MLP step runs in ~29 allocations and GC stays out of the training loop. `Predict` always returns freshly allocated results, so predictions are safe to keep.

--- a/gpu/wgpu_autograd_test.go
+++ b/gpu/wgpu_autograd_test.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/mattn/tensai"
 	"github.com/mattn/tensai/autograd"
+	"github.com/mattn/tensai/gpu"
+	"github.com/mattn/tensai/layer"
+	"github.com/mattn/tensai/loss"
+	"github.com/mattn/tensai/model"
 	"github.com/mattn/tensai/optim"
 )
 
@@ -345,6 +349,87 @@ func TestGPUResidentShapes(t *testing.T) {
 		}
 		if v := s.node.Value(); len(v.Shape) != len(s.want) {
 			t.Fatalf("%s downloaded shape %v, want %v", s.name, v.Shape, s.want)
+		}
+	}
+}
+
+// TestGPUSequentialGraph trains a Sequential model through its graph form
+// on the device and checks the result against the same training on the
+// host. The model is an ordinary layer stack: it is the graph that puts it
+// on a GPU, which the hand-written Forward and Backward cannot.
+func TestGPUSequentialGraph(t *testing.T) {
+	g := openTestGPU(t)
+	defer g.Close()
+
+	build := func() (*model.Sequential, *tensai.Matrix, *tensai.Matrix) {
+		rng := rand.New(rand.NewSource(313))
+		x := randTensor(rng, 16, 24)
+		y := randTensor(rng, 16, 4)
+		xm, err := x.Matrix()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ym, err := y.Matrix()
+		if err != nil {
+			t.Fatal(err)
+		}
+		net := model.NewSequential()
+		net.Add(layer.NewDense(32))
+		net.Add(&layer.Tanh{})
+		net.Add(layer.NewDense(4))
+		// NewSequential seeds its own generator, so two models built the
+		// same way start from the same weights.
+		if err := net.Compile(24, loss.MeanSquaredError{}, optim.NewAdam(0.01)); err != nil {
+			t.Fatal(err)
+		}
+		return net, xm, ym
+	}
+
+	train := func(dev *gpu.Device) (*model.Sequential, tensai.Float) {
+		net, x, y := build()
+		graph, err := net.Graph()
+		if err != nil {
+			t.Fatal(err)
+		}
+		trainer := autograd.NewTrainer(optim.NewAdam(0.01), graph.Params()...)
+		tape := autograd.NewTape()
+		if dev != nil {
+			tape.UseDevice(dev)
+		}
+		tape.Bind(graph.Params()...)
+		var last tensai.Float
+		for i := 0; i < 60; i++ {
+			l, err := graph.Loss(graph.Forward(autograd.Input(x)), y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			last = trainer.Step(l)
+			tape.Reset()
+		}
+		graph.Sync()
+		return net, last
+	}
+
+	cpuNet, cpuLoss := train(nil)
+	devNet, devLoss := train(g)
+	if diff := math.Abs(float64(cpuLoss - devLoss)); diff > 1e-3*(1+math.Abs(float64(cpuLoss))) {
+		t.Fatalf("loss differs: cpu=%g device=%g", cpuLoss, devLoss)
+	}
+
+	// Sync copied the device's weights back into the layers, so the model
+	// predicts with them.
+	_, x, _ := build()
+	want, err := cpuNet.Predict(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := devNet.Predict(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range want.Data {
+		if diff := math.Abs(float64(want.Data[i] - got.Data[i])); diff > 1e-3*(1+math.Abs(float64(want.Data[i]))) {
+			t.Fatalf("prediction %d: cpu=%v device=%v", i, want.Data[i], got.Data[i])
 		}
 	}
 }

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -436,6 +436,9 @@ func (l *LayerNorm) Grads() (*tensai.Matrix, []tensai.Float) {
 	return l.gradGamma, l.gradBeta
 }
 
+// Eps returns the epsilon the normalization adds to the variance.
+func (l *LayerNorm) Eps() tensai.Float { return l.eps }
+
 func (l *LayerNorm) Params() (*tensai.Matrix, []tensai.Float) {
 	return l.gamma, l.beta
 }

--- a/model/graph.go
+++ b/model/graph.go
@@ -1,0 +1,168 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/autograd"
+	"github.com/mattn/tensai/layer"
+)
+
+// Graph is a Sequential built as an autograd graph instead of a stack of
+// hand-written Forward and Backward passes. The parameters are the very
+// matrices the layers hold, so training through the graph trains the model
+// -- Predict, Save and the rest keep working afterwards -- and the graph
+// can run on a GPU, which the layer stack cannot:
+//
+//	g, err := net.Graph()
+//	trainer := autograd.NewTrainer(optim.NewAdam(0.01), g.Params()...)
+//	tape := autograd.NewTape()
+//	tape.UseDevice(dev) // optional
+//	tape.Bind(g.Params()...)
+//	for step := 0; step < steps; step++ {
+//		trainer.Step(g.Loss(g.Forward(autograd.Input(x)), y))
+//		tape.Reset()
+//	}
+//	g.Sync() // only needed after training on a device
+//
+// Dropout, BatchNorm and Embedding have no graph form yet, so a model
+// holding one is refused rather than silently trained differently.
+type Graph struct {
+	steps  []func(*autograd.Node) *autograd.Node
+	params []*autograd.Node
+	hosts  []hostParam
+	loss   string
+}
+
+// hostParam remembers where a parameter lives in its layer, so a value
+// that came back from a device can be copied home.
+type hostParam struct {
+	node *autograd.Node
+	data []tensai.Float
+}
+
+// Graph builds the graph form of a compiled model.
+func (s *Sequential) Graph() (*Graph, error) {
+	if len(s.layers) == 0 {
+		return nil, fmt.Errorf("tensai: cannot build a graph from a model with no layers")
+	}
+	g := &Graph{loss: s.lossName}
+	for i, l := range s.layers {
+		step, err := g.add(l)
+		if err != nil {
+			return nil, fmt.Errorf("tensai: layer %d: %w", i, err)
+		}
+		g.steps = append(g.steps, step)
+	}
+	return g, nil
+}
+
+// param registers a trainable buffer, sharing the layer's memory so an
+// update lands where the layer will read it.
+func (g *Graph) param(t *tensai.Tensor) *autograd.Node {
+	n := autograd.Param(t)
+	g.params = append(g.params, n)
+	g.hosts = append(g.hosts, hostParam{node: n, data: t.Data})
+	return n
+}
+
+// rowVector views a bias slice as a 1 x n matrix without copying it.
+func rowVector(b []tensai.Float) *tensai.Tensor {
+	return &tensai.Tensor{Shape: []int{1, len(b)}, Data: b}
+}
+
+// add turns one layer into a step of the graph.
+func (g *Graph) add(l layer.Layer) (func(*autograd.Node) *autograd.Node, error) {
+	switch v := l.(type) {
+	case *layer.Dense:
+		w, b := v.Params()
+		wn, bn := g.param(w.Tensor()), g.param(rowVector(b))
+		return func(x *autograd.Node) *autograd.Node { return x.MatMul(wn).Add(bn) }, nil
+
+	case *layer.LayerNorm:
+		gamma, beta := v.Params()
+		gn := g.param(&tensai.Tensor{Shape: []int{gamma.Cols}, Data: gamma.Data})
+		bn := g.param(&tensai.Tensor{Shape: []int{len(beta)}, Data: beta})
+		eps := v.Eps()
+		return func(x *autograd.Node) *autograd.Node { return x.LayerNorm(gn, bn, eps) }, nil
+
+	case *layer.Conv2D:
+		inH, inW, inC, outC, kernel, stride, pad := v.Shape()
+		w, b := v.Params()
+		wn, bn := g.param(w.Tensor()), g.param(&tensai.Tensor{Shape: []int{len(b)}, Data: b})
+		cfg := autograd.Conv{Kernel: kernel, Stride: stride, Pad: pad}
+		outH, outW := (inH+2*pad-kernel)/stride+1, (inW+2*pad-kernel)/stride+1
+		return func(x *autograd.Node) *autograd.Node {
+			// The rows a Sequential passes around are channel-major
+			// images; the graph works on them with the spatial axes split
+			// out, and folds them back for the next layer.
+			img := x.Reshape(-1, inC, inH, inW)
+			return img.Conv2D(wn, bn, cfg).Reshape(-1, outC*outH*outW)
+		}, nil
+
+	case *layer.MaxPool2D:
+		inH, inW, ch, size := v.Shape()
+		outH, outW := inH/size, inW/size
+		return func(x *autograd.Node) *autograd.Node {
+			img := x.Reshape(-1, ch, inH, inW)
+			return img.MaxPool2D(size).Reshape(-1, ch*outH*outW)
+		}, nil
+
+	case *layer.ReLU:
+		return (*autograd.Node).ReLU, nil
+	case *layer.Sigmoid:
+		return (*autograd.Node).Sigmoid, nil
+	case *layer.Tanh:
+		return (*autograd.Node).Tanh, nil
+	case *layer.GELU:
+		return (*autograd.Node).GELU, nil
+	case *layer.Softmax:
+		return (*autograd.Node).Softmax, nil
+	case *layer.LeakyReLU:
+		alpha := v.Alpha
+		return func(x *autograd.Node) *autograd.Node { return x.LeakyReLU(alpha) }, nil
+	}
+	return nil, fmt.Errorf("%T has no graph form", l)
+}
+
+// Params returns the trainable nodes, in layer order, for a Trainer and a
+// Tape.
+func (g *Graph) Params() []*autograd.Node { return g.params }
+
+// Forward runs the stack on a (batch, inputs) node.
+func (g *Graph) Forward(x *autograd.Node) *autograd.Node {
+	for _, step := range g.steps {
+		x = step(x)
+	}
+	return x
+}
+
+// Loss applies the loss the model was compiled with. Softmax
+// cross-entropy takes an Mx1 matrix of class indices, as it does
+// everywhere else here; the others take a target the shape of the output.
+func (g *Graph) Loss(pred *autograd.Node, target *tensai.Matrix) (*autograd.Node, error) {
+	switch g.loss {
+	case "softmax_ce":
+		return pred.SoftmaxCELoss(target.Tensor()), nil
+	case "mse":
+		return pred.MSELoss(target.Tensor()), nil
+	case "":
+		return nil, fmt.Errorf("tensai: the model has no loss; compile it first")
+	}
+	return nil, fmt.Errorf("tensai: loss %q has no graph form", g.loss)
+}
+
+// Sync copies the parameters back into the layers. Training on the host
+// updates them in place and needs no call; a device holds its own copies,
+// and this is what brings them home.
+func (g *Graph) Sync() {
+	for _, h := range g.hosts {
+		v := h.node.Value()
+		if len(v.Data) != len(h.data) {
+			continue
+		}
+		if &v.Data[0] != &h.data[0] {
+			copy(h.data, v.Data)
+		}
+	}
+}

--- a/model/graph_test.go
+++ b/model/graph_test.go
@@ -1,0 +1,147 @@
+package model
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/autograd"
+	"github.com/mattn/tensai/layer"
+	"github.com/mattn/tensai/loss"
+	"github.com/mattn/tensai/optim"
+)
+
+func randMatrix(rng *rand.Rand, rows, cols int) *tensai.Matrix {
+	m := tensai.NewMatrix(rows, cols)
+	for i := range m.Data {
+		m.Data[i] = tensai.Float(rng.NormFloat64())
+	}
+	return m
+}
+
+// TestGraphMatchesPredict checks that the graph form of a model computes
+// what the layer stack computes, for a dense net and for a convolutional
+// one, since the convolution has to fold the spatial axes in and out.
+func TestGraphMatchesPredict(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *Sequential
+		input *tensai.Matrix
+	}{
+		{"dense", func() *Sequential {
+			net := NewSequential()
+			net.Add(layer.NewDense(8))
+			net.Add(&layer.Tanh{})
+			net.Add(layer.NewLayerNorm())
+			net.Add(layer.NewDense(3))
+			if err := net.Compile(5, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
+				t.Fatal(err)
+			}
+			return net
+		}, randMatrix(rand.New(rand.NewSource(1)), 4, 5)},
+		{"conv", func() *Sequential {
+			net := NewSequential()
+			net.Add(layer.NewConv2D(4, 3, 1, 1))
+			net.Add(&layer.ReLU{})
+			net.Add(layer.NewMaxPool2D(2))
+			net.Add(layer.NewDense(3))
+			if err := net.CompileImage(layer.Image{H: 8, W: 8, C: 2}, loss.SoftmaxCrossEntropy{}, optim.NewAdam(0.01)); err != nil {
+				t.Fatal(err)
+			}
+			return net
+		}, randMatrix(rand.New(rand.NewSource(2)), 3, 2*8*8)},
+	}
+	for _, tc := range cases {
+		net := tc.build()
+		want, err := net.Predict(tc.input)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		g, err := net.Graph()
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		got := g.Forward(autograd.Input(tc.input)).Value()
+		if len(got.Data) != len(want.Data) {
+			t.Fatalf("%s: got %d elements, want %d", tc.name, len(got.Data), len(want.Data))
+		}
+		for i := range want.Data {
+			if diff := math.Abs(float64(got.Data[i] - want.Data[i])); diff > 1e-4 {
+				t.Fatalf("%s element %d: graph=%v layers=%v", tc.name, i, got.Data[i], want.Data[i])
+			}
+		}
+	}
+}
+
+// TestGraphTrainsTheModel trains through the graph and checks that the
+// model itself learned: the parameters are the layers' own buffers, so
+// Predict sees the result without any copying.
+func TestGraphTrainsTheModel(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	inputs, err := tensai.NewMatrixFromSlice(4, 2, []tensai.Float{0, 0, 0, 1, 1, 0, 1, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets, err := tensai.NewMatrixFromSlice(4, 1, []tensai.Float{0, 1, 1, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = rng
+
+	net := NewSequential()
+	net.Add(layer.NewDense(8))
+	net.Add(&layer.Tanh{})
+	net.Add(layer.NewDense(1))
+	net.Add(&layer.Sigmoid{})
+	if err := net.Compile(2, loss.MeanSquaredError{}, optim.NewAdam(0.05)); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := net.Graph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	trainer := autograd.NewTrainer(optim.NewAdam(0.05), g.Params()...)
+	tape := autograd.NewTape()
+	tape.Bind(g.Params()...)
+	var lossVal tensai.Float
+	for step := 0; step < 1500; step++ {
+		out := g.Forward(autograd.Input(inputs))
+		l, err := g.Loss(out, targets)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lossVal = trainer.Step(l)
+		tape.Reset()
+	}
+	if lossVal > 0.02 {
+		t.Fatalf("graph training did not converge: loss=%g", lossVal)
+	}
+
+	// The layers hold the trained weights, so the model predicts with them.
+	g.Sync()
+	pred, err := net.Predict(inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for r := 0; r < 4; r++ {
+		if diff := math.Abs(float64(pred.At(r, 0) - targets.At(r, 0))); diff > 0.15 {
+			t.Errorf("sample %d: model predicts %.3f, want %g", r, pred.At(r, 0), targets.At(r, 0))
+		}
+	}
+}
+
+// TestGraphRefusesUnsupportedLayers checks that a layer with no graph form
+// is reported rather than quietly skipped.
+func TestGraphRefusesUnsupportedLayers(t *testing.T) {
+	net := NewSequential()
+	net.Add(layer.NewDense(4))
+	net.Add(layer.NewDropout(0.5))
+	if err := net.Compile(3, loss.MeanSquaredError{}, optim.NewSGD(0.1, 0.9)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := net.Graph(); err == nil {
+		t.Fatal("expected an error for a model holding a Dropout")
+	}
+}


### PR DESCRIPTION
A Sequential ran only on its layers' hand-written Forward and Backward, which is the fastest path on a CPU and the only one that cannot leave it. net.Graph() builds the same model as an autograd graph: the parameters are the layers' own matrices, so training through the graph trains the model — Predict, Save and the exports keep working — and a tape can put the whole thing on a GPU.

Dense, the activations, LayerNorm, Conv2D and MaxPool2D have graph forms. Dropout, BatchNorm and Embedding do not, and a model holding one is refused rather than trained differently than Fit would train it.

The graph's forward pass is checked against Predict for a dense and a convolutional model, training through it is checked to leave the model itself trained, and on a device the whole run is checked against the same run on the host, predictions included.