### PR TITLE
Have bench name the weight layout it measured

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -381,13 +381,16 @@ func benchCmd(o *llm.Options, p, n, reps int) {
 	} else {
 		fmt.Printf("gpu build: %s\n", tag)
 	}
+	// Each side names the layout it measured: the two sides do not always
+	// run the same one, and a cache an earlier run wrote can change which
+	// one the next run gets, which is invisible in the numbers alone.
 	row := func(name string, r benchResult) {
-		fmt.Printf("%-8s %9.1f %-14s %8.1f %s\n", name,
+		fmt.Printf("%-8s %9.1f %-14s %8.1f %-10s %s\n", name,
 			median(r.Prefill), spread(r.Prefill),
-			median(r.Decode), spread(r.Decode))
+			median(r.Decode), spread(r.Decode), r.Layout)
 	}
 	fmt.Printf("\nmedian of %d runs after one warm-up, tokens/sec\n\n", reps)
-	fmt.Printf("%-8s %9s %-14s %8s\n", "", "prefill", "", "decode")
+	fmt.Printf("%-8s %9s %-14s %8s %-10s %s\n", "", "prefill", "", "decode", "", "weights")
 	row("cpu", cpu)
 	if gpuErr != nil {
 		fmt.Printf("%-8s unavailable: %v\n", "gpu", gpuErr)
@@ -410,6 +413,7 @@ type benchResult struct {
 	Prefill []float64 // one sample per repetition
 	Decode  []float64
 	Adapter string `json:",omitempty"`
+	Layout  string `json:",omitempty"`
 	Err     string `json:",omitempty"`
 }
 
@@ -449,6 +453,7 @@ func benchChild(side string) {
 	} else {
 		defer e.Close()
 		r.Adapter = e.GPUName()
+		r.Layout = e.WeightLayout()
 		// The model stays loaded across repetitions and the first pass is
 		// discarded, so the samples describe steady state rather than a
 		// cold cache and a ramping clock — the same thing llama-bench

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -395,6 +395,23 @@ func (e *Engine) Reset() {
 // GPUName reports the adapter the engine is running on, empty when
 // decoding on the CPU. Backend names the binding generation the binary
 // was built with.
+// WeightLayout names the quantized form the decode kernels ran on. The
+// same flags reach different layouts — the gpu path requantizes where
+// the cpu path repacks a gguf's own blocks, and a requantized cache an
+// earlier run left behind is preferred once it exists — so anything
+// reporting a speed should report this beside it.
+func (e *Engine) WeightLayout() string {
+	if e.model == nil {
+		return ""
+	}
+	if e.model.layout != "" {
+		return e.model.layout
+	}
+	// A safetensors checkpoint has no stored blocks to repack: its
+	// weights quantize from float32, which is the requantized form.
+	return layoutName(e.opts.Bits, false)
+}
+
 func (e *Engine) GPUName() string {
 	if e.g == nil {
 		return ""

--- a/internal/llm/gguf.go
+++ b/internal/llm/gguf.go
@@ -818,6 +818,21 @@ func blockShape(b *qblock, cfg config, i int) {
 // grouped-int8 matrices — no dequantize/requantize round trip, and finer
 // (32-row) scales than the float path would produce. The GPU path has no
 // grouped kernel yet, so -gpu passes direct=false.
+// layoutName spells the quantized form a load produced. A gguf's own
+// blocks repack straight into the grouped layout, while the requantized
+// form goes through float32 for per-column scales; the two decode at
+// different speeds, and which one a run gets depends on the gpu flag and
+// on whether an earlier run left a requantized cache behind.
+func layoutName(bits int, direct bool) string {
+	if bits == 0 {
+		return "float32"
+	}
+	if direct {
+		return fmt.Sprintf("int%d, gguf blocks repacked", bits)
+	}
+	return fmt.Sprintf("int%d, requantized", bits)
+}
+
 func loadGGUF(path string, bits int, direct, cache bool, vlog io.Writer) (*qwen, *tokenizer.Tokenizer, error) {
 	g, err := gguf.Open(path)
 	if err != nil {
@@ -1354,6 +1369,7 @@ func loadGGUF(path string, bits int, direct, cache bool, vlog io.Writer) (*qwen,
 		fastPath := cachePath(path, bits, false)
 		if m, err := loadWeightCache(fastPath, path, bits, false, cfg, headSz); err == nil {
 			fmt.Fprintf(os.Stderr, "using faster requantized cache: %s\n", fastPath)
+			m.layout = layoutName(bits, false)
 			return m, tok, nil
 		}
 	}
@@ -1361,6 +1377,7 @@ func loadGGUF(path string, bits int, direct, cache bool, vlog io.Writer) (*qwen,
 	if useCache {
 		if m, err := loadWeightCache(cpath, path, bits, direct, cfg, headSz); err == nil {
 			fmt.Fprintln(vlog, "weights mapped from the repack cache")
+			m.layout = layoutName(bits, direct)
 			return m, tok, nil
 		} else if !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "repack cache unusable (%v); repacking\n", err)
@@ -1373,7 +1390,7 @@ func loadGGUF(path string, bits int, direct, cache bool, vlog io.Writer) (*qwen,
 	fmt.Fprintf(vlog, "%s into int%d weights, %d layers over %d workers\n",
 		how, bits, cfg.Layers, min(runtime.NumCPU(), 8))
 	repackStart := time.Now()
-	m := &qwen{cfg: cfg, headSz: headSz}
+	m := &qwen{cfg: cfg, headSz: headSz, layout: layoutName(bits, direct)}
 	m.embed = tensor("token_embd.weight")
 	var ropeFF []float32
 	if arch == "gemma4" {

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -219,6 +219,10 @@ type expertFFN struct {
 type qwen struct {
 	cfg    config
 	headSz int
+	// layout names the quantized form the decode kernels run on, for
+	// anything that reports a measurement: the same flags reach
+	// different layouts, so a number without one cannot be compared.
+	layout string
 	embed  *tensai.Tensor // [vocab, hidden]
 	lmT    *tensai.Matrix // [hidden, vocab]
 	qLmT   *qmat


### PR DESCRIPTION
The same flags do not always reach the same weights: the gpu path requantizes through float32 where the cpu path repacks a gguf's own blocks, and once a run has written a requantized cache, later -q8 runs prefer it. So bench's two rows can measure two different layouts, and the same command can measure a different one tomorrow than it did today, with nothing in the output saying so. This records the layout a load produced and prints it beside each row: on a machine with a requantized cache both rows read "int8, requantized", on a fresh one the cpu row reads "int8, gguf blocks repacked" while the gpu row still requantizes.