### PR TITLE
Split three single-threaded loads across workers

### DIFF
--- a/encoding/gguf/gguf.go
+++ b/encoding/gguf/gguf.go
@@ -30,9 +30,11 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync/atomic"
 
 	tensai "github.com/mattn/tensai"
 	"github.com/mattn/tensai/internal/mmapfile"
+	"github.com/mattn/tensai/internal/workpool"
 )
 
 // Tensor encodings from the GGML type enum; only the ones this package
@@ -288,6 +290,131 @@ func (f *File) Float(key string) (float64, bool) {
 	return float64(n), ok
 }
 
+// parallelDequantMin is how many values a tensor needs before decoding
+// it is worth splitting; a var so a test can reach the parallel path
+// without a megabyte of fixture.
+var parallelDequantMin = 1 << 20
+
+// dequantBlocks fills dst from raw for one whole number of blocks. Every
+// case walks its blocks from the front, so a caller can hand it any
+// block-aligned window of a tensor and get that window decoded -- which
+// is what lets the big ones decode on several workers at once.
+func dequantBlocks(typ uint32, name string, dst []float32, raw []byte, n int64) error {
+	switch typ {
+	case typeF32:
+		for i := range dst {
+			dst[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[4*i:]))
+		}
+	case typeF16:
+		for i := range dst {
+			dst[i] = f16to32(binary.LittleEndian.Uint16(raw[2*i:]))
+		}
+	case typeBF16:
+		for i := range dst {
+			dst[i] = math.Float32frombits(uint32(binary.LittleEndian.Uint16(raw[2*i:])) << 16)
+		}
+	case typeQ8_0:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*34:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			for i := 0; i < 32; i++ {
+				dst[b*32+int64(i)] = s * float32(int8(blk[2+i]))
+			}
+		}
+	case typeQ4_0:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*18:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			for i := 0; i < 16; i++ {
+				q := blk[2+i]
+				dst[b*32+int64(i)] = s * (float32(q&0x0F) - 8)
+				dst[b*32+int64(i)+16] = s * (float32(q>>4) - 8)
+			}
+		}
+	case typeQ4_1:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*20:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			m := f16to32(binary.LittleEndian.Uint16(blk[2:]))
+			for i := 0; i < 16; i++ {
+				q := blk[4+i]
+				dst[b*32+int64(i)] = s*float32(q&0x0F) + m
+				dst[b*32+int64(i)+16] = s*float32(q>>4) + m
+			}
+		}
+	case typeQ5_0:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*22:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			qh := binary.LittleEndian.Uint32(blk[2:])
+			for i := 0; i < 16; i++ {
+				q := blk[6+i]
+				lo := uint32(q&0x0F) | qh>>i<<4&0x10
+				hi := uint32(q>>4) | qh>>(i+12)&0x10
+				dst[b*32+int64(i)] = s * (float32(lo) - 16)
+				dst[b*32+int64(i)+16] = s * (float32(hi) - 16)
+			}
+		}
+	case typeQ5_1:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*24:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			m := f16to32(binary.LittleEndian.Uint16(blk[2:]))
+			qh := binary.LittleEndian.Uint32(blk[4:])
+			for i := 0; i < 16; i++ {
+				q := blk[8+i]
+				lo := uint32(q&0x0F) | qh>>i<<4&0x10
+				hi := uint32(q>>4) | qh>>(i+12)&0x10
+				dst[b*32+int64(i)] = s*float32(lo) + m
+				dst[b*32+int64(i)+16] = s*float32(hi) + m
+			}
+		}
+	case typeIQ4NL:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*18:]
+			s := f16to32(binary.LittleEndian.Uint16(blk))
+			for i := 0; i < 16; i++ {
+				q := blk[2+i]
+				dst[b*32+int64(i)] = s * iq4nl[q&0x0F]
+				dst[b*32+int64(i)+16] = s * iq4nl[q>>4]
+			}
+		}
+	case typeMXFP4:
+		for b := int64(0); b < n/32; b++ {
+			blk := raw[b*17:]
+			// E8M0 exponent; the table carries twice the FP4 values, so
+			// the factor halves.
+			s := float32(math.Ldexp(1, int(blk[0])-128))
+			for i := 0; i < 16; i++ {
+				q := blk[1+i]
+				dst[b*32+int64(i)] = s * mxfp4[q&0x0F]
+				dst[b*32+int64(i)+16] = s * mxfp4[q>>4]
+			}
+		}
+	case typeQ2_K:
+		for b := int64(0); b < n/256; b++ {
+			dequantQ2K(raw[b*84:b*84+84], dst[b*256:b*256+256])
+		}
+	case typeQ3_K:
+		for b := int64(0); b < n/256; b++ {
+			dequantQ3K(raw[b*110:b*110+110], dst[b*256:b*256+256])
+		}
+	case typeQ4_K:
+		for b := int64(0); b < n/256; b++ {
+			dequantQ4K(raw[b*144:b*144+144], dst[b*256:b*256+256])
+		}
+	case typeQ5_K:
+		for b := int64(0); b < n/256; b++ {
+			dequantQ5K(raw[b*176:b*176+176], dst[b*256:b*256+256])
+		}
+	case typeQ6_K:
+		for b := int64(0); b < n/256; b++ {
+			dequantQ6K(raw[b*210:b*210+210], dst[b*256:b*256+256])
+		}
+	}
+	return nil
+}
+
 // Ints returns an integer array metadata value, whatever width the file
 // stored its elements at, or nil when the key is absent or not an array
 // of integers. Gemma 4 states its per-layer feed-forward widths this way.
