### PR TITLE
Keep a token to prefill when the cache holds the whole prompt

### DIFF
--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -1147,6 +1147,9 @@ func (m *qwen) rope(h []float32, pos int, b *qblock) {
 // batch instead of once per token. The lm_head runs only on the final
 // position.
 func (m *qwen) prefill(tokens []int, startPos int) []float32 {
+	if len(tokens) == 0 {
+		panic("tensai: prefill of no tokens; the caller must keep one to produce logits from")
+	}
 	x := m.forwardBatch(tokens, startPos)
 	hs := m.cfg.HiddenSize
 	last := x.Data[(len(tokens)-1)*hs : len(tokens)*hs]

--- a/internal/llm/promptcache.go
+++ b/internal/llm/promptcache.go
@@ -51,6 +51,11 @@ func (c *promptCache) plan(tokens []int) (start int, restore bool) {
 	} else if !c.hasDelta && n > 0 && n < len(tokens) {
 		// Rolling a KV cache back is just a shorter slice of it.
 		return n, false
+	} else if !c.hasDelta && n > 1 && n == len(tokens) {
+		// The same prompt again -- a retry, or a regenerate. Its logits
+		// come from the last token, so that one row rolls back and is
+		// computed again while everything before it stands.
+		return n - 1, false
 	}
 	if n := commonPrefix(c.ckpt, tokens); n > 0 && n == len(c.ckpt) && n < len(tokens) {
 		return n, true

--- a/internal/llm/promptcache_test.go
+++ b/internal/llm/promptcache_test.go
@@ -43,9 +43,13 @@ func TestPlan(t *testing.T) {
 		{"diverges, recurrent, checkpointed", promptCache{enabled: true, hasDelta: true,
 			live: append(append([]int{}, sys...), 9), ckpt: sys},
 			append(append([]int{}, sys...), 5), 4, true},
-		// An identical prompt has nothing left to prefill and must not
-		// claim the whole thing is already done.
-		{"identical", promptCache{enabled: true, live: sys}, sys, 0, false},
+		// An identical prompt -- a retry, or a regenerate -- keeps
+		// everything but its last token, whose logits are the answer.
+		// It must never claim the whole thing is already done: that
+		// leaves nothing to prefill.
+		{"identical", promptCache{enabled: true, live: sys}, sys, len(sys) - 1, false},
+		// A recurrent state cannot roll that one row back, so it starts over.
+		{"identical, recurrent", promptCache{enabled: true, hasDelta: true, live: sys}, sys, 0, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			start, restore := tt.c.plan(tt.tokens)
@@ -85,5 +89,34 @@ func TestDeltaSnapshotRoundTrip(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("after restore out[%d] = %v, want %v", i, got[i], want[i])
 		}
+	}
+}
+
+// The same question asked twice: the cache holds the whole prompt, and
+// what is left to prefill must still be a token, since its logits are
+// the answer. It used to be nothing, and the slice ran off the front.
+func TestCachedWholePromptStillFeedsALastToken(t *testing.T) {
+	ids := []int{1, 2, 3, 4}
+	var c promptCache
+	c.enabled = true
+	c.live = append(c.live, ids...)
+
+	start, restore := c.plan(ids)
+	if restore || start != len(ids)-1 {
+		t.Fatalf("plan(identical) = %d, restore %v; want %d, the last token re-fed",
+			start, restore, len(ids)-1)
+	}
+	// The checkpoint step runs after the plan and used to push start to
+	// the end of the prompt on its own.
+	if mark := commonPrefix(c.live, ids); mark > 0 && mark < len(ids) {
+		start = mark
+	}
+	if start >= len(ids) {
+		t.Fatalf("start %d leaves nothing of a %d-token prompt to prefill", start, len(ids))
+	}
+	// A prompt that merely extends the cached one keeps its whole tail.
+	longer := []int{1, 2, 3, 4, 5}
+	if start, _ := c.plan(longer); start != len(ids) {
+		t.Errorf("plan(extended) = %d, want %d", start, len(ids))
 	}
 }

--- a/internal/llm/serve.go
+++ b/internal/llm/serve.go
@@ -1080,7 +1080,11 @@ func (s *server) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Where two prompts part company is worth a checkpoint: the next one
 	// to share this opening starts from there instead of from nothing.
 	// The KV rows need no copy; only a recurrent state does.
-	if mark := commonPrefix(s.cache.live, ids); s.cache.enabled && start == 0 && mark > 0 && mark > len(s.cache.ckpt) {
+	// The last token always stays to be fed: its logits are the answer,
+	// and a prompt the cache already holds whole -- the same question
+	// asked twice -- would otherwise leave nothing to prefill at all.
+	if mark := commonPrefix(s.cache.live, ids); s.cache.enabled && start == 0 &&
+		mark > 0 && mark < len(ids) && mark > len(s.cache.ckpt) {
 		s.prefill(ids[:mark], 0)
 		s.cache.ckpt = append(s.cache.ckpt[:0], ids[:mark]...)
 		if s.cache.hasDelta {


### PR DESCRIPTION
Asking the same question twice killed the request: the checkpoint step took the cache forward to where the prompt stopped matching, which for an identical prompt is its end, leaving nothing to prefill and a slice that ran off the front. The checkpoint now stops one short, and a repeated prompt rolls one row back and recomputes that token, so a retry prefills one token instead of twenty-one. Recurrent layers cannot roll a row back and still start over.