### PR TITLE
Let a block keep its own KV cache by default

### DIFF
--- a/internal/llm/blockdefaults_test.go
+++ b/internal/llm/blockdefaults_test.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"math/rand"
+	"testing"
+
+	tensai "github.com/mattn/tensai"
+)
+
+// A model assembled the way the safetensors loader assembles one -- the
+// blocks made and filled in place, with none of the gguf loader's
+// per-layer shaping -- has to decode. It did not: a layer's "whose cache
+// do I attend against" started at zero, which named layer 0 rather than
+// itself, so no layer wrote a cache and the first attention read an
+// empty one.
+func TestZeroValueBlockKeepsItsOwnCache(t *testing.T) {
+	const layers, hidden, heads, kvHeads, ff = 2, 8, 2, 1, 16
+	head := hidden / heads
+	rng := rand.New(rand.NewSource(1))
+	mat := func(r, c int) *tensai.Matrix {
+		m := tensai.NewMatrix(r, c)
+		for i := range m.Data {
+			m.Data[i] = float32(rng.NormFloat64()) * 0.1
+		}
+		return m
+	}
+	vec := func(n int) []float32 {
+		v := make([]float32, n)
+		for i := range v {
+			v[i] = 1
+		}
+		return v
+	}
+	m := &qwen{
+		cfg: config{
+			ModelType: "qwen2", Layers: layers, HiddenSize: hidden, Heads: heads,
+			KVHeads: kvHeads, Intermediate: ff, RMSEps: 1e-6, RopeTheta: 10000,
+			Vocab: 4, MaxPos: 64,
+		},
+		headSz: head,
+	}
+	m.embed = tensai.NewTensor(4, hidden)
+	for i := range m.embed.Data {
+		m.embed.Data[i] = float32(rng.NormFloat64())
+	}
+	m.normW = vec(hidden)
+	m.lmT = mat(hidden, 4)
+	m.blocks = make([]qblock, layers) // exactly what loadQwen does
+	for i := range m.blocks {
+		b := &m.blocks[i]
+		b.ln1, b.ln2 = vec(hidden), vec(hidden)
+		b.wQKV = mat(hidden, heads*head+2*kvHeads*head)
+		b.wo = mat(heads*head, hidden)
+		b.wGU = mat(hidden, 2*ff)
+		b.wDown = mat(ff, hidden)
+	}
+	m.initRopeFreqs()
+
+	// Prefill is where the empty cache was read, and decode has to agree
+	// with it: feeding the same tokens one at a time lands in the same
+	// place.
+	batch := m.prefill([]int{0, 1, 2}, 0)
+	m.reset()
+	var one []float32
+	for i, tok := range []int{0, 1, 2} {
+		one = m.step(tok, i)
+	}
+	for i := range batch {
+		if diff := batch[i] - one[i]; diff > 1e-4 || diff < -1e-4 {
+			t.Fatalf("logit %d: %v prefilled, %v decoded", i, batch[i], one[i])
+		}
+	}
+	for i := range m.blocks {
+		if got := len(m.blocks[i].kc); got != 3 {
+			t.Errorf("layer %d holds %d cache rows, want 3", i, got)
+		}
+	}
+}

