### PR TITLE
Accumulate a small a^T * b in registers

### DIFF
--- a/dot_generic.go
+++ b/dot_generic.go
@@ -27,6 +27,13 @@ func dotWorkerCount(rows, inner, cols int) int {
 
 // dotTARows computes out rows lo..hi of out = a^T * b. Portable fallback;
 // see dot_simd.go for the AVX2 kernel.
+// dotTATall is the portable stand-in for the register-accumulating kernel
+// in dot_simd.go; without vectors there is nothing to gain, so it is the
+// general one.
+func dotTATall(out, a, b *Matrix, lo, hi int) {
+	dotTARowsGeneric(out, a, b, lo, hi)
+}
+
 func dotTARows(out, a, b *Matrix, lo, hi int) {
 	dotTARowsGeneric(out, a, b, lo, hi)
 }

--- a/dot_simd.go
+++ b/dot_simd.go
@@ -91,6 +91,70 @@ func dotWorkerCount(rows, inner, cols int) int {
 // dotTARows computes out rows lo..hi of out = a^T * b with the same
 // SSE-free 8-lane FMA pattern as dotRows: a's element is fetched as integer
 // bits for the zero test and broadcast through an integer register.
+// dotTATall computes out = a^T * b when b has at most eight columns: the
+// output rows lo..hi are accumulated four at a time in vector registers,
+// so the inputs are streamed instead of the output being read back and
+// written for every element. The general kernel below does the opposite,
+// which is right when the output is wide and wrong when it is a handful of
+// values -- the shape a convolution's weight gradient has, where the
+// contracted axis is every pixel of every image in the batch.
+func dotTATall(out, a, b *Matrix, lo, hi int) {
+	if !simd.HasAVX2 {
+		dotTARowsGeneric(out, a, b, lo, hi)
+		return
+	}
+	defer archsimd.ClearAVXUpperBits()
+
+	k, n, rows := a.Cols, b.Cols, a.Rows
+	for j0 := 0; j0 < n; j0 += 8 {
+		width := min(8, n-j0)
+		dotTATallCols(out, a, b, lo, hi, k, n, rows, j0, width)
+	}
+}
+
+// dotTATallCols is dotTATall over one eight-wide slice of b's columns.
+func dotTATallCols(out, a, b *Matrix, lo, hi, k, n, rows, j0, width int) {
+	for i0 := lo; i0 < hi; i0 += 4 {
+		var acc0, acc1, acc2, acc3 archsimd.Float32x8
+		switch hi - i0 {
+		case 1:
+			for r := 0; r < rows; r++ {
+				bv := simd.LoadF32x8Part(b.Data[r*n+j0 : r*n+j0+width])
+				aRow := a.Data[r*k+i0:]
+				acc0 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[0]), acc0)
+			}
+		case 2:
+			for r := 0; r < rows; r++ {
+				bv := simd.LoadF32x8Part(b.Data[r*n+j0 : r*n+j0+width])
+				aRow := a.Data[r*k+i0:]
+				acc0 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[0]), acc0)
+				acc1 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[1]), acc1)
+			}
+		case 3:
+			for r := 0; r < rows; r++ {
+				bv := simd.LoadF32x8Part(b.Data[r*n+j0 : r*n+j0+width])
+				aRow := a.Data[r*k+i0:]
+				acc0 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[0]), acc0)
+				acc1 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[1]), acc1)
+				acc2 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[2]), acc2)
+			}
+		default:
+			for r := 0; r < rows; r++ {
+				bv := simd.LoadF32x8Part(b.Data[r*n+j0 : r*n+j0+width])
+				aRow := a.Data[r*k+i0:]
+				acc0 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[0]), acc0)
+				acc1 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[1]), acc1)
+				acc2 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[2]), acc2)
+				acc3 = bv.MulAdd(archsimd.BroadcastFloat32x8(aRow[3]), acc3)
+			}
+		}
+		accs := [4]archsimd.Float32x8{acc0, acc1, acc2, acc3}
+		for i := i0; i < hi && i < i0+4; i++ {
+			simd.StoreF32x8Part(accs[i-i0], out.Data[i*n+j0:i*n+j0+width])
+		}
+	}
+}
+
 func dotTARows(out, a, b *Matrix, lo, hi int) {
 	if !simd.HasAVX2 {
 		dotTARowsGeneric(out, a, b, lo, hi)

--- a/tensai_test.go
+++ b/tensai_test.go
@@ -39,7 +39,12 @@ func TestDotShape(t *testing.T) {
 
 func TestDotTAInto(t *testing.T) {
 	rng := rand.New(rand.NewSource(89))
-	for _, dims := range [][3]int{{5, 3, 4}, {8, 8, 8}, {17, 9, 13}, {64, 33, 5}} {
+	// The last three are tall and narrow, which is the shape a
+	// convolution's weight gradient has and the register-accumulating
+	// kernel takes: a k that is not a multiple of four, a b that is not a
+	// multiple of eight columns, and one wide enough to need two passes.
+	for _, dims := range [][3]int{{5, 3, 4}, {8, 8, 8}, {17, 9, 13}, {64, 33, 5},
+		{1024, 9, 8}, {600, 6, 5}, {1000, 7, 20}} {
 		r, i, j := dims[0], dims[1], dims[2]
 		a := RandomMatrix(r, i, rng)
 		b := RandomMatrix(r, j, rng)

--- a/tensor.go
+++ b/tensor.go
@@ -168,6 +168,16 @@ func DotTAInto(out, a, b *Matrix) error {
 		return fmt.Errorf("tensai: dotta output shape mismatch: got %dx%d, want %dx%d",
 			out.Rows, out.Cols, a.Cols, b.Cols)
 	}
+	// When the result is small enough to sit in vector registers, the
+	// operands can be streamed once instead of the output being read back
+	// and written for every element. The kernel covers four output rows
+	// and eight columns at a time, so a bigger result means reading the
+	// operands again for each block -- past a few blocks that costs more
+	// than it saves, and past that the general kernel wins.
+	if a.Rows >= 512 && ((a.Cols+3)/4)*((b.Cols+7)/8) <= 8 {
+		dotTATall(out, a, b, 0, a.Cols)
+		return nil
+	}
 	clear(out.Data) // dotTARows accumulates
 	workers := dotWorkerCount(a.Cols, a.Rows, b.Cols)
 	if workers == 1 {


### PR DESCRIPTION
A convolution's weight gradient contracts over every pixel of every image in the batch and produces a handful of numbers: 78400 by 9 transposed against 78400 by 8, for the first layer of the mnist example. The general kernel reads the output back and writes it for every element, which is right when the output is wide and wrong here — and splitting its rows across workers only made each of them stream both operands again, so sixteen cores bought 13%.

dotTATall keeps four output rows by eight columns in vector registers and streams the operands past them once. That product goes from 2.47ms to 0.60ms, and a training step of a single-convolution model from 14.4ms to 12.8ms.

It is chosen by how many register blocks the result needs: past about eight, reading the operands again for each block costs more than it saves. The first cut of that test looked only at the width, which sent the mnist example's second convolution — 72 by 16, thirty-six blocks — down the new path and made the example 4% slower. Only running it caught that.