### PR TITLE
Drop the column-sum stream from the grouped int8 matvec

### DIFF
--- a/quant/quant8g.go
+++ b/quant/quant8g.go
@@ -28,7 +28,9 @@ type Q8GMatrix struct {
 
 // NewQ8GMatrix allocates the layout for rows x cols with `group` input
 // rows per scale (0 for the default 32); the caller fills Q (quad
-// layout), Scale, and ColSum64 — see the loaders in internal/llm.
+// layout), Scale, and ColSum64 — see the loaders in internal/llm. AVX2
+// decode computes with signed activations directly and does not read
+// ColSum64; the table remains the portable fallback's correction term.
 func NewQ8GMatrix(rows, cols, group int) *Q8GMatrix {
 	if group == 0 {
 		group = q8Group

--- a/quant/quant8g_simd.go
+++ b/quant/quant8g_simd.go
@@ -24,6 +24,7 @@ func q8gMatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, s
 	quads := len(xu) / 4
 	groups := (len(xu) + group - 1) / group
 	ones := archsimd.BroadcastInt16x16(1)
+	offset := archsimd.BroadcastInt8x32(64)
 	vecEnd := lo + ((hi - lo) &^ 31)
 	if vecEnd > lo {
 		clear(out[lo:vecEnd])
@@ -32,7 +33,6 @@ func q8gMatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, s
 		for jt := lo; jt < vecEnd; jt += 32 {
 			tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
 			stab := scale[(jt/q4Tile)*groups*q4Tile:]
-			ctab := colSum64[(jt/q4Tile)*groups*q4Tile:]
 			d0 := out[jt : jt+8 : jt+8]
 			d1 := out[jt+8 : jt+16 : jt+16]
 			d2 := out[jt+16 : jt+24 : jt+24]
@@ -42,22 +42,31 @@ func q8gMatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, s
 				ie := min(ib+group/4, quads)
 				var a0, a1, a2, a3 archsimd.Int32x8
 				for i4 := ib; i4 < ie; i4++ {
-					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsUint8x32()
+					// VPMADDUBSW only accepts unsigned*signed bytes.  Keep the
+					// activation signed by taking the absolute value of each
+					// weight and applying its sign to the broadcast activation.
+					// This costs two cheap integer operations per weight vector,
+					// but removes the 4-byte column-sum stream from every 32-byte
+					// Q8_0 group -- decode is bandwidth-bound on real models.
+					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsInt8x32().Sub(offset)
 					row := tile[i4*4*q4Tile:]
-					a0 = a0.Add(xp.DotProductPairsSaturated(simd.LoadI8x32(row)).DotProductPairs(ones))
-					a1 = a1.Add(xp.DotProductPairsSaturated(simd.LoadI8x32(row[32:])).DotProductPairs(ones))
-					a2 = a2.Add(xp.DotProductPairsSaturated(simd.LoadI8x32(row[64:])).DotProductPairs(ones))
-					a3 = a3.Add(xp.DotProductPairsSaturated(simd.LoadI8x32(row[96:])).DotProductPairs(ones))
+					w := simd.LoadI8x32(row)
+					a0 = a0.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					w = simd.LoadI8x32(row[32:])
+					a1 = a1.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					w = simd.LoadI8x32(row[64:])
+					a2 = a2.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					w = simd.LoadI8x32(row[96:])
+					a3 = a3.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
 				}
 				sg := stab[g*q4Tile:]
-				cg := ctab[g*q4Tile:]
-				f := a0.Sub(simd.LoadI32x8(cg)).ConvertToFloat32().Mul(simd.LoadF32x8(sg))
+				f := a0.ConvertToFloat32().Mul(simd.LoadF32x8(sg))
 				simd.StoreF32x8(simd.LoadF32x8(d0).Add(f), d0)
-				f = a1.Sub(simd.LoadI32x8(cg[8:])).ConvertToFloat32().Mul(simd.LoadF32x8(sg[8:]))
+				f = a1.ConvertToFloat32().Mul(simd.LoadF32x8(sg[8:]))
 				simd.StoreF32x8(simd.LoadF32x8(d1).Add(f), d1)
-				f = a2.Sub(simd.LoadI32x8(cg[16:])).ConvertToFloat32().Mul(simd.LoadF32x8(sg[16:]))
+				f = a2.ConvertToFloat32().Mul(simd.LoadF32x8(sg[16:]))
 				simd.StoreF32x8(simd.LoadF32x8(d2).Add(f), d2)
-				f = a3.Sub(simd.LoadI32x8(cg[24:])).ConvertToFloat32().Mul(simd.LoadF32x8(sg[24:]))
+				f = a3.ConvertToFloat32().Mul(simd.LoadF32x8(sg[24:]))
 				simd.StoreF32x8(simd.LoadF32x8(d3).Add(f), d3)
 			}
 		}

--- a/quant/vocab_bench_test.go
+++ b/quant/vocab_bench_test.go
@@ -46,6 +46,31 @@ func BenchmarkQ8GateUpProjection(b *testing.B) { benchmarkQ8Shape(b, 896, 9728) 
 func BenchmarkQ8DownProjection(b *testing.B)   { benchmarkQ8Shape(b, 4864, 896) }
 func BenchmarkQ8VocabProjection(b *testing.B)  { benchmarkQ8Shape(b, 896, 151936) }
 
+func benchmarkQ8GShape(b *testing.B, rows, cols int) {
+	q := NewQ8GMatrix(rows, cols, 0)
+	for i := range q.Q {
+		q.Q[i] = int8(i%127 - 63)
+	}
+	for i := range q.Scale {
+		q.Scale[i] = 1.0 / 127
+	}
+	x := make([]tensai.Float, rows)
+	for i := range x {
+		x[i] = tensai.Float(i%31-15) / 16
+	}
+	out := make([]tensai.Float, cols)
+	b.SetBytes(int64(rows * cols))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := q.MatVec(x, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkQ8GGateUpProjection(b *testing.B) { benchmarkQ8GShape(b, 896, 9728) }
+func BenchmarkQ8GVocabProjection(b *testing.B)  { benchmarkQ8GShape(b, 896, 151936) }
+
 // Cold cycles through one down projection per transformer layer, matching
 // decode where the next matrix displaces the previous one from shared cache.
 func BenchmarkQ8DownProjectionCold(b *testing.B) {


### PR DESCRIPTION
VPMADDUBSW multiplies unsigned bytes by signed ones, so the kernel held the activations as unsigned with a +64 bias and paid for the bias at the end by subtracting a per-column, per-group sum of the weights. That correction table is four bytes per thirty-two weights, an eighth of the weight stream, on a decode bound by exactly that stream.

Taking the activations back to signed, handing the multiply the absolute value of each weight and moving the weight's sign onto the activation gives |w| * (x * sign w) = w * x, the same integer as before, so the correction disappears rather than moving. Nothing saturates: weights reach 128 in absolute value, activations stay within +-64, and two products fit an int16 with room over. The column sums stay as the portable fallback's term.

Greedy output is byte-identical on Q8_0 and on Q4_K read through -q8. Decode on the direct repack path gains about a tenth: Qwen2.5-0.5B Q8_0 48.4 -> 53.2 tok/s over six alternating rounds, all six to the new kernel, and Qwen3-0.6B Q4_K_M 36.4 -> 39.8 over three. The vocabulary projection alone, which streams 137MB, goes 4533 -> 4158us. Shapes small enough to sit in L3 pay the two extra integer operations instead, with the gate-up projection about 3% slower. The requantized layout carries no column sums and is untouched.