### PR TITLE
Say when a turn spent its budget without answering

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -624,6 +624,14 @@ func (e *Engine) toolRounds(w io.Writer, msgs []chatMessage, n int) ([]chatMessa
 		if visible != "" {
 			fmt.Fprintln(w, visible)
 		}
+		// A turn that spent its whole budget without saying anything
+		// leaves an empty screen, which reads as a broken model rather
+		// than as a limit that was reached: a thinking model can fill
+		// the default budget with thought alone, and the round after a
+		// tool result is the one where it does.
+		if visible == "" && len(calls) == 0 && finish == "length" {
+			fmt.Fprintf(e.opts.Log, "(nothing to show: the turn reached the %d-token limit before it answered; raise -n)\n", n)
+		}
 		msgs = append(msgs, chatMessage{Role: "assistant", Content: content, ToolCalls: calls})
 		if len(calls) == 0 || round == maxToolRounds {
 			total.Content = strings.TrimSpace(content)


### PR DESCRIPTION
A thinking model given a tool result often fills the whole token budget with thought, and the round right after the tool call is where it does. The visible text is then empty and the run ends without a word, which reads as a broken model rather than as a limit that was reached. This prints one line when a round ends with no visible text, no tool call and a length finish, naming the limit and the flag that raises it. Gemma 4 E2B asked about a wikipedia result needs about 315 tokens to answer: at -n 30 and at -n 250 it says nothing at all, at -n 900 it answers.