### PR TITLE
Tune decode worker pool for bandwidth-bound matvecs

### DIFF
--- a/internal/workpool/pool.go
+++ b/internal/workpool/pool.go
@@ -42,12 +42,20 @@ var (
 // spinFor is how long a worker spins on PAUSE waiting for the next
 // region before parking. Regions inside one token are microseconds
 // apart; sampling between tokens is longer and should park. Swept over
-// 5us-2ms: shorter loses regions to parking mid-token, longer burns the
-// hyperthread siblings through the serial stretches for nothing.
-const spinFor = 20 * time.Microsecond
+// 5us-2ms: shorter loses regions to parking mid-token, while millisecond
+// windows begin burning through the serial stretches for no further gain.
+// Re-sweeping on the full Qwen decode path put the knee at about 100us.
+const spinFor = 100 * time.Microsecond
 
 func setup() {
 	workers = runtime.GOMAXPROCS(0)
+	// Decode matvecs stream weights from memory. Beyond eight workers the
+	// extra SMT siblings contend for the same cores and memory channels;
+	// on the 8C/16T Zen 3 reference machine they reduce end-to-end decode
+	// by about 8%. This also matches the cap used by the dense CPU kernels.
+	if workers > 8 {
+		workers = 8
+	}
 	if workers < 2 {
 		workers = 0
 		return


### PR DESCRIPTION
Spin for 100us instead of 20 before parking, and cap the pool at eight workers.

Measured against 108aa77 on Qwen2.5-0.5B Q8_0, five alternating rounds, all five to the new setting: cpu decode 53.0 -> 56.8 tok/s (+7%). Prefill is unchanged at 387-396 against 394-408, as it should be: the prompt path fans out through parallelChunks and never touches this pool. Against llama.cpp in the same window this takes cpu decode from about 94% to 99%.

The worker count was swept in August and found not to matter. It matters now because the surrounding code changed: the decode attention rewrite and the bounds-check work altered both the serial stretches and the work per region, which is the case for re-testing a rejected knob rather than trusting the old answer.

One cost to note: the pool also serves gguf dequantization and gpu weight upload, so the cap slows those too. A 0.5B -nocache load goes 1.05 -> 1.13-1.24s, about 10%, and that should scale with model size. Scoping the cap to the decode path would keep the gain without it.