### PR TITLE
Run decode attention's softmax the way prefill does

### DIFF
--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -49,3 +49,10 @@ func Axpy(a float32, x, y []float32) { axpyGeneric(a, x, y) }
 func DotVecs(qs, k []float32, out []float32) { dotVecsGeneric(qs, k, out) }
 
 func Axpys(ws []float32, v, outs []float32) { axpysGeneric(ws, v, outs) }
+
+// AxpyRows accumulates out += sum over i of ws[i] * rows[i][off:off+d].
+func AxpyRows(out, ws []float32, rows [][]float32, off int) {
+	for i, w := range ws {
+		axpyGeneric(w, rows[i][off:off+len(out)], out)
+	}
+}

--- a/internal/kernels/dispatch_simd.go
+++ b/internal/kernels/dispatch_simd.go
@@ -1062,3 +1062,68 @@ func axpy8(ws []float32, v, outs []float32) {
 		o7[i] += ws[7] * v[i]
 	}
 }
+
+// AxpyRows accumulates out += sum over i of ws[i] * rows[i][off:off+d],
+// the value half of one attention head at decode. Called per position
+// instead, an Axpy over a 64-wide head is eight vector instructions
+// wrapped in a call and a VZEROUPPER, and the output row makes a round
+// trip to memory for every position; a context of a few hundred turns
+// that overhead into the cost of attention. Here the output block stays
+// in registers across every row, and the upper bits clear once.
+//
+// The rows accumulate in the order given, product by product, the same
+// order and the same fused multiply-add a per-position Axpy runs, so the
+// result matches it bit for bit.
+func AxpyRows(out, ws []float32, rows [][]float32, off int) {
+	d := len(out)
+	if !simd.HasAVX2 || d < 8 {
+		for i, w := range ws {
+			axpyGeneric(w, rows[i][off:off+d], out)
+		}
+		return
+	}
+	n := d &^ 7
+	// Eight accumulators is the register file's limit, and naming them
+	// keeps them there: an array indexed by the loop variable spills.
+	for b := 0; b+64 <= n; b += 64 {
+		o := out[b:]
+		a0, a1, a2, a3 := simd.LoadF32x8(o), simd.LoadF32x8(o[8:]), simd.LoadF32x8(o[16:]), simd.LoadF32x8(o[24:])
+		a4, a5, a6, a7 := simd.LoadF32x8(o[32:]), simd.LoadF32x8(o[40:]), simd.LoadF32x8(o[48:]), simd.LoadF32x8(o[56:])
+		for i, w := range ws {
+			av := archsimd.BroadcastFloat32x8(w)
+			r := rows[i][off+b:]
+			a0 = simd.LoadF32x8(r).MulAdd(av, a0)
+			a1 = simd.LoadF32x8(r[8:]).MulAdd(av, a1)
+			a2 = simd.LoadF32x8(r[16:]).MulAdd(av, a2)
+			a3 = simd.LoadF32x8(r[24:]).MulAdd(av, a3)
+			a4 = simd.LoadF32x8(r[32:]).MulAdd(av, a4)
+			a5 = simd.LoadF32x8(r[40:]).MulAdd(av, a5)
+			a6 = simd.LoadF32x8(r[48:]).MulAdd(av, a6)
+			a7 = simd.LoadF32x8(r[56:]).MulAdd(av, a7)
+		}
+		simd.StoreF32x8(a0, o)
+		simd.StoreF32x8(a1, o[8:])
+		simd.StoreF32x8(a2, o[16:])
+		simd.StoreF32x8(a3, o[24:])
+		simd.StoreF32x8(a4, o[32:])
+		simd.StoreF32x8(a5, o[40:])
+		simd.StoreF32x8(a6, o[48:])
+		simd.StoreF32x8(a7, o[56:])
+	}
+	// A head that is not a multiple of 64 finishes eight lanes at a time.
+	for b := n &^ 63; b < n; b += 8 {
+		o := out[b:]
+		acc := simd.LoadF32x8(o)
+		for i, w := range ws {
+			acc = simd.LoadF32x8(rows[i][off+b:]).MulAdd(archsimd.BroadcastFloat32x8(w), acc)
+		}
+		simd.StoreF32x8(acc, o)
+	}
+	archsimd.ClearAVXUpperBits()
+	for i, w := range ws {
+		r := rows[i][off:]
+		for k := n; k < d; k++ {
+			out[k] += w * r[k]
+		}
+	}
+}

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -889,13 +889,22 @@ func mmb(x, w *tensai.Matrix, q *qmat, bias []float32) *tensai.Matrix {
 }
 
 // attendHead runs one head of cached-KV attention: SIMD dot-product
