### PR TITLE
Vectorize the decode kernels on arm64

### DIFF
--- a/cmd/tensai/main.go
+++ b/cmd/tensai/main.go
@@ -365,10 +365,13 @@ func benchCmd(o *llm.Options, p, n, reps int) {
 	// A binary built without GOEXPERIMENT=simd runs the portable kernels
 	// and measures an order of magnitude slower, which is easy to mistake
 	// for a slow machine.
-	if simd.HasAVX2 {
+	switch {
+	case simd.HasAVX2:
 		fmt.Println("cpu: AVX2 kernels")
-	} else {
-		fmt.Println("cpu: portable kernels (rebuild with GOEXPERIMENT=simd on amd64 for AVX2)")
+	case simd.HasNEON:
+		fmt.Println("cpu: NEON kernels")
+	default:
+		fmt.Println("cpu: portable kernels (rebuild with GOEXPERIMENT=simd on amd64 or arm64 to vectorize)")
 	}
 	// The two binding generations reach different adapters and differ in
 	// speed on the same one, so the table names which build measured.

--- a/dot_generic.go
+++ b/dot_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package tensai
 

--- a/dot_neon.go
+++ b/dot_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package tensai
 

--- a/dot_neon.go
+++ b/dot_neon.go
@@ -1,12 +1,13 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build goexperiment.simd && arm64
 
 package tensai
 
 import "runtime"
 
-// dotRows computes rows lo..hi of out = a * b. This is the portable
-// fallback; build with GOEXPERIMENT=simd on amd64 to get the AVX2 kernel in
-// dot_simd.go.
+// The dense float matmuls keep the portable bodies on arm64. They are the
+// training path; the decode kernels that carry a chat are in quant and
+// internal/kernels, which do have NEON here.
+
 func dotRows(out, a, b *Matrix, lo, hi int) {
 	dotRowsGeneric(out, a, b, lo, hi)
 }
@@ -25,11 +26,6 @@ func dotWorkerCount(rows, inner, cols int) int {
 	return workers
 }
 
-// dotTARows computes out rows lo..hi of out = a^T * b. Portable fallback;
-// see dot_simd.go for the AVX2 kernel.
-// dotTATall is the portable stand-in for the register-accumulating kernel
-// in dot_simd.go; without vectors there is nothing to gain, so it is the
-// general one.
 func dotTATall(out, a, b *Matrix, lo, hi int) {
 	dotTARowsGeneric(out, a, b, lo, hi)
 }

--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package kernels
 

--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || !amd64
+//go:build !goexperiment.simd || (!amd64 && !arm64)
 
 package kernels
 

--- a/internal/kernels/dispatch_neon.go
+++ b/internal/kernels/dispatch_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package kernels
 

--- a/internal/kernels/dispatch_neon.go
+++ b/internal/kernels/dispatch_neon.go
@@ -1,0 +1,260 @@
+//go:build goexperiment.simd && arm64
+
+package kernels
+
+import (
+	"simd/archsimd"
+
+	"github.com/mattn/tensai/internal/simd"
+)
+
+// 128-bit NEON kernels, the arm64 half of dispatch_simd.go. Four lanes
+// where AVX2 has eight, and no dot-product instruction in the exposed
+// API, so the integer matvecs widen by hand (see quant/quant_neon.go);
+// the float work here maps straight across, FMLA for MulAdd included.
+//
+// Vectorized: the ops a decode step runs per token — the attention dot
+// products and value accumulation, the exponentials, the element-wise
+// rows. The training-side kernels keep the portable bodies; they run once
+// per step over long slices where the scalar loop is not the wall.
+
+// vexpf4 is vexpf's polynomial at four lanes: range reduction to
+// r in [-ln2/2, ln2/2] with a split ln2, a degree-5 minimax on r, and
+// the 2^n scale folded into the exponent bits. Same constants as the
+// AVX2 one, so the two agree to the last bit on the same input.
+func vexpf4(x archsimd.Float32x4) archsimd.Float32x4 {
+	x = x.Min(archsimd.BroadcastFloat32x4(88.0)).Max(archsimd.BroadcastFloat32x4(-87.0))
+	z := x.Mul(archsimd.BroadcastFloat32x4(1.44269504)).Round()
+	r := z.MulAdd(archsimd.BroadcastFloat32x4(-0.693359375), x)
+	r = z.MulAdd(archsimd.BroadcastFloat32x4(2.12194440e-4), r)
+	p := archsimd.BroadcastFloat32x4(1.9875691500e-4)
+	p = p.MulAdd(r, archsimd.BroadcastFloat32x4(1.3981999507e-3))
+	p = p.MulAdd(r, archsimd.BroadcastFloat32x4(8.3334519073e-3))
+	p = p.MulAdd(r, archsimd.BroadcastFloat32x4(4.1665795894e-2))
+	p = p.MulAdd(r, archsimd.BroadcastFloat32x4(1.6666665459e-1))
+	p = p.MulAdd(r, archsimd.BroadcastFloat32x4(5.0000001201e-1))
+	er := p.MulAdd(r.Mul(r), r).Add(archsimd.BroadcastFloat32x4(1))
+	// 2^n through the exponent field. arm64 has no int-to-float bit cast,
+	// so the biased exponent is built in the float domain first: the input
+	// clamp keeps z in [-126, 127], so z+127 is a positive integer value
+	// and the unsigned convert is exact.
+	scale := z.Add(archsimd.BroadcastFloat32x4(127)).ConvertToUint32().ShiftAllLeft(23).BitsToFloat32()
+	return er.Mul(scale)
+}
+
+// map4 runs a four-lane body over dst/src, the tail through a partial
+// load and store so it takes the same path as the full vectors; the amd64
+// twin does the same, which is what keeps the two architectures agreeing
+// on the last elements of an odd-length row.
+func map4(dst, src []float32, f func(archsimd.Float32x4) archsimd.Float32x4) {
+	for len(dst) >= 4 && len(src) >= 4 {
+		simd.StoreF32x4(f(simd.LoadF32x4(src)), dst)
+		dst, src = dst[4:], src[4:]
+	}
+	if len(dst) > 0 {
+		simd.StoreF32x4Part(f(simd.LoadF32x4Part(src)), dst)
+	}
+}
+
+// map4x2 is map4 over two inputs.
+func map4x2(dst, x, y []float32, f func(a, b archsimd.Float32x4) archsimd.Float32x4) {
+	for len(dst) >= 4 && len(x) >= 4 && len(y) >= 4 {
+		simd.StoreF32x4(f(simd.LoadF32x4(x), simd.LoadF32x4(y)), dst)
+		dst, x, y = dst[4:], x[4:], y[4:]
+	}
+	if len(dst) > 0 {
+		simd.StoreF32x4Part(f(simd.LoadF32x4Part(x), simd.LoadF32x4Part(y)), dst)
+	}
+}
+
+func ExpShift(dst, src []float32, shift float32) {
+	sv := archsimd.BroadcastFloat32x4(shift)
+	map4(dst, src, func(v archsimd.Float32x4) archsimd.Float32x4 {
+		return vexpf4(v.Sub(sv))
+	})
+}
+
+// sigmoid4 is 1/(1+e^-x), the gate silu multiplies by.
+func sigmoid4(v archsimd.Float32x4) archsimd.Float32x4 {
+	one := archsimd.BroadcastFloat32x4(1)
+	return one.Div(one.Add(vexpf4(v.Neg())))
+}
+
+func SigmoidFwd(dst, src []float32) {
+	map4(dst, src, sigmoid4)
+}
+
+func Silu(v []float32) {
+	map4(v, v, func(x archsimd.Float32x4) archsimd.Float32x4 {
+		return x.Mul(sigmoid4(x))
+	})
+}
+
+// SiluMul is the SwiGLU gate: gate = silu(gate) * up.
+func SiluMul(gate, up []float32) {
+	map4x2(gate, gate, up, func(g, u archsimd.Float32x4) archsimd.Float32x4 {
+		return g.Mul(sigmoid4(g)).Mul(u)
+	})
+}
+
+// AddSlice accumulates dst += src.
+func AddSlice(dst, src []float32) {
+	map4x2(dst, dst, src, func(a, b archsimd.Float32x4) archsimd.Float32x4 { return a.Add(b) })
+}
+
+func AddSlices(dst, x, y []float32) {
+	map4x2(dst, x, y, func(a, b archsimd.Float32x4) archsimd.Float32x4 { return a.Add(b) })
+}
+
+func SubSlices(dst, x, y []float32) {
+	map4x2(dst, x, y, func(a, b archsimd.Float32x4) archsimd.Float32x4 { return a.Sub(b) })
+}
+
+func MulSlices(dst, x, y []float32) {
+	map4x2(dst, x, y, func(a, b archsimd.Float32x4) archsimd.Float32x4 { return a.Mul(b) })
+}
+
+func DivSlices(dst, x, y []float32) {
+	map4x2(dst, x, y, func(a, b archsimd.Float32x4) archsimd.Float32x4 { return a.Div(b) })
+}
+
+func ScaleSlice(dst []float32, s float32) {
+	sv := archsimd.BroadcastFloat32x4(s)
+	map4(dst, dst, func(v archsimd.Float32x4) archsimd.Float32x4 { return v.Mul(sv) })
+}
+
+// DotVec sums a*b four lanes at a time, folding the lanes in index order
+// so the result is stable across runs.
+func DotVec(a, b []float32) float32 {
+	if len(a) < 8 {
+		return dotVecGeneric(a, b)
+	}
+	n := min(len(a), len(b)) &^ 3
+	var acc archsimd.Float32x4
+	for i := 0; i < n; i += 4 {
+		acc = simd.LoadF32x4(a[i:]).MulAdd(simd.LoadF32x4(b[i:]), acc)
+	}
+	var buf [4]float32
+	simd.StoreF32x4(acc, buf[:])
+	s := buf[0] + buf[1] + buf[2] + buf[3]
+	for i := n; i < len(a) && i < len(b); i++ {
+		s += a[i] * b[i]
+	}
+	return s
+}
+
+// Axpy computes y += a*x, four lanes at a time.
+func Axpy(a float32, x, y []float32) {
+	if len(x) < 8 {
+		axpyGeneric(a, x, y)
+		return
+	}
+	av := archsimd.BroadcastFloat32x4(a)
+	n := min(len(x), len(y)) &^ 3
+	for i := 0; i < n; i += 4 {
+		simd.StoreF32x4(simd.LoadF32x4(x[i:]).MulAdd(av, simd.LoadF32x4(y[i:])), y[i:])
+	}
+	for i := n; i < len(x) && i < len(y); i++ {
+		y[i] += a * x[i]
+	}
+}
+
+// AxpyRows accumulates out += sum over i of ws[i] * rows[i][off:off+d].
+// The output block stays in registers across every row, which is what
+// makes it worth having over a call per row; see the amd64 twin.
+func AxpyRows(out, ws []float32, rows [][]float32, off int) {
+	d := len(out)
+	if d < 8 {
+		for i, w := range ws {
+			axpyGeneric(w, rows[i][off:off+d], out)
+		}
+		return
+	}
+	n := d &^ 3
+	for b := 0; b+32 <= n; b += 32 {
+		o := out[b:]
+		a0, a1, a2, a3 := simd.LoadF32x4(o), simd.LoadF32x4(o[4:]), simd.LoadF32x4(o[8:]), simd.LoadF32x4(o[12:])
+		a4, a5, a6, a7 := simd.LoadF32x4(o[16:]), simd.LoadF32x4(o[20:]), simd.LoadF32x4(o[24:]), simd.LoadF32x4(o[28:])
+		for i, w := range ws {
+			av := archsimd.BroadcastFloat32x4(w)
+			r := rows[i][off+b:]
+			a0 = simd.LoadF32x4(r).MulAdd(av, a0)
+			a1 = simd.LoadF32x4(r[4:]).MulAdd(av, a1)
+			a2 = simd.LoadF32x4(r[8:]).MulAdd(av, a2)
+			a3 = simd.LoadF32x4(r[12:]).MulAdd(av, a3)
+			a4 = simd.LoadF32x4(r[16:]).MulAdd(av, a4)
+			a5 = simd.LoadF32x4(r[20:]).MulAdd(av, a5)
+			a6 = simd.LoadF32x4(r[24:]).MulAdd(av, a6)
+			a7 = simd.LoadF32x4(r[28:]).MulAdd(av, a7)
+		}
+		simd.StoreF32x4(a0, o)
+		simd.StoreF32x4(a1, o[4:])
+		simd.StoreF32x4(a2, o[8:])
+		simd.StoreF32x4(a3, o[12:])
+		simd.StoreF32x4(a4, o[16:])
+		simd.StoreF32x4(a5, o[20:])
+		simd.StoreF32x4(a6, o[24:])
+		simd.StoreF32x4(a7, o[28:])
+	}
+	for b := n &^ 31; b < n; b += 4 {
+		o := out[b:]
+		acc := simd.LoadF32x4(o)
+		for i, w := range ws {
+			acc = simd.LoadF32x4(rows[i][off+b:]).MulAdd(archsimd.BroadcastFloat32x4(w), acc)
+		}
+		simd.StoreF32x4(acc, o)
+	}
+	for i, w := range ws {
+		r := rows[i][off:]
+		for k := n; k < d; k++ {
+			out[k] += w * r[k]
+		}
+	}
+}
+
+// DotVecs is DotVec for a stack of queries against one key row.
+func DotVecs(qs, k []float32, out []float32) {
+	d := len(k)
+	for i := range out {
+		out[i] = DotVec(qs[i*d:(i+1)*d], k)
+	}
+}
+
+// Axpys accumulates one value row into several outputs, one weight each.
+func Axpys(ws []float32, v, outs []float32) {
+	d := len(v)
+	for i, w := range ws {
+		Axpy(w, v, outs[i*d:(i+1)*d])
+	}
+}
+
+// The rest keep the portable bodies: they are training-side kernels that
+// run once per step over long slices, not per token.
+
+func ReluFwd(dst, src []float32)                 { reluFwdGeneric(dst, src) }
+func ReluBwd(dst, grad, src []float32)           { reluBwdGeneric(dst, grad, src) }
+func LeakyFwd(dst, src []float32, alpha float32) { leakyFwdGeneric(dst, src, alpha) }
+func LeakyBwd(dst, grad, src []float32, alpha float32) {
+	leakyBwdGeneric(dst, grad, src, alpha)
+}
+func GeluMul(gate, up []float32)        { geluMulGeneric(gate, up) }
+func SigmoidBwd(dst, grad, y []float32) { sigmoidBwdGeneric(dst, grad, y) }
+func TanhFwd(dst, src []float32)        { tanhFwdGeneric(dst, src) }
+func TanhBwd(dst, grad, y []float32)    { tanhBwdGeneric(dst, grad, y) }
+func SoftmaxBwdAdd(dst, grad, y []float32) {
+	softmaxBwdAddGeneric(dst, grad, y)
+}
+func AdamStep(w, g, m, v []float32, beta1, beta2, rc1, rc2, lr, eps, wd float32) {
+	adamStepGeneric(w, g, m, v, beta1, beta2, rc1, rc2, lr, eps, wd)
+}
+func SGDStep(w, g, vel []float32, momentum, lr float32) {
+	sgdStepGeneric(w, g, vel, momentum, lr)
+}
+func GeluFwd(dst, src []float32)       { geluFwdGeneric(dst, src) }
+func GeluBwd(dst, grad, src []float32) { geluBwdGeneric(dst, grad, src) }
+func LnFwdRow(out, xhat, src, gamma, beta []float32, eps float32) float32 {
+	return lnFwdRowGeneric(out, xhat, src, gamma, beta, eps)
+}
+func LnBwdRow(out, g, xhat, gamma, gradGamma, gradBeta []float32, invStd float32) {
+	lnBwdRowGeneric(out, g, xhat, gamma, gradGamma, gradBeta, invStd)
+}

--- a/internal/simd/avx.go
+++ b/internal/simd/avx.go
@@ -6,3 +6,6 @@ import "simd/archsimd"
 
 // HasAVX2 gates the vector kernels on the CPU actually supporting AVX2+FMA.
 var HasAVX2 = archsimd.X86.AVX2() && archsimd.X86.FMA()
+
+// HasNEON is the arm64 counterpart; false here.
+const HasNEON = false

--- a/internal/simd/neon.go
+++ b/internal/simd/neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package simd
 

--- a/internal/simd/neon.go
+++ b/internal/simd/neon.go
@@ -1,0 +1,36 @@
+//go:build goexperiment.simd && arm64
+
+package simd
+
+import "simd/archsimd"
+
+// The arm64 half of the load/store wrappers: 128-bit NEON vectors where
+// the amd64 files use 256-bit AVX2 ones. Every arm64 chip Go targets has
+// NEON, so there is no feature gate to check the way HasAVX2 gates the
+// x86 kernels; HasAVX2 stays defined and false so code that asks about
+// AVX2 keeps compiling here.
+const (
+	HasAVX2 = false
+	HasNEON = true
+)
+
+func LoadF32x4(s []float32) archsimd.Float32x4 { return archsimd.LoadFloat32x4(s) }
+
+func StoreF32x4(v archsimd.Float32x4, s []float32) { v.Store(s) }
+
+func LoadI32x4(s []int32) archsimd.Int32x4 { return archsimd.LoadInt32x4(s) }
+
+func StoreI32x4(v archsimd.Int32x4, s []int32) { v.Store(s) }
+
+func LoadI8x16(s []int8) archsimd.Int8x16 { return archsimd.LoadInt8x16(s) }
+
+func LoadU8x16(s []uint8) archsimd.Uint8x16 { return archsimd.LoadUint8x16(s) }
+
+func LoadU32x4(s []uint32) archsimd.Uint32x4 { return archsimd.LoadUint32x4(s) }
+
+func LoadF32x4Part(s []float32) archsimd.Float32x4 {
+	v, _ := archsimd.LoadFloat32x4Part(s)
+	return v
+}
+
+func StoreF32x4Part(v archsimd.Float32x4, s []float32) { v.StorePart(s) }

--- a/internal/simd/stub.go
+++ b/internal/simd/stub.go
@@ -1,4 +1,4 @@
-//go:build !(goexperiment.simd && amd64)
+//go:build !(goexperiment.simd && (amd64 || arm64))
 
 // Package simd wraps the experimental simd/archsimd load/store calls whose
 // spellings changed between Go releases, so the kernels can target one set
@@ -6,5 +6,8 @@
 // compiling; nothing imports it there.
 package simd
 
-// HasAVX2 is always false without the simd experiment.
-const HasAVX2 = false
+// HasAVX2 and HasNEON are always false without the simd experiment.
+const (
+	HasAVX2 = false
+	HasNEON = false
+)

--- a/internal/simd/stub.go
+++ b/internal/simd/stub.go
@@ -1,4 +1,4 @@
-//go:build !(goexperiment.simd && (amd64 || arm64))
+//go:build !(goexperiment.simd && (amd64 || (arm64 && go1.27)))
 
 // Package simd wraps the experimental simd/archsimd load/store calls whose
 // spellings changed between Go releases, so the kernels can target one set

--- a/quant/mxfp4_generic.go
+++ b/quant/mxfp4_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package quant
 

--- a/quant/mxfp4_neon.go
+++ b/quant/mxfp4_neon.go
@@ -1,11 +1,10 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build goexperiment.simd && arm64
 
 package quant
 
 import "github.com/mattn/tensai"
 
-// Portable dispatchers for the MXFP4 kernels; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 versions in mxfp4_simd.go.
+// gpt-oss's MXFP4 keeps the portable bodies on arm64.
 
 func mxfp4MatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []uint8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
 	mxfp4MatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, lo, hi)

--- a/quant/mxfp4_neon.go
+++ b/quant/mxfp4_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package quant
 

--- a/quant/quant4_generic.go
+++ b/quant/quant4_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package quant
 

--- a/quant/quant4_neon.go
+++ b/quant/quant4_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package quant
 

--- a/quant/quant4_neon.go
+++ b/quant/quant4_neon.go
@@ -1,11 +1,13 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build goexperiment.simd && arm64
 
 package quant
 
 import "github.com/mattn/tensai"
 
-// Portable dispatcher for the 4-bit matvec kernel; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 version in quant4_simd.go.
+// The 4-bit kernels keep the portable bodies on arm64 for now. Unpacking
+// nibbles into the quad layout is the same shape of work the int8 kernel
+// in quant_neon.go does, one mask and shift ahead of it; it is the next
+// one to vectorize here.
 
 func q4matvecCols(out []tensai.Float, xu []uint8, xq []uint32, sx tensai.Float, gsum []int32, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
 	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)

--- a/quant/quant8g_generic.go
+++ b/quant/quant8g_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package quant
 

--- a/quant/quant8g_neon.go
+++ b/quant/quant8g_neon.go
@@ -1,11 +1,12 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build goexperiment.simd && arm64
 
 package quant
 
 import "github.com/mattn/tensai"
 
-// Portable dispatchers for the grouped int8 kernels; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 versions in quant8g_simd.go.
+// The grouped int8 kernels keep the portable bodies on arm64 for now.
+// They share the quad layout quant_neon.go vectorizes, with a scale and
+// a column-sum table per group folded in at group boundaries.
 
 func q8gMatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, scale []tensai.Float, colSum64 []int32, group, cols, lo, hi int) {
 	q8gMatvecColsGeneric(out, xu, sx, qw, scale, colSum64, group, cols, lo, hi)

--- a/quant/quant8g_neon.go
+++ b/quant/quant8g_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package quant
 

--- a/quant/quant_generic.go
+++ b/quant/quant_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || !amd64
+//go:build !goexperiment.simd || (!amd64 && !arm64)
 
 package quant
 

--- a/quant/quant_generic.go
+++ b/quant/quant_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package quant
 

--- a/quant/quant_neon.go
+++ b/quant/quant_neon.go
@@ -1,0 +1,94 @@
+//go:build goexperiment.simd && arm64
+
+package quant
+
+import (
+	"simd/archsimd"
+
+	"github.com/mattn/tensai"
+	"github.com/mattn/tensai/internal/simd"
+)
+
+// 128-bit NEON kernels for the int8 matvec over the quad-row layout, the
+// arm64 counterpart of quant_simd.go. NEON has no unsigned-by-signed
+// pairwise multiply-add (VPMADDUBSW) and no widening pair-add (VPMADDWD),
+// so the fold is built by hand: sign-extend the bytes to int16, multiply,
+// and let two pairwise adds (VADDP) collapse a column's four rows into
+// one lane. Sixteen weight bytes hold four columns four rows deep, so one
+// pass over 128 bytes covers a 32-column tile.
+//
+// Because the widening is explicit, the activations can stay signed
+// rather than carrying the +64 bias the u8-by-s8 multiply forces on
+// amd64. That drops the column-sum correction: the accumulator is already
+// the value the amd64 kernel reaches only after subtracting it, so the
+// two agree exactly and this side never reads the table.
+//
+// Overflow: |activation| <= 63 and |weight| <= 127, so a product fits
+// 8001, a pair 16002, and a column's four rows 32004 -- inside int16 with
+// room to spare. The per-quad column sums widen to int32 before they
+// accumulate.
+
+// qxSigned8 broadcasts one activation quad as sixteen signed bytes,
+// [x0 x1 x2 x3] four times over, with the storage bias removed.
+func qxSigned8(xu []uint8, i4 int) archsimd.Int16x8 {
+	q := uint32(xu[4*i4]) | uint32(xu[4*i4+1])<<8 |
+		uint32(xu[4*i4+2])<<16 | uint32(xu[4*i4+3])<<24
+	v := archsimd.BroadcastUint32x4(q).ReshapeToUint8s().BitsToInt8()
+	return v.ExtendLo8ToInt16().Sub(archsimd.BroadcastInt16x8(64))
+}
+
+// quadCols folds one 16-byte group (four columns, four rows) against the
+// broadcast activations into four int32 column sums.
+func quadCols(row []int8, xv archsimd.Int16x8) archsimd.Int32x4 {
+	wv := simd.LoadI8x16(row)
+	w0 := wv.ExtendLo8ToInt16()                // columns 0 and 1
+	w1 := wv.HiToLo().ExtendLo8ToInt16()       // columns 2 and 3
+	p := w0.Mul(xv).ConcatAddPairs(w1.Mul(xv)) // two halves per column
+	return p.ConcatAddPairs(p).ExtendLo4ToInt32()
+}
+
+func qmatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
+	quads := len(xu) / 4
+	vecEnd := lo + ((hi - lo) &^ 31)
+	for jt := lo; jt < vecEnd; jt += 32 {
+		tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
+		var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x4
+		for i4 := 0; i4 < quads; i4++ {
+			xv := qxSigned8(xu, i4)
+			row := tile[i4*4*q4Tile : i4*4*q4Tile+4*q4Tile]
+			a0 = a0.Add(quadCols(row, xv))
+			a1 = a1.Add(quadCols(row[16:], xv))
+			a2 = a2.Add(quadCols(row[32:], xv))
+			a3 = a3.Add(quadCols(row[48:], xv))
+			a4 = a4.Add(quadCols(row[64:], xv))
+			a5 = a5.Add(quadCols(row[80:], xv))
+			a6 = a6.Add(quadCols(row[96:], xv))
+			a7 = a7.Add(quadCols(row[112:], xv))
+		}
+		sxv := archsimd.BroadcastFloat32x4(sx)
+		o := out[jt : jt+32 : jt+32]
+		sc := scale[jt : jt+32 : jt+32]
+		store := func(a archsimd.Int32x4, k int) {
+			f := a.ConvertToFloat32().Mul(simd.LoadF32x4(sc[k:])).Mul(sxv)
+			simd.StoreF32x4(f, o[k:])
+		}
+		store(a0, 0)
+		store(a1, 4)
+		store(a2, 8)
+		store(a3, 12)
+		store(a4, 16)
+		store(a5, 20)
+		store(a6, 24)
+		store(a7, 28)
+	}
+	if vecEnd < hi {
+		qmatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, vecEnd, hi)
+	}
+}
+
+// qmatmulRows8 keeps the portable body for now: prefill amortizes the
+// weight stream over eight rows already, and the batched fold wants a
+// different shape from the matvec's. See PERF-INVESTIGATION.md.
+func qmatmulRows8(out *tensai.Matrix, xus [][]uint8, xq []uint32, sxs []tensai.Float, r0 int, qw []int8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
+	qmatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
+}

