### PR TITLE
Point the kernel comments at files that exist

### DIFF
--- a/internal/kernels/dispatch_generic.go
+++ b/internal/kernels/dispatch_generic.go
@@ -3,7 +3,8 @@
 package kernels
 
 // Portable dispatchers for the element-wise kernels; build with
-// GOEXPERIMENT=simd on amd64 for the AVX2 versions in mathvec_simd.go.
+// GOEXPERIMENT=simd for the AVX2 versions in dispatch_simd.go on amd64
+// or the NEON versions in dispatch_neon.go on arm64.
 
 func ReluFwd(dst, src []float32)                 { reluFwdGeneric(dst, src) }
 func ReluBwd(dst, grad, src []float32)           { reluBwdGeneric(dst, grad, src) }

--- a/internal/simd/compat_go127.go
+++ b/internal/simd/compat_go127.go
@@ -7,7 +7,7 @@ import "simd/archsimd"
 // Thin wrappers over the archsimd calls whose names changed between Go
 // releases; the experimental package is not covered by the compatibility
 // promise. This file targets the Go 1.27 API, compat_go126.go the
-// older one. The kernels in dot_simd.go and mathvec_simd.go use only these
+// older one. The kernels in dot_simd.go and dispatch_simd.go use only these
 // names for loads, stores, and rounding.
 
 func LoadF32x8(s []float32) archsimd.Float32x8 {

--- a/internal/workpool/pool.go
+++ b/internal/workpool/pool.go
@@ -3,14 +3,14 @@
 // A decode step is ~100 short parallel regions (~200us each) per token,
 // and spawning goroutines puts a sleep/wake on every one of them: the
 // wake cost, not memory access, is what keeps the cycled-weight
-// bandwidth at 62% of a single sweep (see PERF-INVESTIGATION.md). ggml
-// hides it with a resident thread pool that spins on PAUSE between
-// regions. Earlier Go attempts substituted Gosched or a bare busy loop
-// for PAUSE and lost — a yielded P gets rescheduled, and a bare spin
-// starves the sibling hyperthread. This pool spins on the real PAUSE
-// instruction, briefly, then parks: within a token the next region
-// arrives in microseconds, so the spin window almost always absorbs it,
-// and the park bounds the burn between tokens and after decode ends.
+// bandwidth at 62% of a single sweep. ggml hides it with a resident
+// thread pool that spins on PAUSE between regions. Earlier Go attempts
+// substituted Gosched or a bare busy loop for PAUSE and lost — a yielded
+// P gets rescheduled, and a bare spin starves the sibling hyperthread.
+// This pool spins on the real PAUSE instruction, briefly, then parks:
+// within a token the next region arrives in microseconds, so the spin
+// window almost always absorbs it, and the park bounds the burn between
+// tokens and after decode ends.
 package workpool
 
 import (


### PR DESCRIPTION
**Problems**

Three comments send the reader somewhere they cannot follow.

**Solution**

internal/kernels/dispatch_generic.go and internal/simd/compat_go127.go both name mathvec_simd.go, which has never been in the tree: the file is dispatch_simd.go, and the name has been stale since the packages were extracted in #126. The dispatcher comment also still describes the AVX2 build as the only vector one, from before dispatch_neon.go existed.

internal/workpool/pool.go cites PERF-INVESTIGATION.md, which .gitignore keeps out of the repository, so no reader outside the author's machine can open it. The sentence already carries the conclusion the document would support, so the reference just goes.

The other _generic.go comments stay as they are. Their arm64 halves are pass-throughs to the portable bodies, so "build with GOEXPERIMENT=simd on amd64" is still the whole story there.