### PR TITLE
Vectorize the int4 kernels and the batched int8 prefill on arm64

### DIFF
--- a/quant/quant4.go
+++ b/quant/quant4.go
@@ -168,17 +168,19 @@ func quantize4Columns(m *tensai.Matrix, q *Q4Matrix, groups, colLo, colHi int) {
 
 // packQuads re-centers the 7-bit activations to signed bytes and packs
 // each quad into the u32 the kernels broadcast, so the scalar assembly
-// runs once per call instead of once per column tile.
+// runs once per call instead of once per column tile. The lane order is
+// the kernel's own: packQuad ships next to each build's kernels.
 func packQuads(xu []uint8) []uint32 {
 	xq := make([]uint32, len(xu)/4)
 	for i := range xq {
-		x0 := uint32(uint8(int8(int(xu[4*i]) - 64)))
-		x1 := uint32(uint8(int8(int(xu[4*i+1]) - 64)))
-		x2 := uint32(uint8(int8(int(xu[4*i+2]) - 64)))
-		x3 := uint32(uint8(int8(int(xu[4*i+3]) - 64)))
-		xq[i] = x0 | x1<<8 | x2<<16 | x3<<24
+		xq[i] = packQuad(xu[4*i : 4*i+4 : 4*i+4])
 	}
 	return xq
+}
+
+// recenter maps one 7-bit offset-binary activation to its signed byte.
+func recenter(u uint8) uint32 {
+	return uint32(uint8(int8(int(u) - 64)))
 }
 
 // MatVec computes out = x @ Q for a single activation row: len(x) must be

--- a/quant/quant4_generic.go
+++ b/quant/quant4_generic.go
@@ -5,7 +5,8 @@ package quant
 import "github.com/mattn/tensai"
 
 // Portable dispatcher for the 4-bit matvec kernel; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 version in quant4_simd.go.
+// GOEXPERIMENT=simd for the AVX2 version in quant4_simd.go on amd64 or
+// the NEON version in quant4_neon.go on arm64.
 
 func q4matvecCols(out []tensai.Float, xu []uint8, xq []uint32, sx tensai.Float, gsum []int32, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
 	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
@@ -18,4 +19,10 @@ func q4matmulCols4(out *tensai.Matrix, xus [][]uint8, _ [][]uint32, sxs []tensai
 func q4matmulCols8(out *tensai.Matrix, xus [][]uint8, _ [][]uint32, sxs []tensai.Float, gsums [][]int32, r0 int, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
 	q4matmulCols4Generic(out, xus[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, lo, hi)
 	q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, lo, hi)
+}
+
+// packQuad packs a re-centered activation quad in weight-layout order.
+// Only the vector kernels read it; the portable bodies take xu directly.
+func packQuad(x []uint8) uint32 {
+	return recenter(x[0]) | recenter(x[1])<<8 | recenter(x[2])<<16 | recenter(x[3])<<24
 }

--- a/quant/quant4_neon.go
+++ b/quant/quant4_neon.go
@@ -2,22 +2,238 @@
 
 package quant
 
-import "github.com/mattn/tensai"
+import (
+	"simd/archsimd"
 
-// The 4-bit kernels keep the portable bodies on arm64 for now. Unpacking
-// nibbles into the quad layout is the same shape of work the int8 kernel
-// in quant_neon.go does, one mask and shift ahead of it; it is the next
-// one to vectorize here.
+	"github.com/mattn/tensai"
+)
+
+// 128-bit NEON kernels for the 4-bit matvec and matmul over the quad-row
+// layout, the arm64 counterpart of the AVX2 kernels in quant4_simd.go.
+// Sixteen loaded bytes hold eight columns four rows deep, two nibble
+// bytes per column. Expanding them into the int8 kernel's quad layout
+// would need two registers where AVX2 needs one, so the nibbles stay
+// where the mask and the shift leave them: masking puts column k's rows
+// 0 and 2 in lanes 2k and 2k+1, shifting puts its rows 1 and 3 there.
+// Each plane then meets a broadcast activation pair — (x0,x2) for the
+// low plane, (x1,x3) for the high — and four signed widening multiplies
+// plus a pair-add per plane land all eight columns' quad sums in one i16
+// vector.
+//
+// Nibbles are at most 15 and |activations| at most 63, so a column's four
+// products sum to 3780 at worst: the quad closes inside i16 and only the
+// accumulator widens, one i32 vector per four columns. Group scales and
+// the nibble-offset correction (8 times the group's activation sum) fold
+// in per group, as on amd64.
+
+// packQuad packs a re-centered activation quad as the two byte pairs the
+// nibble planes meet: (x0,x2) in the low half, (x1,x3) in the high.
+func packQuad(x []uint8) uint32 {
+	return recenter(x[0]) | recenter(x[2])<<8 | recenter(x[1])<<16 | recenter(x[3])<<24
+}
+
+// q4Acts spreads a packed quad's two byte pairs over their own vectors.
+func q4Acts(quad uint32) (xa, xb archsimd.Int8x16) {
+	return q4Spread(uint16(quad)), q4Spread(uint16(quad >> 16))
+}
+
+func q4Spread(pair uint16) archsimd.Int8x16 {
+	return archsimd.BroadcastUint16x8(pair).ReshapeToUint8s().BitsToInt8()
+}
+
+// q4Planes splits a sixteen-byte nibble load into the low and the high
+// nibble plane, each next to its own high half shifted down so a row
+// block pays that shift once.
+func q4Planes(row []uint8, mask archsimd.Uint8x16) (l0, l1, h0, h1 archsimd.Int8x16) {
+	w := archsimd.LoadUint8x16(row)
+	l := w.And(mask).BitsToInt8()
+	h := w.ShiftAllRight(4).BitsToInt8()
+	return l, l.HiToLo(), h, h.HiToLo()
+}
+
+// q4dot8 folds both nibble planes against one row's activation pairs into
+// eight per-column i16 quad sums.
+func q4dot8(l0, l1, h0, h1, xa, xb archsimd.Int8x16) archsimd.Int16x8 {
+	return xa.MulWidenLo(l0).ConcatAddPairs(xa.MulWidenLo(l1)).
+		Add(xb.MulWidenLo(h0).ConcatAddPairs(xb.MulWidenLo(h1)))
+}
+
+// q4rowAdd widens one nibble load's eight column sums into a row's pair
+// of i32 accumulators.
+func q4rowAdd(a0, a1 archsimd.Int32x4, l0, l1, h0, h1, xa, xb archsimd.Int8x16) (archsimd.Int32x4, archsimd.Int32x4) {
+	s := q4dot8(l0, l1, h0, h1, xa, xb)
+	return a0.Add(s.ExtendLo4ToInt32()), a1.Add(s.HiToLo().ExtendLo4ToInt32())
+}
+
+// q4foldSym adds a group's sums into the output in the symmetric form:
+// the nibble offset folds out through 8 times the group's activation sum.
+func q4foldSym(a, corr archsimd.Int32x4, tg, d []tensai.Float) {
+	f := a.Sub(corr).ConvertToFloat32().Mul(archsimd.LoadFloat32x4(tg))
+	archsimd.LoadFloat32x4(d).Add(f).Store(d)
+}
+
+// q4foldMin is the asymmetric twin: one bfloat16 scale/min pair per
+// (group, column), scale in the low half and min in the high.
+func q4foldMin(a archsimd.Int32x4, gsf archsimd.Float32x4, mMin archsimd.Uint32x4, tg []uint32, d []tensai.Float) {
+	u := archsimd.LoadUint32x4(tg)
+	f := a.ConvertToFloat32().Mul(u.ShiftAllLeft(16).BitsToFloat32()).Sub(gsf.Mul(u.And(mMin).BitsToFloat32()))
+	archsimd.LoadFloat32x4(d).Add(f).Store(d)
+}
+
+// q4scaleRow applies a row's activation scale to a finished column span,
+// whose length the callers keep a multiple of four.
+func q4scaleRow(out []tensai.Float, sx tensai.Float, lo, hi int) {
+	sxv := archsimd.BroadcastFloat32x4(sx)
+	for j := lo; j < hi; j += 4 {
+		archsimd.LoadFloat32x4(out[j:]).Mul(sxv).Store(out[j:])
+	}
+}
 
 func q4matvecCols(out []tensai.Float, xu []uint8, xq []uint32, sx tensai.Float, gsum []int32, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
-	q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, lo, hi)
+	quads := len(xq)
+	groups := len(gsum)
+	vecEnd := lo + ((hi - lo) &^ 31)
+	if vecEnd > lo {
+		gsumF := make([]tensai.Float, groups)
+		gsum8 := make([]int32, groups)
+		for i, v := range gsum {
+			gsumF[i] = tensai.Float(v)
+			gsum8[i] = 8 * v
+		}
+		mask := archsimd.BroadcastUint8x16(0x0F)
+		mMin := archsimd.BroadcastUint32x4(0xFFFF0000)
+		clear(out[lo:vecEnd])
+		// Tiles outermost: the nibble walk and the tile-major table walk
+		// both advance strictly sequentially per worker.
+		for jt := lo; jt < vecEnd; jt += 32 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile:]
+			d := out[jt : jt+32 : jt+32]
+			for g := 0; g < groups; g++ {
+				ib := g * group / 4
+				ie := min(ib+group/4, quads)
+				// Eight named accumulators, one per four columns: an
+				// array of SIMD values would live on the stack and turn
+				// every multiply-add into a load-op-store round trip.
+				var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x4
+				for i4 := ib; i4 < ie; i4++ {
+					xa, xb := q4Acts(xq[i4])
+					row := tile[i4*2*q4Tile:]
+					l0, l1, h0, h1 := q4Planes(row, mask)
+					a0, a1 = q4rowAdd(a0, a1, l0, l1, h0, h1, xa, xb)
+					l0, l1, h0, h1 = q4Planes(row[16:], mask)
+					a2, a3 = q4rowAdd(a2, a3, l0, l1, h0, h1, xa, xb)
+					l0, l1, h0, h1 = q4Planes(row[32:], mask)
+					a4, a5 = q4rowAdd(a4, a5, l0, l1, h0, h1, xa, xb)
+					l0, l1, h0, h1 = q4Planes(row[48:], mask)
+					a6, a7 = q4rowAdd(a6, a7, l0, l1, h0, h1, xa, xb)
+				}
+				acc := [8]archsimd.Int32x4{a0, a1, a2, a3, a4, a5, a6, a7}
+				base := (jt/q4Tile)*groups*q4Tile + g*q4Tile
+				if sm != nil {
+					gsf := archsimd.BroadcastFloat32x4(gsumF[g])
+					for k, a := range acc {
+						q4foldMin(a, gsf, mMin, sm[base+4*k:], d[4*k:])
+					}
+				} else {
+					corr := archsimd.BroadcastInt32x4(gsum8[g])
+					for k, a := range acc {
+						q4foldSym(a, corr, scale[base+4*k:], d[4*k:])
+					}
+				}
+			}
+		}
+		q4scaleRow(out, sx, lo, vecEnd)
+	}
+	if vecEnd < hi {
+		q4matvecColsGeneric(out, xu, sx, gsum, qw, scale, sm, group, cols, vecEnd, hi)
+	}
 }
 