--- a/quant/quant_neon.go
+++ b/quant/quant_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package quant
 

--- a/quant/quantacts_generic.go
+++ b/quant/quantacts_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || !amd64
+//go:build !goexperiment.simd || (!amd64 && !arm64)
 
 package quant
 

--- a/quant/quantacts_generic.go
+++ b/quant/quantacts_generic.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.simd || (!amd64 && !arm64)
+//go:build !goexperiment.simd || (!amd64 && (!arm64 || !go1.27))
 
 package quant
 

--- a/quant/quantacts_neon.go
+++ b/quant/quantacts_neon.go
@@ -1,4 +1,4 @@
-//go:build goexperiment.simd && arm64
+//go:build goexperiment.simd && arm64 && go1.27
 
 package quant
 

--- a/quant/quantacts_neon.go
+++ b/quant/quantacts_neon.go
@@ -1,0 +1,13 @@
+//go:build goexperiment.simd && arm64
+
+package quant
+
+import "github.com/mattn/tensai"
+
+// The activation quantizer keeps the scalar body on arm64. It is one pass
+// over a row, tens of microseconds against a token's tens of milliseconds,
+// and its rounding leans on an int-to-float bit cast that NEON's exposed
+// API does not have.
+func quantizeActsInto(x []tensai.Float, xu []uint8) tensai.Float {
+	return quantizeActsScalar(x, xu)
+}


