### PR TITLE
Reach VPSIGNB by the name each toolchain has for it

### DIFF
--- a/internal/simd/compat_go126.go
+++ b/internal/simd/compat_go126.go
@@ -50,3 +50,7 @@ func StoreF32x8Part(v archsimd.Float32x8, s []float32) {
 func RoundEven(v archsimd.Float32x8) archsimd.Float32x8 {
 	return v.RoundToEven()
 }
+
+// MulSignI8x32 multiplies x by the sign of y (VPSIGNB); Go 1.26 spells
+// the method CopySign.
+func MulSignI8x32(x, y archsimd.Int8x32) archsimd.Int8x32 { return x.CopySign(y) }

--- a/internal/simd/compat_go127.go
+++ b/internal/simd/compat_go127.go
@@ -54,3 +54,7 @@ func StoreF32x8Part(v archsimd.Float32x8, s []float32) {
 func RoundEven(v archsimd.Float32x8) archsimd.Float32x8 {
 	return v.Round()
 }
+
+// MulSignI8x32 multiplies x by the sign of y (VPSIGNB); Go 1.26 spells
+// the method CopySign, which is what compat_go126.go calls.
+func MulSignI8x32(x, y archsimd.Int8x32) archsimd.Int8x32 { return x.MulSign(y) }

--- a/quant/quant8g_simd.go
+++ b/quant/quant8g_simd.go
@@ -51,13 +51,13 @@ func q8gMatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, s
 					xp := archsimd.BroadcastUint32x8(qxQuad(xu, i4)).AsInt8x32().Sub(offset)
 					row := tile[i4*4*q4Tile:]
 					w := simd.LoadI8x32(row)
-					a0 = a0.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					a0 = a0.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(simd.MulSignI8x32(xp, w)).DotProductPairs(ones))
 					w = simd.LoadI8x32(row[32:])
-					a1 = a1.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					a1 = a1.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(simd.MulSignI8x32(xp, w)).DotProductPairs(ones))
 					w = simd.LoadI8x32(row[64:])
-					a2 = a2.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					a2 = a2.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(simd.MulSignI8x32(xp, w)).DotProductPairs(ones))
 					w = simd.LoadI8x32(row[96:])
-					a3 = a3.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(xp.MulSign(w)).DotProductPairs(ones))
+					a3 = a3.Add(w.Abs().AsUint8x32().DotProductPairsSaturated(simd.MulSignI8x32(xp, w)).DotProductPairs(ones))
 				}
 				sg := stab[g*q4Tile:]
 				f := a0.ConvertToFloat32().Mul(simd.LoadF32x8(sg))


### PR DESCRIPTION
The grouped int8 kernel moved the weight's sign onto the activation with MulSign, which is what Go 1.27 calls VPSIGNB. Go 1.26 calls the same instruction CopySign, so every simd build on 1.26 has failed to compile since that kernel landed. CI has been red on main since then, and the failure is only visible in the 1.26 simd job because the other three cancel with it.

internal/simd exists to absorb exactly this: the two compat files carry one name per toolchain and the kernel asks for MulSignI8x32. The documentation on both spellings agrees, the product of x with the sign of y, and both assemble to VPSIGNB, so the arithmetic is untouched. Verified by building and testing the full matrix locally: 1.26 and 1.27, each with and without the simd experiment.