@@ -468,117 +595,23 @@ func (f *File) TensorRows(name string, from, to int) (*tensai.Tensor, error) {
 	}
 	out := tensai.NewTensor(shape...)
 	dst := out.Data
-	switch t.typ {
-	case typeF32:
-		for i := range dst {
-			dst[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[4*i:]))
-		}
-	case typeF16:
-		for i := range dst {
-			dst[i] = f16to32(binary.LittleEndian.Uint16(raw[2*i:]))
-		}
-	case typeBF16:
-		for i := range dst {
-			dst[i] = math.Float32frombits(uint32(binary.LittleEndian.Uint16(raw[2*i:])) << 16)
-		}
-	case typeQ8_0:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*34:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			for i := 0; i < 32; i++ {
-				dst[b*32+int64(i)] = s * float32(int8(blk[2+i]))
+	// A 400-million-value embedding is a second and a half of scalar
+	// decoding; block ranges are independent, so they split across the
+	// workers a decode step already keeps resident.
+	if blocks := n / spec.values; blocks >= 64 && len(dst) >= parallelDequantMin {
+		var ferr atomic.Pointer[error]
+		workpool.Run(int(blocks), 1, func(lo, hi int) {
+			w := int64(hi-lo) * spec.values
+			if err := dequantBlocks(t.typ, name, dst[int64(lo)*spec.values:int64(hi)*spec.values],
+				raw[int64(lo)*spec.bytes:int64(hi)*spec.bytes], w); err != nil {
+				ferr.CompareAndSwap(nil, &err)
 			}
+		})
+		if p := ferr.Load(); p != nil {
+			return nil, *p
 		}
-	case typeQ4_0:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*18:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			for i := 0; i < 16; i++ {
-				q := blk[2+i]
-				dst[b*32+int64(i)] = s * (float32(q&0x0F) - 8)
-				dst[b*32+int64(i)+16] = s * (float32(q>>4) - 8)
-			}
-		}
-	case typeQ4_1:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*20:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			m := f16to32(binary.LittleEndian.Uint16(blk[2:]))
-			for i := 0; i < 16; i++ {
-				q := blk[4+i]
-				dst[b*32+int64(i)] = s*float32(q&0x0F) + m
-				dst[b*32+int64(i)+16] = s*float32(q>>4) + m
-			}
-		}
-	case typeQ5_0:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*22:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			qh := binary.LittleEndian.Uint32(blk[2:])
-			for i := 0; i < 16; i++ {
-				q := blk[6+i]
-				lo := uint32(q&0x0F) | qh>>i<<4&0x10
-				hi := uint32(q>>4) | qh>>(i+12)&0x10
-				dst[b*32+int64(i)] = s * (float32(lo) - 16)
-				dst[b*32+int64(i)+16] = s * (float32(hi) - 16)
-			}
-		}
-	case typeQ5_1:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*24:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			m := f16to32(binary.LittleEndian.Uint16(blk[2:]))
-			qh := binary.LittleEndian.Uint32(blk[4:])
-			for i := 0; i < 16; i++ {
-				q := blk[8+i]
-				lo := uint32(q&0x0F) | qh>>i<<4&0x10
-				hi := uint32(q>>4) | qh>>(i+12)&0x10
-				dst[b*32+int64(i)] = s*float32(lo) + m
-				dst[b*32+int64(i)+16] = s*float32(hi) + m
-			}
-		}
-	case typeIQ4NL:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*18:]
-			s := f16to32(binary.LittleEndian.Uint16(blk))
-			for i := 0; i < 16; i++ {
-				q := blk[2+i]
-				dst[b*32+int64(i)] = s * iq4nl[q&0x0F]
-				dst[b*32+int64(i)+16] = s * iq4nl[q>>4]
-			}
-		}
-	case typeMXFP4:
-		for b := int64(0); b < n/32; b++ {
-			blk := raw[b*17:]
-			// E8M0 exponent; the table carries twice the FP4 values, so
-			// the factor halves.
-			s := float32(math.Ldexp(1, int(blk[0])-128))
-			for i := 0; i < 16; i++ {
-				q := blk[1+i]
-				dst[b*32+int64(i)] = s * mxfp4[q&0x0F]
-				dst[b*32+int64(i)+16] = s * mxfp4[q>>4]
-			}
-		}
-	case typeQ2_K:
-		for b := int64(0); b < n/256; b++ {
-			dequantQ2K(raw[b*84:b*84+84], dst[b*256:b*256+256])
-		}
-	case typeQ3_K:
-		for b := int64(0); b < n/256; b++ {
-			dequantQ3K(raw[b*110:b*110+110], dst[b*256:b*256+256])
-		}
-	case typeQ4_K:
-		for b := int64(0); b < n/256; b++ {
-			dequantQ4K(raw[b*144:b*144+144], dst[b*256:b*256+256])
-		}
-	case typeQ5_K:
-		for b := int64(0); b < n/256; b++ {
-			dequantQ5K(raw[b*176:b*176+176], dst[b*256:b*256+256])
-		}
-	case typeQ6_K:
-		for b := int64(0); b < n/256; b++ {
-			dequantQ6K(raw[b*210:b*210+210], dst[b*256:b*256+256])
-		}
+	} else if err := dequantBlocks(t.typ, name, dst, raw, n); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/encoding/gguf/gguf_test.go
+++ b/encoding/gguf/gguf_test.go
@@ -304,3 +304,35 @@ func TestBadInput(t *testing.T) {
 		t.Fatal("expected error for IQ2_XXS")
 	}
 }
