### PR TITLE
Read Gemma 4's feed-forward width in either form

### DIFF
--- a/internal/llm/gemma4.go
+++ b/internal/llm/gemma4.go
@@ -19,7 +19,18 @@ import (
 // Everything here is stated per layer or not at all, so a missing array
 // is a file this loader cannot honestly claim to understand.
 func gemma4Config(g *gguf.File, cfg *config) error {
-	for _, n := range g.Ints("gemma4.feed_forward_length") {
+	ff := g.Ints("gemma4.feed_forward_length")
+	if len(ff) == 0 {
+		// E2B widens its feed-forward halfway down and states a width per
+		// layer; E4B keeps one width throughout and states it once.
+		if n, ok := g.Int("gemma4.feed_forward_length"); ok && n > 0 {
+			ff = make([]int64, cfg.Layers)
+			for i := range ff {
+				ff[i] = n
+			}
+		}
+	}
+	for _, n := range ff {
 		cfg.FFPerLayer = append(cfg.FFPerLayer, int(n))
 		cfg.Intermediate = max(cfg.Intermediate, int(n))
 	}

--- a/internal/llm/gemma4_test.go
+++ b/internal/llm/gemma4_test.go
@@ -144,3 +144,42 @@ func TestGPUSupportsArch(t *testing.T) {
 		}
 	}
 }
+
+// E4B's geometry, which differs from E2B's in every way the loader has
+// to read rather than assume: 42 layers on a six-layer window cycle,
+// two KV heads, one feed-forward width for the whole model, and the KV
+// boundary in a different place.
+func TestGemma4E4BShape(t *testing.T) {
+	cfg := config{
+		ModelType: "gemma4", Layers: 42, Heads: 8, KVHeads: 2,
+		HiddenSize: 2560, HeadDim: 512, HeadDimSWA: 256,
+		SlidingWin: 512, RopeTheta: 1e6, RopeThetaSWA: 10000,
+		KVFromStart: 42 - 18, PLEDim: 256, LogitCap: 30, Intermediate: 10240,
+	}
+	for i := 0; i < cfg.Layers; i++ {
+		cfg.FFPerLayer = append(cfg.FFPerLayer, 10240)
+		cfg.SWAPattern = append(cfg.SWAPattern, (i+1)%6 != 0)
+	}
+	blocks := make([]qblock, cfg.Layers)
+	for i := range blocks {
+		blockShape(&blocks[i], cfg, i)
+	}
+	// The layer the reuse rule picks has to be the same kind, which is
+	// what makes the shared cache the right shape.
+	for i, b := range blocks {
+		if (i < cfg.KVFromStart) != (b.kvFrom < 0) {
+			t.Fatalf("layer %d: kvFrom %d against a boundary at %d", i, b.kvFrom, cfg.KVFromStart)
+		}
+		if b.kvFrom >= 0 && blocks[b.kvFrom].headSz != b.headSz {
+			t.Errorf("layer %d (head %d) reuses layer %d (head %d)",
+				i, b.headSz, b.kvFrom, blocks[b.kvFrom].headSz)
+		}
+		if b.ff != 10240 {
+			t.Errorf("layer %d: ff %d", i, b.ff)
+		}
+	}
+	if blocks[23].headSz != 512 || blocks[24].headSz != 256 {
+		t.Errorf("the window cycle is off: layer 23 head %d, layer 24 head %d",
+			blocks[23].headSz, blocks[24].headSz)
+	}
+}


### PR DESCRIPTION
E2B states a feed-forward width per layer; E4B keeps one width for all 42 layers and states it once, which the loader did not accept. The rest of E4B's geometry -- a six-layer window cycle, two KV heads, the KV boundary at 24 -- already comes off the file. Checked against the real E4B header; the weights themselves have not been run yet.