-// scores over the cache, a float64 softmax, and SIMD weighted value
-// accumulation into attn's slot for the head. Heads touch disjoint
-// output ranges, so callers fan heads out across goroutines freely —
-// which is why decode uses it: at short and medium contexts the KV
-// rows sit in L3 anyway, so attendGroup's shared streaming buys
-// nothing there while head-level fan-out keeps every core busy.
-func (m *qwen) attendHead(b *qblock, q, attn []float32, h, group, steps int, scores []float64) {
+// scores over the cache, a float32 softmax on the vector kernel, and
+// SIMD weighted value accumulation into attn's slot for the head. Heads
+// touch disjoint output ranges, so callers fan heads out across
+// goroutines freely -- which is why decode uses it: at short and medium
+// contexts the KV rows sit in L3 anyway, so attendGroup's shared
+// streaming buys nothing there while head-level fan-out keeps every core
+// busy.
+//
+// The softmax runs the same way attendGroup's does: scores land in a
+// contiguous float32 row so the exponentials go through the vector
+// kernel, and the normalization is one reciprocal rather than a divide
+// per position. A scalar float64 exp per position costs about as much as
+// the head's whole share of the dot products, which at decode's one row
+// per token made the scalar tail, not the cache stream, the cost of
+// attention.
+func (m *qwen) attendHead(b *qblock, q, attn []float32, h, group, steps int, scores []float32) {
 	// Sliding-window layers (Gemma) see only the last window positions.
 	start := 0
 	if b.window > 0 && steps > b.window {
@@ -904,33 +913,35 @@ func (m *qwen) attendHead(b *qblock, q, attn []float32, h, group, steps int, sco
 	d := m.headSize(b)
 	qOff := h * d
 	kvOff := (h / group) * d
-	scale := m.qkScale(b, d)
+	scale := float32(m.qkScale(b, d))
 	qh := q[qOff : qOff+d]
-	maxs := math.Inf(-1)
+	si := scores[:steps-start]
+	maxs := float32(math.Inf(-1))
 	for t := start; t < steps; t++ {
-		s := float64(tensai.DotVec(qh, b.kc[t][kvOff:kvOff+d])) * scale
-		scores[t] = s
+		s := tensai.DotVec(qh, b.kc[t][kvOff:kvOff+d]) * scale
+		si[t-start] = s
 		if s > maxs {
 			maxs = s
 		}
 	}
-	if b.sinks != nil && float64(b.sinks[h]) > maxs {
-		maxs = float64(b.sinks[h])
+	if b.sinks != nil && b.sinks[h] > maxs {
+		maxs = b.sinks[h]
 	}
-	var sum float64
-	for t := start; t < steps; t++ {
-		scores[t] = math.Exp(scores[t] - maxs)
-		sum += scores[t]
+	kernels.ExpShift(si, si, maxs)
+	var sum float32
+	for _, v := range si {
+		sum += v
 	}
 	if b.sinks != nil {
 		// The sink is an extra softmax slot with no value: it only
 		// absorbs probability mass.
-		sum += math.Exp(float64(b.sinks[h]) - maxs)
+		sum += kernels.ExpF(b.sinks[h] - maxs)
 	}
-	out := attn[qOff : qOff+d]
-	for t := start; t < steps; t++ {
-		tensai.Axpy(float32(scores[t]/sum), b.vc[t][kvOff:kvOff+d], out)
+	inv := 1 / sum
+	for i := range si {
+		si[i] *= inv
 	}
+	kernels.AxpyRows(attn[qOff:qOff+d], si, b.vc[start:steps], kvOff)
 }
 
 // attendGroup runs one KV head's worth of cached-KV attention — the
@@ -1528,6 +1539,9 @@ func (m *qwen) step(token, pos int) []float32 {
 	for li := range m.blocks {
 		maxKV = max(maxKV, m.kvHeadCount(&m.blocks[li]))
 	}
+	// Attention scores for this token: one contiguous row per head,
+	// sized on first use and reused by every block below.
+	var headScores []float32
 	maxQ := cfg.Heads * maxHead
 	qkv := make([]float32, maxQ+2*maxKV*maxHead+cfg.Heads*maxHead)
 	attn := make([]float32, maxQ)
@@ -1615,17 +1629,21 @@ func (m *qwen) step(token, pos int) []float32 {
 		steps := len(b.kc)
 		// Short contexts run the heads serially; past that the dispatch
 		// cost disappears into the O(steps*headSz) work per head.
+		// One score row per head, grown once per token: a fresh buffer
+		// per worker per layer was an allocation for every head of every
+		// block, and the rows are disjoint so the heads stay independent.
+		if len(headScores) < cfg.Heads*steps {
+			headScores = make([]float32, cfg.Heads*steps)
+		}
 		if runtime.NumCPU() > 1 && cfg.Heads > 1 && steps >= 64 {
 			workpool.Run(cfg.Heads, 1, func(lo, hi int) {
-				scores := make([]float64, steps)
 				for h := lo; h < hi; h++ {
-					m.attendHead(b, q, att, h, group, steps, scores)
+					m.attendHead(b, q, att, h, group, steps, headScores[h*steps:(h+1)*steps])
 				}
 			})
 		} else {
-			scores := make([]float64, steps)
 			for h := 0; h < cfg.Heads; h++ {
-				m.attendHead(b, q, att, h, group, steps, scores)
+				m.attendHead(b, q, att, h, group, steps, headScores[h*steps:(h+1)*steps])
 			}
 		}
 		if cfg.AttnOutputGate {


### PR DESCRIPTION
Timing a decode token by phase put attention at 2.78ms of 17.1ms on a 0.5B at a 326-token context, while it moves only 8MB of KV cache: the matvecs were streaming at 34.5 GB/s and attention was scalar tail, not bandwidth. Both costs were already solved on the prefill side by attendGroup.

The softmax ran in float64, an exp and a divide per position, 110k of each per token. It now gathers into the contiguous float32 row the vector kernel takes, exponentiates with ExpShift and normalizes with one reciprocal. The value accumulation called Axpy per position, eight vector instructions wrapped in a call and a VZEROUPPER with the output row making a round trip to memory each time; AxpyRows keeps the output block in registers across every row and clears the upper bits once, accumulating in the same order with the same fused multiply-add. The score buffer also moved out of the worker, where it was 384 allocations a token.

Attention goes 2.78 to 2.01 ms/token and decode 51.7 to 54.4 tok/s over five alternating rounds, four of five to the new path. Against llama.cpp in the same window that moves cpu decode from about 88% to 94%.

The float64 softmax is gone, so greedy output can differ from before where a score margin was thinner than float32. Prefill has computed it this way since #142, so the two halves now agree rather than differ.

Batching the score side the same way does not work: a DotRows over the cache rows measured 2.8 to 3.6 ms/token, worse than the per-position DotVec, so the dot products stay as they are.