+
+// A big tensor decodes on several workers, one block range each. The
+// answer has to be the one the single-threaded walk gives, for every
+// encoding the reader knows.
+func TestParallelDequantMatchesSerial(t *testing.T) {
+	f, err := NewFile(bytes.NewReader(buildTestFile(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range f.Names() {
+		was := parallelDequantMin
+		parallelDequantMin = 1 << 30 // serial
+		serial, err := f.Tensor(name)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		parallelDequantMin = 1 // every block range its own chunk
+		split, err := f.Tensor(name)
+		parallelDequantMin = was
+		if err != nil {
+			t.Fatalf("%s split: %v", name, err)
+		}
+		if len(serial.Data) != len(split.Data) {
+			t.Fatalf("%s: %d values serial, %d split", name, len(serial.Data), len(split.Data))
+		}
+		for i := range serial.Data {
+			if serial.Data[i] != split.Data[i] {
+				t.Fatalf("%s[%d] = %v serial, %v split", name, i, serial.Data[i], split.Data[i])
+			}
+		}
+	}
+}

--- a/gpu/wgpu_stub.go
+++ b/gpu/wgpu_stub.go
@@ -265,6 +265,9 @@ func (g *Device) IntDot() bool { return false }
 // NewF16Tensor always fails in builds without the wgpu tag.
 func (g *Device) NewF16Tensor(shape ...int) (*Tensor, error) { return nil, errNoWGPU }
 
+// NewZeroTensor always fails in builds without the wgpu tag.
+func (g *Device) NewZeroTensor(shape ...int) (*Tensor, error) { return nil, errNoWGPU }
+
 // MatMul always fails in builds without the wgpu tag.
 func (q *Q4Matrix) MatMul(x *Tensor) (*Tensor, error) { return nil, errNoWGPU }
 

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mattn/tensai"
 	"github.com/mattn/tensai/internal/dims"
 	"github.com/mattn/tensai/internal/kernels"
+	"github.com/mattn/tensai/internal/workpool"
 	"github.com/mattn/tensai/quant"
 )
 
@@ -3348,6 +3349,33 @@ func (g *Device) HasF16() bool { return g.hasF16 }
 // NewF16Tensor allocates a zeroed half-precision Device tensor. Only the
 // attention cache kernels read and write f16 tensors: fill it with
 // CopyRowsInto, feed it to GroupedCausalAttention.
+// NewZeroTensor allocates a float32 tensor on the device without
+// sending anything: a buffer starts zeroed, so a KV cache -- which is
+// gigabytes of it, and every row written before it is read -- has no
+// reason to be uploaded from the host at all.
+func (g *Device) NewZeroTensor(shape ...int) (*Tensor, error) {
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	if n <= 0 {
+		return nil, errors.New("tensai: empty tensor")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	wgpuMu.Lock()
+	defer wgpuMu.Unlock()
+	if g.closed {
+		return nil, errors.New("tensai: gpu is closed")
+	}
+	t := &Tensor{g: g, shape: append([]int(nil), shape...)}
+	t.buf = g.newBuffer(gpuTensorUsage, t.byteLen())
+	if t.buf == 0 {
+		return nil, errors.New("tensai: gpu buffer allocation failed")
+	}
+	return t, nil
+}
+
 func (g *Device) NewF16Tensor(shape ...int) (*Tensor, error) {
 	if !g.hasF16 {
 		return nil, errors.New("tensai: device has no shader-f16 support")
@@ -4657,13 +4685,17 @@ func (g *Device) UploadQ8(q *quant.QMatrix) (*QMatrix, error) {
 		return nil, errors.New("tensai: cannot upload an empty matrix")
 	}
 	words := (q.Cols + 3) / 4
+	// One row per stretch of packed words, so the walk splits across
+	// workers the way the int4 one does.
 	packed := make([]uint32, q.Rows*words)
-	for i := 0; i < q.Rows; i++ {
-		for j := 0; j < q.Cols; j++ {
-			b := uint32(uint8(q.Q[q.Index(i, j)]))
-			packed[i*words+j/4] |= b << (8 * (j % 4))
+	workpool.Run(q.Rows, 1, func(lo, hi int) {
+		for i := lo; i < hi; i++ {
+			for j := 0; j < q.Cols; j++ {
+				b := uint32(uint8(q.Q[q.Index(i, j)]))
+				packed[i*words+j/4] |= b << (8 * (j % 4))
+			}
 		}
-	}
+	})
 	scales := make([]float32, words*4)
 	for j, s := range q.Scale {
 		scales[j] = float32(s)
@@ -5640,20 +5672,27 @@ func (g *Device) UploadQ4(q *quant.Q4Matrix) (*Q4Matrix, error) {
 		}
 		return uint32(q.Q[q.Index(i, j)]>>(4*(i%2))) & 0x0F
 	}
+	// A row pair owns its stretch of the packed words, so the walk splits
+	// across workers cleanly. It is a billion iterations on a small model
+	// and was most of what -gpu spent getting started.
 	packed := make([]uint32, pairs*words)
-	for i2 := 0; i2 < pairs; i2++ {
-		for j := 0; j < q.Cols; j++ {
-			b := nib(2*i2, j) | nib(2*i2+1, j)<<4
-			packed[i2*words+j/4] |= b << (8 * (j % 4))
+	workpool.Run(pairs, 1, func(lo, hi int) {
+		for i2 := lo; i2 < hi; i2++ {
+			for j := 0; j < q.Cols; j++ {
+				b := nib(2*i2, j) | nib(2*i2+1, j)<<4
+				packed[i2*words+j/4] |= b << (8 * (j % 4))
+			}
 		}
-	}
+	})
 	groups := (q.Rows + 63) / 64 // q4Group
 	scales := make([]float32, groups*words*4)
-	for gi := 0; gi < groups; gi++ {
-		for j := 0; j < q.Cols; j++ {
-			scales[gi*words*4+j] = q.Scale[q.TableIndex(gi, j)]
+	workpool.Run(groups, 1, func(lo, hi int) {
+		for gi := lo; gi < hi; gi++ {
+			for j := 0; j < q.Cols; j++ {
+				scales[gi*words*4+j] = q.Scale[q.TableIndex(gi, j)]
+			}
 		}
-	}
+	})
 
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/internal/llm/gpu.go
+++ b/internal/llm/gpu.go
@@ -339,8 +339,8 @@ func newGPUQwen(m *qwen, g *gpu.Device, nCtx int, logw, vlog io.Writer) (*gpuQwe
 			l.kc = must(g.NewF16Tensor(nCtx, kvDim))
 			l.vc = must(g.NewF16Tensor(nCtx, kvDim))
 		default:
-			l.kc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
-			l.vc = must(g.Upload(tensai.NewTensor(nCtx, kvDim)))
+			l.kc = must(g.NewZeroTensor(nCtx, kvDim))
+			l.vc = must(g.NewZeroTensor(nCtx, kvDim))
 		}
 	}
 	// The lm_head is the single biggest weight in a small model — for


### PR DESCRIPTION
Starting a model on the device took eleven and a half seconds, almost none of it transfer. UploadQ4 and UploadQ8 rebuild the kernel's layout on one core, a billion iterations for a 2B model; the gguf reader decodes a tensor's blocks on one core, and the token embedding is four hundred million values of it. All three are row- or block-independent and now split across the resident pool. The KV cache also stops uploading its zeros. Device upload goes 11.5s to 5.7s, a cold gguf load 5.1s to 3.2s, and the new gguf test pins that a split decode matches the serial one.