### PR DESCRIPTION
Every vector kernel was gated on amd64, so Apple Silicon ran the portable scalar bodies for everything. On this machine that gap measures 5.7x on decode and 22x on prefill between the portable build and AVX2, which is the order a 12B chat on an M4 Max was reported at: 1.5 tok/s with the weights already repacked to int4.

Go 1.27's simd/archsimd covers arm64, so these are Go rather than assembly. NEON is half the width and, more to the point, exposes no unsigned-by-signed pairwise multiply-add and no widening pair-add, so the int8 matvec cannot copy the two-instruction fold the AVX2 kernel uses. It sign-extends the bytes to int16 and lets two VADDPs collapse a column's four rows instead, ten instructions per sixteen weights against x86's four per thirty-two. Because the widening is explicit the activations stay signed rather than carrying the +64 bias the u8-by-s8 multiply forces, so the column-sum correction disappears and this side never reads that table.

The exponentials, the attention dot products and value accumulation, and the element-wise rows come across directly, with FMLA for the fused multiply-add. 2^n is built through the float domain since arm64 has no int-to-float bit cast, and odd-length rows take a partial load so their tail runs the same polynomial as the full vectors, which keeps the two architectures agreeing element for element.

Verified under qemu: every package's tests pass on arm64, a quantized matvec checksums identically across NEON, the scalar bodies and AVX2, and the 0.5B generates the same text on both architectures. I have no arm64 hardware here, so there is no speed measurement in this PR: it needs a run on the Mac.

Still portable on arm64: the 4-bit and grouped-int8 matvecs, the batched prefill folds, MXFP4, the activation quantizer, and the dense float matmuls. The 4-bit one matters most and is next.