### PR TITLE
Keep bulk work off the decode pool

### DIFF
--- a/encoding/gguf/gguf.go
+++ b/encoding/gguf/gguf.go
@@ -600,7 +600,7 @@ func (f *File) TensorRows(name string, from, to int) (*tensai.Tensor, error) {
 	// workers a decode step already keeps resident.
 	if blocks := n / spec.values; blocks >= 64 && len(dst) >= parallelDequantMin {
 		var ferr atomic.Pointer[error]
-		workpool.Run(int(blocks), 1, func(lo, hi int) {
+		workpool.Bulk(int(blocks), 1, func(lo, hi int) {
 			w := int64(hi-lo) * spec.values
 			if err := dequantBlocks(t.typ, name, dst[int64(lo)*spec.values:int64(hi)*spec.values],
 				raw[int64(lo)*spec.bytes:int64(hi)*spec.bytes], w); err != nil {

--- a/gpu/wgputensor.go
+++ b/gpu/wgputensor.go
@@ -4688,7 +4688,7 @@ func (g *Device) UploadQ8(q *quant.QMatrix) (*QMatrix, error) {
 	// One row per stretch of packed words, so the walk splits across
 	// workers the way the int4 one does.
 	packed := make([]uint32, q.Rows*words)
-	workpool.Run(q.Rows, 1, func(lo, hi int) {
+	workpool.Bulk(q.Rows, 1, func(lo, hi int) {
 		for i := lo; i < hi; i++ {
 			for j := 0; j < q.Cols; j++ {
 				b := uint32(uint8(q.Q[q.Index(i, j)]))
@@ -5676,7 +5676,7 @@ func (g *Device) UploadQ4(q *quant.Q4Matrix) (*Q4Matrix, error) {
 	// across workers cleanly. It is a billion iterations on a small model
 	// and was most of what -gpu spent getting started.
 	packed := make([]uint32, pairs*words)
-	workpool.Run(pairs, 1, func(lo, hi int) {
+	workpool.Bulk(pairs, 1, func(lo, hi int) {
 		for i2 := lo; i2 < hi; i2++ {
 			for j := 0; j < q.Cols; j++ {
 				b := nib(2*i2, j) | nib(2*i2+1, j)<<4
@@ -5686,7 +5686,7 @@ func (g *Device) UploadQ4(q *quant.Q4Matrix) (*Q4Matrix, error) {
 	})
 	groups := (q.Rows + 63) / 64 // q4Group
 	scales := make([]float32, groups*words*4)
-	workpool.Run(groups, 1, func(lo, hi int) {
+	workpool.Bulk(groups, 1, func(lo, hi int) {
 		for gi := lo; gi < hi; gi++ {
 			for j := 0; j < q.Cols; j++ {
 				scales[gi*words*4+j] = q.Scale[q.TableIndex(gi, j)]

--- a/internal/workpool/pool.go
+++ b/internal/workpool/pool.go
@@ -47,14 +47,20 @@ var (
 // Re-sweeping on the full Qwen decode path put the knee at about 100us.
 const spinFor = 100 * time.Microsecond
 
+// maxWorkers caps the resident pool. Decode matvecs stream weights from
+// memory, and beyond eight workers the extra SMT siblings contend for the
+// same cores and memory channels: on the 8C/16T reference machine the
+// full complement costs about 7% of end-to-end decode. The cost is the
+// spinning as much as the work, so the cap is on the residents rather
+// than on the chunks a call hands out -- which is why bulk work that
+// wants every core, like a repack or a weight upload, goes through Bulk
+// instead of borrowing this pool.
+const maxWorkers = 8
+
 func setup() {
 	workers = runtime.GOMAXPROCS(0)
-	// Decode matvecs stream weights from memory. Beyond eight workers the
-	// extra SMT siblings contend for the same cores and memory channels;
-	// on the 8C/16T Zen 3 reference machine they reduce end-to-end decode
-	// by about 8%. This also matches the cap used by the dense CPU kernels.
-	if workers > 8 {
-		workers = 8
+	if workers > maxWorkers {
+		workers = maxWorkers
 	}
 	if workers < 2 {
 		workers = 0
@@ -159,4 +165,34 @@ func Run(n, align int, body func(lo, hi int)) {
 		}
 	}
 	busy.Store(false)
+}
+
+// Bulk splits [0, n) into align-rounded chunks across GOMAXPROCS fresh
+// goroutines, the caller taking the first chunk. It is the counterpart
+// to Run for work that happens once rather than a hundred times per
+// token: a repack, a dequantization, a weight upload. There the goroutine
+// wake this package exists to avoid is noise against the work itself, and
+// what matters instead is using every core -- including the ones the
+// decode pool deliberately leaves alone.
+func Bulk(n, align int, body func(lo, hi int)) {
+	parts := runtime.GOMAXPROCS(0)
+	if parts < 2 || n <= align {
+		body(0, n)
+		return
+	}
+	chunk := ((n+parts-1)/parts + align - 1) &^ (align - 1)
+	if chunk <= 0 {
+		chunk = align
+	}
+	var wg sync.WaitGroup
+	for lo := chunk; lo < n; lo += chunk {
+		hi := min(lo+chunk, n)
+		wg.Add(1)
+		go func(lo, hi int) {
+			defer wg.Done()
+			body(lo, hi)
+		}(lo, hi)
+	}
+	body(0, min(chunk, n))
+	wg.Wait()
 }


### PR DESCRIPTION
Capping the resident pool at eight workers bought decode about 7%, but the pool also carried work that runs once per model rather than a hundred times per token: gguf dequantization on load, and the weight packing a gpu run uploads. Those want every core, and the cap took a fifth of them away, so a 4B repack went 16.3 to 18.1 seconds.

Bulk fans that work out over GOMAXPROCS fresh goroutines instead. The goroutine wake this package exists to avoid is real at ~200us a region, a hundred regions a token; against a repack it is noise. The cap stays where it was measured, on the residents rather than on the chunks a call hands out, because during decode the extra workers cost spinning as much as work.

4B repack 18.1 -> 15.6s, and decode is unchanged at 55.4 against 55.0 tok/s over five alternating rounds.