-func q4matmulCols4(out *tensai.Matrix, xus [][]uint8, _ [][]uint32, sxs []tensai.Float, gsums [][]int32, r0 int, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
-	q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, lo, hi)
+// q4matmulCols4 is the four-row batched form: per eight-column step each
+// sixteen-byte nibble load splits into planes once and feeds four rows'
+// activation pairs, amortizing the nibble traffic fourfold; steps stay
+// outermost so both streams advance sequentially.
+func q4matmulCols4(out *tensai.Matrix, xus [][]uint8, xqs [][]uint32, sxs []tensai.Float, gsums [][]int32, r0 int, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
+	quads := len(xus[0]) / 4
+	groups := len(gsums[0])
+	xq0, xq1, xq2, xq3 := xqs[0], xqs[1], xqs[2], xqs[3]
+	// Flat copies keep the folds free of nested-slice loads: one indexed
+	// read per row instead of a header chase and two bounds checks.
+	gsf := make([]tensai.Float, 4*groups)
+	gsc := make([]int32, 4*groups)
+	for r := 0; r < 4; r++ {
+		for g, v := range gsums[r] {
+			gsf[4*g+r] = tensai.Float(v)
+			gsc[4*g+r] = 8 * v
+		}
+	}
+	vecEnd := lo + ((hi - lo) &^ 7)
+	if vecEnd > lo {
+		mask := archsimd.BroadcastUint8x16(0x0F)
+		mMin := archsimd.BroadcastUint32x4(0xFFFF0000)
+		o0 := out.Data[r0*cols:]
+		o1 := out.Data[(r0+1)*cols:]
+		o2 := out.Data[(r0+2)*cols:]
+		o3 := out.Data[(r0+3)*cols:]
+		for r := 0; r < 4; r++ {
+			clear(out.Data[(r0+r)*cols+lo : (r0+r)*cols+vecEnd])
+		}
+		for jt := lo; jt < vecEnd; jt += 8 {
+			tile := qw[(jt/q4Tile)*quads*2*q4Tile+(jt%q4Tile)*2:]
+			d0 := o0[jt : jt+8 : jt+8]
+			d1 := o1[jt : jt+8 : jt+8]
+			d2 := o2[jt : jt+8 : jt+8]
+			d3 := o3[jt : jt+8 : jt+8]
+			for g := 0; g < groups; g++ {
+				ib := g * group / 4
+				ie := min(ib+group/4, quads)
+				var a0, a1, b0, b1, c0, c1, e0, e1 archsimd.Int32x4
+				for i4 := ib; i4 < ie; i4++ {
+					l0, l1, h0, h1 := q4Planes(tile[i4*2*q4Tile:], mask)
+					xa, xb := q4Acts(xq0[i4])
+					a0, a1 = q4rowAdd(a0, a1, l0, l1, h0, h1, xa, xb)
+					xa, xb = q4Acts(xq1[i4])
+					b0, b1 = q4rowAdd(b0, b1, l0, l1, h0, h1, xa, xb)
+					xa, xb = q4Acts(xq2[i4])
+					c0, c1 = q4rowAdd(c0, c1, l0, l1, h0, h1, xa, xb)
+					xa, xb = q4Acts(xq3[i4])
+					e0, e1 = q4rowAdd(e0, e1, l0, l1, h0, h1, xa, xb)
+				}
+				base := (jt/q4Tile)*groups*q4Tile + jt%q4Tile + g*q4Tile
+				rows := [4][2]archsimd.Int32x4{{a0, a1}, {b0, b1}, {c0, c1}, {e0, e1}}
+				dst := [4][]tensai.Float{d0, d1, d2, d3}
+				if sm != nil {
+					gr := gsf[4*g : 4*g+4 : 4*g+4]
+					for r, a := range rows {
+						gv := archsimd.BroadcastFloat32x4(gr[r])
+						q4foldMin(a[0], gv, mMin, sm[base:], dst[r])
+						q4foldMin(a[1], gv, mMin, sm[base+4:], dst[r][4:])
+					}
+				} else {
+					gr := gsc[4*g : 4*g+4 : 4*g+4]
+					for r, a := range rows {
+						corr := archsimd.BroadcastInt32x4(gr[r])
+						q4foldSym(a[0], corr, scale[base:], dst[r])
+						q4foldSym(a[1], corr, scale[base+4:], dst[r][4:])
+					}
+				}
+			}
+		}
+		for r := 0; r < 4; r++ {
+			q4scaleRow(out.Data[(r0+r)*cols:], sxs[r], lo, vecEnd)
+		}
+	}
+	if vecEnd < hi {
+		q4matmulCols4Generic(out, xus, sxs, gsums, r0, qw, scale, sm, group, cols, vecEnd, hi)
+	}
 }
 