--- a/internal/llm/cache_test.go
+++ b/internal/llm/cache_test.go
@@ -93,9 +93,9 @@ func TestWeightCacheRoundTrip(t *testing.T) {
 		same("wPleProj", a.wPleProj.Data, b.wPleProj.Data)
 		same("wQKV", a.wQKV.Data, b.wQKV.Data)
 		// The geometry comes from the config, not from the cache.
-		if b.ff != a.ff || b.headSz != a.headSz || b.kvFrom != a.kvFrom || !b.unitQK {
-			t.Errorf("layer %d geometry: ff %d head %d kvFrom %d unitQK %v",
-				i, b.ff, b.headSz, b.kvFrom, b.unitQK)
+		if b.ff != a.ff || b.headSz != a.headSz || b.kvShared != a.kvShared || !b.unitQK {
+			t.Errorf("layer %d geometry: ff %d head %d kvShared %v unitQK %v",
+				i, b.ff, b.headSz, b.kvShared, b.unitQK)
 		}
 	}
 }

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -315,7 +315,7 @@ func Open(o Options) (*Engine, error) {
 		total, widest := 0, 0
 		for i := range model.blocks {
 			b := &model.blocks[i]
-			if b.kvFrom >= 0 {
+			if b.kvShared {
 				continue
 			}
 			kvDim := model.cfg.KVHeads * model.headSize(b)

--- a/internal/llm/gemma4_test.go
+++ b/internal/llm/gemma4_test.go
@@ -36,7 +36,7 @@ func TestGemma4BlockShape(t *testing.T) {
 		window int
 		theta  float64
 		ff     int
-		kvFrom int
+		kvFrom int // -1 for a layer that keeps its own
 	}{
 		{0, 256, 512, 10000, 6144, -1},   // local, its own cache
 		{4, 512, 0, 0, 6144, -1},         // global, its own cache
@@ -50,14 +50,18 @@ func TestGemma4BlockShape(t *testing.T) {
 			t.Errorf("layer %d: head %d window %d theta %v, want %d %d %v",
 				tt.layer, b.headSz, b.window, b.ropeTheta, tt.head, tt.window, tt.theta)
 		}
-		if b.ff != tt.ff || b.kvFrom != tt.kvFrom {
-			t.Errorf("layer %d: ff %d kvFrom %d, want %d %d", tt.layer, b.ff, b.kvFrom, tt.ff, tt.kvFrom)
+		kvFrom := -1
+		if b.kvShared {
+			kvFrom = b.kvFrom
+		}
+		if b.ff != tt.ff || kvFrom != tt.kvFrom {
+			t.Errorf("layer %d: ff %d kvFrom %d, want %d %d", tt.layer, b.ff, kvFrom, tt.ff, tt.kvFrom)
 		}
 		if !b.geglu || !b.vNorm || !b.unitQK {
 			t.Errorf("layer %d: geglu %v vNorm %v unitQK %v", tt.layer, b.geglu, b.vNorm, b.unitQK)
 		}
 		// A layer reusing a cache must find the same geometry there.
-		if b.kvFrom >= 0 && blocks[b.kvFrom].headSz != b.headSz {
+		if b.kvShared && blocks[b.kvFrom].headSz != b.headSz {
 			t.Errorf("layer %d reuses layer %d, whose head is %d not %d",
 				tt.layer, b.kvFrom, blocks[b.kvFrom].headSz, b.headSz)
 		}
@@ -67,8 +71,8 @@ func TestGemma4BlockShape(t *testing.T) {
 		cfg := config{ModelType: arch, Layers: 4, SlidingWin: 128}
 		var b qblock
 		blockShape(&b, cfg, 1)
-		if b.kvFrom != -1 || b.ff != 0 || b.unitQK {
-			t.Errorf("%s: kvFrom %d ff %d unitQK %v", arch, b.kvFrom, b.ff, b.unitQK)
+		if b.kvShared || b.ff != 0 || b.unitQK {
+			t.Errorf("%s: kvShared %v ff %d unitQK %v", arch, b.kvShared, b.ff, b.unitQK)
 		}
 	}
 }
@@ -167,10 +171,10 @@ func TestGemma4E4BShape(t *testing.T) {
 	// The layer the reuse rule picks has to be the same kind, which is
 	// what makes the shared cache the right shape.
 	for i, b := range blocks {
-		if (i < cfg.KVFromStart) != (b.kvFrom < 0) {
-			t.Fatalf("layer %d: kvFrom %d against a boundary at %d", i, b.kvFrom, cfg.KVFromStart)
+		if (i < cfg.KVFromStart) == b.kvShared {
+			t.Fatalf("layer %d: kvShared %v against a boundary at %d", i, b.kvShared, cfg.KVFromStart)
 		}
-		if b.kvFrom >= 0 && blocks[b.kvFrom].headSz != b.headSz {
+		if b.kvShared && blocks[b.kvFrom].headSz != b.headSz {
 			t.Errorf("layer %d (head %d) reuses layer %d (head %d)",
 				i, b.headSz, b.kvFrom, blocks[b.kvFrom].headSz)
 		}

--- a/internal/llm/gguf.go
+++ b/internal/llm/gguf.go
@@ -753,7 +753,6 @@ func blockShape(b *qblock, cfg config, i int) {
 	// SmolLM3 skips RoPE on every fourth layer; the GGUF carries no
 	// flag for it, matching llama.cpp's hardcoded rule.
 	b.noPE = arch == "smollm3" && i%4 == 3
-	b.kvFrom = -1
 	switch arch {
 	case "gemma3":
 		// Five of every six layers attend over a sliding window
@@ -785,6 +784,7 @@ func blockShape(b *qblock, cfg config, i int) {
 		// Past KVFromStart a layer projects queries only and attends
 		// against the last layer of its own kind that kept a cache.
 		if i >= cfg.KVFromStart {
+			b.kvShared = true
 			b.kvFrom = cfg.KVFromStart - 1
 			if cfg.SWAPattern[i] {
 				b.kvFrom = cfg.KVFromStart - 2
@@ -1461,7 +1461,7 @@ func loadGGUF(path string, bits int, direct, cache bool, vlog io.Writer) (*qwen,
 				// Phi-3 ships q/k/v pre-fused in that order — the layout
 				// the runtime wants, no permutation (NEOX rope).
 				b.wQKV, b.qQKV = linAuto([]string{p + "attn_qkv.weight"}, []int{0})
-			} else if b.kvFrom >= 0 {
+			} else if b.kvShared {
 				// A layer that attends against an earlier layer's cache
 				// projects queries and nothing else.
 				b.wQKV, b.qQKV = linAuto([]string{p + "attn_q.weight"}, []int{qPerm})

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -45,8 +45,9 @@ type gpuLayer struct {
 	// The widths belong to the layer, not to the model: gemma4 alternates
 	// two head widths and two feed-forward widths, and its deeper layers
 	// project queries only and attend against an earlier layer's cache
-	// (kvFrom, -1 when the layer keeps its own).
+	// (kvFrom, meaningful only when kvShared).
 	headSz, qDim, kvDim, ff int
+	kvShared                bool
 	kvFrom                  int
 	// gemma4: its logits carry no 1/sqrt(head) (qScale folds that back
 	// into the queries), its values are normalized without a weight of
@@ -271,7 +272,7 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw, vlog io.Writer) (*gpuQwe
 		l.qDim = m.cfg.Heads * l.headSz
 		l.kvDim = m.cfg.KVHeads * l.headSz
 		l.ff = m.ffWidth(b)
-		l.kvFrom = b.kvFrom
+		l.kvShared, l.kvFrom = b.kvShared, b.kvFrom
 		hs, kvDim := l.qDim, l.kvDim
 		// A half-precision KV cache halves the resident cache when the
 		// device has shader-f16 and this layer's head grouping fits the
@@ -280,7 +281,7 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw, vlog io.Writer) (*gpuQwe
 		// A view onto the fused result needs a 256-byte aligned offset,
 		// so both the q and the q|k boundary have to sit on 64 floats.
 		fuseQKV := hs%64 == 0 && kvDim%64 == 0
-		if l.kvFrom >= 0 {
+		if l.kvShared {
 			// Nothing but queries comes out of the projection, so the
 			// views that would carve k and v out never happen.
 			fuseQKV = true
@@ -329,7 +330,7 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw, vlog io.Writer) (*gpuQwe
 		l.qGU = up(b.qGU)
 		l.qDown = up(b.qDown)
 		switch {
-		case l.kvFrom >= 0:
+		case l.kvShared:
 			// This layer writes no keys or values: it attends against
 			// the cache an earlier layer of its own kind already fills.
 			src := &gq.layers[l.kvFrom]
@@ -387,7 +388,7 @@ func (gq *gpuQwen) qkv(l *gpuLayer, x *gpu.Tensor, norm *gpu.Tensor, eps float64
 			must(l.qv.MatMulRMSNorm(x, norm, eps, l.bv, nil)), nil
 	}
 	f := must(l.qQKV.MatMulRMSNorm(x, norm, eps, l.bQKV, nil))
-	if l.kvFrom >= 0 {
+	if l.kvShared {
 		// Queries only: there is nothing else in the row.
 		return must(f.View(0, 1, l.qDim)), nil, nil, f
 	}
@@ -409,7 +410,7 @@ func (gq *gpuQwen) qkvRows(l *gpuLayer, a *gpu.Tensor) (q, k, v *gpu.Tensor) {
 	}
 	f := must(l.qQKV.MatMulOpts(a, l.bQKV, nil))
 	defer f.Free()
-	if l.kvFrom >= 0 {
+	if l.kvShared {
 		return must(f.SliceCols(0, l.qDim)), nil, nil
 	}
 	return must(f.SliceCols(0, l.qDim)),

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -158,7 +158,8 @@ type qblock struct {
 	noPE         bool           // smollm3: every fourth layer skips RoPE
 	headSz       int            // this layer's head width; gemma4 alternates 256 and 512
 	ff           int            // this layer's feed-forward width; 0 = cfg.Intermediate
-	kvFrom       int            // gemma4: the layer whose KV cache this one attends against; -1 = its own
+	kvShared     bool           // gemma4: this layer keeps no cache of its own
+	kvFrom       int            // the layer whose cache it attends against, when kvShared
 	vNorm        bool           // gemma4: RMS-normalize V with no weight of its own
 	unitQK       bool           // gemma4: attention logits are not divided by sqrt(head)
 	ropeFF       []float32      // gemma4 global layers: per-pair rope frequency divisor
@@ -1032,7 +1033,7 @@ func (m *qwen) ffWidth(b *qblock) int {
 // earlier layer's for the gemma4 blocks that project no keys or values.
 // The source layer always runs first, so sharing the slices is enough.
 func (m *qwen) kvCache(b *qblock) {
-	if b.kvFrom >= 0 {
+	if b.kvShared {
 		src := &m.blocks[b.kvFrom]
 		b.kc, b.vc = src.kc, src.vc
 	}
@@ -1230,7 +1231,7 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 		qDim := cfg.Heads * headSz
 		qProjW := m.qProjWidth(b)
 		qkvW := qProjW + 2*kvDim
-		if b.kvFrom >= 0 {
+		if b.kvShared {
 			// This layer projects queries only.
 			qkvW = qProjW
 		}
@@ -1264,7 +1265,7 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 			// Two batch-wide backings detach the cache rows from the wide
 			// fused buffer instead of 2n little allocations per layer.
 			var kb, vb []float32
-			if b.kvFrom < 0 {
+			if !b.kvShared {
 				kb = make([]float32, n*kvDim)
 				vb = make([]float32, n*kvDim)
 			}
@@ -1282,7 +1283,7 @@ func (m *qwen) forwardBatch(tokens []int, startPos int) *tensai.Matrix {
 						m.rope(qr[h*headSz:(h+1)*headSz], pos, b)
 					}
 				}
-				if b.kvFrom >= 0 {
+				if b.kvShared {
 					continue
 				}
 				kr := row[qProjW : qProjW+kvDim]
@@ -1499,7 +1500,7 @@ func (m *qwen) step(token, pos int) []float32 {
 		qDim := cfg.Heads * headSz
 		qProjW := m.qProjWidth(b)
 		qkvW := qProjW + 2*kvDim
-		if b.kvFrom >= 0 {
+		if b.kvShared {
 			// This layer projects queries only.
 			qkvW = qProjW
 		}
@@ -1531,7 +1532,7 @@ func (m *qwen) step(token, pos int) []float32 {
 				m.rope(q[h*headSz:(h+1)*headSz], pos, b)
 			}
 		}
-		if b.kvFrom >= 0 {
+		if b.kvShared {
 			m.kvCache(b)
 		} else {
 			k := row[qProjW : qProjW+kvDim]


### PR DESCRIPTION
gemma4 brought layers that attend against an earlier layer's cache, marked by an index whose "mine" was -1. The gguf loader set it; the safetensors loader, which shapes its blocks itself, did not, so every layer of every checkpoint loaded that way believed it shared layer 0's cache and the first attention read an empty one. Panics on the first message with the default model, since #208. The sentinel becomes a flag, so the zero value is the common case, and the test builds a model the way the safetensors loader does and decodes with it.