-func q4matmulCols8(out *tensai.Matrix, xus [][]uint8, _ [][]uint32, sxs []tensai.Float, gsums [][]int32, r0 int, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
-	q4matmulCols4Generic(out, xus[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, lo, hi)
-	q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, lo, hi)
+// q4matmulCols8 is the eight-row batched body, which runs the four-row
+// kernel twice. Eight rows want sixteen i32 accumulators next to the four
+// nibble planes; that spills the register file and benchmarked even with
+// this, because the plane split the second pass repeats is three
+// instructions against the eleven every row already pays.
+func q4matmulCols8(out *tensai.Matrix, xus [][]uint8, xqs [][]uint32, sxs []tensai.Float, gsums [][]int32, r0 int, qw []uint8, scale []tensai.Float, sm []uint32, group, cols, lo, hi int) {
+	q4matmulCols4(out, xus[:4], xqs[:4], sxs[:4], gsums[:4], r0, qw, scale, sm, group, cols, lo, hi)
+	q4matmulCols4(out, xus[4:8], xqs[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, lo, hi)
 }

--- a/quant/quant4_simd.go
+++ b/quant/quant4_simd.go
@@ -371,3 +371,10 @@ func q4matmulCols8(out *tensai.Matrix, xus [][]uint8, xqs [][]uint32, sxs []tens
 		q4matmulCols4Generic(out, xus[4:8], sxs[4:8], gsums[4:8], r0+4, qw, scale, sm, group, cols, vecEnd, hi)
 	}
 }
+
+// packQuad packs a re-centered activation quad in weight-layout order:
+// the nibble unpack lands rows 0..3 in four consecutive u8 lanes, so the
+// broadcast operand is just the quad in row order.
+func packQuad(x []uint8) uint32 {
+	return recenter(x[0]) | recenter(x[1])<<8 | recenter(x[2])<<16 | recenter(x[3])<<24
+}

--- a/quant/quant_generic.go
+++ b/quant/quant_generic.go
@@ -5,7 +5,8 @@ package quant
 import "github.com/mattn/tensai"
 
 // Portable dispatcher for the quantized matvec kernel; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 version in quant_simd.go.
+// GOEXPERIMENT=simd for the AVX2 version in quant_simd.go on amd64 or the
+// NEON version in quant_neon.go on arm64.
 
 func qmatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
 	qmatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, lo, hi)

--- a/quant/quant_neon.go
+++ b/quant/quant_neon.go
@@ -9,8 +9,10 @@ import (
 	"github.com/mattn/tensai/internal/simd"
 )
 
-// 128-bit NEON kernels for the int8 matvec over the quad-row layout, the
-// arm64 counterpart of quant_simd.go. NEON has no unsigned-by-signed
+// 128-bit NEON kernels for the int8 matvec and the batched matmul over
+// the quad-row layout, the arm64 counterpart of quant_simd.go. The two
+// fold differently, so each carries its own note; this one covers the
+// matvec. NEON has no unsigned-by-signed
 // pairwise multiply-add (VPMADDUBSW) and no widening pair-add (VPMADDWD),
 // so the fold is built by hand: sign-extend the bytes to int16, multiply,
 // and let two pairwise adds (VADDP) collapse a column's four rows into
@@ -21,7 +23,7 @@ import (
 // rather than carrying the +64 bias the u8-by-s8 multiply forces on
 // amd64. That drops the column-sum correction: the accumulator is already
 // the value the amd64 kernel reaches only after subtracting it, so the
-// two agree exactly and this side never reads the table.
+// two agree exactly and the matvec never reads colSum64.
 //
 // Overflow: |activation| <= 63 and |weight| <= 127, so a product fits
 // 8001, a pair 16002, and a column's four rows 32004 -- inside int16 with
@@ -86,9 +88,75 @@ func qmatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, sca
 	}
 }
 
-// qmatmulRows8 keeps the portable body for now: prefill amortizes the
-// weight stream over eight rows already, and the batched fold wants a
-// different shape from the matvec's. See PERF-INVESTIGATION.md.
+// The batched prefill form below folds differently. Its weight load is
+// shared by eight activation rows, so the multiply runs eight times per
+// load and the cheaper operand matters more than the bias: the signed
+// widening multiply (SMULL/SMULL2) takes the weight bytes as they are,
+// where the matvec above first sign-extends them. Activations stay in
+// their 7-bit offset-binary form, which the +64 correction in colSum64
+// folds back out, exactly as the amd64 kernel does.
+//
+// Overflow: products reach 127*127, so a column's four rows can hit
+// 64516. The i16 pair-add still holds the two-row partials, but the sums
+// widen to i32 before the second one.
+
+// qxSpread broadcasts a packed activation quad across all sixteen byte
+// lanes so both halves of a weight load meet the same four activations.
+func qxSpread(quad uint32) archsimd.Int8x16 {
+	return archsimd.BroadcastUint32x4(quad).ReshapeToUint8s().BitsToInt8()
+}
+
+// qdot4Hi folds one 16-byte weight load -- four columns four rows deep --
+// against a spread activation quad into four per-column i32 sums. The
+// load's high half arrives already shifted down so a row block pays that
+// shift once for all eight rows.
+func qdot4Hi(xp, w, wh archsimd.Int8x16) archsimd.Int32x4 {
+	p := xp.MulWidenLo(w).ConcatAddPairs(xp.MulWidenLo(wh))
+	return p.ExtendLo4ToInt32().ConcatAddPairs(p.HiToLo().ExtendLo4ToInt32())
+}
+
+// qscale turns a column's accumulated i32 sums into the output floats:
+// the +64 activation offset folds out through colSum64, and the two
+// scales bring the product back to the original units.
+func qscale(a archsimd.Int32x4, cs []int32, sc []tensai.Float, sxv archsimd.Float32x4, out []tensai.Float) {
+	f := a.Sub(simd.LoadI32x4(cs)).ConvertToFloat32().Mul(simd.LoadF32x4(sc)).Mul(sxv)
+	simd.StoreF32x4(f, out)
+}
+
+// qmatmulRows8 is the eight-row batched form: per four-column tile each
+// 16-byte weight load feeds eight spread activation quads, so the weight
+// stream that dominates a single matvec amortizes eightfold.
 func qmatmulRows8(out *tensai.Matrix, xus [][]uint8, xq []uint32, sxs []tensai.Float, r0 int, qw []int8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
-	qmatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, lo, hi)
+	quads := len(xus[0]) / 4
+	// xq holds the caller-packed activation quads, interleaved per quad
+	// row so the inner loop walks one contiguous stream.
+	vecEnd := lo + ((hi - lo) &^ 3)
+	for jt := lo; jt < vecEnd; jt += 4 {
+		tile := qw[(jt/q4Tile)*quads*4*q4Tile+(jt%q4Tile)*4:]
+		// Eight named accumulators, one per row: an array of SIMD values
+		// would live on the stack and turn every multiply-add into a
+		// load-op-store round trip.
+		var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x4
+		for i4 := 0; i4 < quads; i4++ {
+			w := simd.LoadI8x16(tile[i4*4*q4Tile:])
+			wh := w.HiToLo()
+			xf := xq[i4*8 : i4*8+8 : i4*8+8]
+			a0 = a0.Add(qdot4Hi(qxSpread(xf[0]), w, wh))
+			a1 = a1.Add(qdot4Hi(qxSpread(xf[1]), w, wh))
+			a2 = a2.Add(qdot4Hi(qxSpread(xf[2]), w, wh))
+			a3 = a3.Add(qdot4Hi(qxSpread(xf[3]), w, wh))
+			a4 = a4.Add(qdot4Hi(qxSpread(xf[4]), w, wh))
+			a5 = a5.Add(qdot4Hi(qxSpread(xf[5]), w, wh))
+			a6 = a6.Add(qdot4Hi(qxSpread(xf[6]), w, wh))
+			a7 = a7.Add(qdot4Hi(qxSpread(xf[7]), w, wh))
+		}
+		cs := colSum64[jt:]
+		sc := scale[jt:]
+		for r, a := range [8]archsimd.Int32x4{a0, a1, a2, a3, a4, a5, a6, a7} {
+			qscale(a, cs, sc, archsimd.BroadcastFloat32x4(sxs[r]), out.Data[(r0+r)*cols+jt:])
+		}
+	}
+	if vecEnd < hi {
+		qmatmulRows8Generic(out, xus, sxs, r0, qw, scale, colSum64, cols, vecEnd, hi)
+	}
 }


### PR DESCRIPTION
**Problem**

The arm64 NEON half covered the int8 matvec, the grouped int8 kernels, the activation quantizer and MXFP4; the 4-bit kernels and the eight-row batched int8 form stayed on the portable bodies. Those two carry decode and prefill for a 4-bit model, so they were the ones left to do.

**Solution**

The 4-bit fold works the nibbles where the mask and the shift leave them. Sixteen loaded bytes hold eight columns four rows deep, two nibble bytes per column; expanding them into the int8 kernel's quad layout would need two registers where AVX2 needs one. Masking puts column k's rows 0 and 2 in lanes 2k and 2k+1, shifting puts its rows 1 and 3 there, so each plane meets its own broadcast activation pair and four signed widening multiplies plus a pair-add land all eight columns in one i16 vector. Nibbles are at most 15 and activations at most 63, so a column's quad closes inside i16 and only the accumulator widens.

The batched int8 form shares one 16-byte weight load across eight activation rows, shifting the load's high half down once for the block. It folds differently from the matvec next to it: the multiply runs eight times per load, so the signed widening multiply takes the weight bytes as they are rather than sign-extending them first, and the activations stay in their offset-binary form with colSum64 folding the +64 back out, as on amd64. The matvec keeps its own signed fold, which measures the same and skips the table.

Because the two 4-bit builds want different lane orders, packQuad ships next to each build's kernels rather than living in quant4.go.

On an M4 Max, GOEXPERIMENT=simd:

                       before        after
    MatVecQ4Big      3178852 ns    347358 ns    9.2x
    Q4PrefillBatched 37724437 ns  4473032 ns    8.4x
    Q8PrefillBatched 32644076 ns  3712895 ns    8.8x