### PR TITLE
Close an int8 column with one SDOT on arm64

### DIFF
--- a/quant/quant_neon.go
+++ b/quant/quant_neon.go
@@ -52,6 +52,13 @@ func quadCols(row []int8, xv archsimd.Int16x8) archsimd.Int32x4 {
 func qmatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, scale []tensai.Float, colSum64 []int32, cols, lo, hi int) {
 	quads := len(xu) / 4
 	vecEnd := lo + ((hi - lo) &^ 31)
+	if hasDotProd && quads > 0 && vecEnd > lo {
+		qmatvecColsDot(out, xu, sx, qw, scale, quads, lo, vecEnd)
+		if vecEnd < hi {
+			qmatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, vecEnd, hi)
+		}
+		return
+	}
 	for jt := lo; jt < vecEnd; jt += 32 {
 		tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
 		var a0, a1, a2, a3, a4, a5, a6, a7 archsimd.Int32x4
@@ -85,6 +92,28 @@ func qmatvecCols(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, sca
 	}
 	if vecEnd < hi {
 		qmatvecColsGeneric(out, xu, sx, qw, scale, colSum64, cols, vecEnd, hi)
+	}
+}
+
+// qmatvecColsDot is the same matvec over SDOT, which closes a column's
+// four rows in one instruction where the widening path above spends a
+// sign-extend, a multiply and two pair-adds. The weights walk a tile
+// exactly as the loop above does, so the two produce the same integers:
+// SDOT accumulates the four products of a lane in one step, and the
+// widening path adds them pairwise, which for exact integers is the same
+// sum. The float epilogue is shared, byte for byte.
+func qmatvecColsDot(out []tensai.Float, xu []uint8, sx tensai.Float, qw []int8, scale []tensai.Float, quads, lo, vecEnd int) {
+	sxv := archsimd.BroadcastFloat32x4(sx)
+	var acc [32]int32
+	for jt := lo; jt < vecEnd; jt += 32 {
+		tile := qw[(jt/q4Tile)*quads*4*q4Tile:]
+		sdotTile32(&acc[0], &tile[0], &xu[0], quads)
+		o := out[jt : jt+32 : jt+32]
+		sc := scale[jt : jt+32 : jt+32]
+		for k := 0; k < 32; k += 4 {
+			f := simd.LoadI32x4(acc[k:]).ConvertToFloat32().Mul(simd.LoadF32x4(sc[k:])).Mul(sxv)
+			simd.StoreF32x4(f, o[k:])
+		}
 	}
 }
 

--- a/quant/sdot_arm64.go
+++ b/quant/sdot_arm64.go
@@ -1,0 +1,63 @@
+//go:build goexperiment.simd && arm64 && go1.27
+
+package quant
+
+import (
+	"encoding/binary"
+	"os"
+	"runtime"
+)
+
+// sdotTile32 accumulates a 32-column tile: acc holds eight int32 vectors,
+// tile the quad-major weights, xu the activation row in its offset-binary
+// form. Implemented in sdot_arm64.s.
+//
+//go:noescape
+func sdotTile32(acc *int32, tile *int8, xu *uint8, quads int)
+
+// hasDotProd reports FEAT_DotProd, the ARMv8.2 extension whose SDOT the
+// tile kernel needs. It is mandatory from ARMv8.4, so every Apple core
+// Go runs on has it, but an older v8.0 part (a Cortex-A72, say) does not
+// and has to keep the widening path.
+var hasDotProd = detectDotProd()
+
+func detectDotProd() bool {
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		// Every arm64 core Apple has shipped implements it, and Go's
+		// darwin/arm64 port runs on nothing else.
+		return true
+	case "linux", "android":
+		return auxvHasDotProd()
+	}
+	// Elsewhere the answer is unknown, and the widening kernels are
+	// correct everywhere.
+	return false
+}
+
+// auxvHasDotProd reads the kernel's hardware capability word out of the
+// process's own auxiliary vector. x/sys would spell this in one call,
+// and internal/cpu already knows the answer, but neither is reachable
+// from here without a dependency.
+func auxvHasDotProd() bool {
+	const (
+		atHWCap      = 16      // AT_HWCAP
+		hwcapASIMDDP = 1 << 20 // HWCAP_ASIMDDP
+		entrySize    = 16      // two 64-bit words per entry
+	)
+	b, err := os.ReadFile("/proc/self/auxv")
+	if err != nil {
+		return false
+	}
+	for i := 0; i+entrySize <= len(b); i += entrySize {
+		tag := binary.LittleEndian.Uint64(b[i:])
+		val := binary.LittleEndian.Uint64(b[i+8:])
+		if tag == 0 {
+			break
+		}
+		if tag == atHWCap {
+			return val&hwcapASIMDDP != 0
+		}
+	}
+	return false
+}

--- a/quant/sdot_arm64.s
+++ b/quant/sdot_arm64.s
@@ -1,0 +1,62 @@
+// Copyright 2026 The tensai Authors. All rights reserved.
+
+//go:build goexperiment.simd && arm64 && go1.27
+
+#include "textflag.h"
+
+// sdotTile32 accumulates one 32-column tile of the int8 matvec.
+//
+// SDOT multiplies four signed bytes against four more and adds the four
+// products into a 32-bit lane, which is the shape of this layout: sixteen
+// weight bytes hold four columns four rows deep, and one instruction
+// closes all four columns. Go's simd/archsimd has no dot product on
+// arm64 and the assembler knows only the SVE spelling, which Apple
+// silicon does not implement, so the four instruction words go in by
+// hand. They are sdot v8..v15.4s, v0..v7.16b, v16.16b, checked against
+// the assembler's own encoding.
+//
+// The activations arrive in the loader's offset-binary form, so the
+// broadcast quad takes one vector subtract to become the signed bytes
+// SDOT wants; that is cheaper than packing a signed copy of the row.
+//
+// func sdotTile32(acc *int32, tile *int8, xu *uint8, quads int)
+TEXT ·sdotTile32(SB), NOSPLIT|NOFRAME, $0-32
+	MOVD	acc+0(FP), R0
+	MOVD	tile+8(FP), R1
+	MOVD	xu+16(FP), R2
+	MOVD	quads+24(FP), R3
+
+	MOVD	$64, R5
+	VDUP	R5, V17.B16
+
+	VEOR	V8.B16, V8.B16, V8.B16
+	VEOR	V9.B16, V9.B16, V9.B16
+	VEOR	V10.B16, V10.B16, V10.B16
+	VEOR	V11.B16, V11.B16, V11.B16
+	VEOR	V12.B16, V12.B16, V12.B16
+	VEOR	V13.B16, V13.B16, V13.B16
+	VEOR	V14.B16, V14.B16, V14.B16
+	VEOR	V15.B16, V15.B16, V15.B16
+
+loop:
+	MOVWU.P	4(R2), R4
+	VDUP	R4, V16.S4
+	VSUB	V17.B16, V16.B16, V16.B16
+	VLD1.P	64(R1), [V0.B16, V1.B16, V2.B16, V3.B16]
+	VLD1.P	64(R1), [V4.B16, V5.B16, V6.B16, V7.B16]
+
+	WORD	$0x4E909408 // sdot v8.4s, v0.16b, v16.16b
+	WORD	$0x4E909429 // sdot v9.4s, v1.16b, v16.16b
+	WORD	$0x4E90944A // sdot v10.4s, v2.16b, v16.16b
+	WORD	$0x4E90946B // sdot v11.4s, v3.16b, v16.16b
+	WORD	$0x4E90948C // sdot v12.4s, v4.16b, v16.16b
+	WORD	$0x4E9094AD // sdot v13.4s, v5.16b, v16.16b
+	WORD	$0x4E9094CE // sdot v14.4s, v6.16b, v16.16b
+	WORD	$0x4E9094EF // sdot v15.4s, v7.16b, v16.16b
+
+	SUB	$1, R3
+	CBNZ	R3, loop
+
+	VST1.P	[V8.S4, V9.S4, V10.S4, V11.S4], 64(R0)
+	VST1	[V12.S4, V13.S4, V14.S4, V15.S4], (R0)
+	RET

--- a/quant/sdot_arm64_test.go
+++ b/quant/sdot_arm64_test.go
@@ -1,0 +1,44 @@
+//go:build goexperiment.simd && arm64 && go1.27
+
+package quant
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/mattn/tensai"
+)
+
+// The SDOT kernel and the widening one accumulate the same products in a
+// different order, which for exact integers is the same sum: the two must
+// agree to the last bit, and a machine without FEAT_DotProd must reach
+// the same answer through the fallback.
+func TestQMatVecDotProdMatchesWidening(t *testing.T) {
+	if !hasDotProd {
+		t.Skip("no FEAT_DotProd on this machine; only the widening path runs here")
+	}
+	rng := rand.New(rand.NewSource(11))
+	for _, shape := range [][2]int{{896, 1152}, {896, 4864}, {4864, 896}, {128, 40}} {
+		q := Quantize(tensai.RandomMatrix(shape[0], shape[1], rng))
+		x := make([]tensai.Float, shape[0])
+		for i := range x {
+			x[i] = tensai.Float(rng.NormFloat64())
+		}
+		dot := make([]tensai.Float, shape[1])
+		if err := q.MatVec(x, dot); err != nil {
+			t.Fatal(err)
+		}
+		hasDotProd = false
+		wide := make([]tensai.Float, shape[1])
+		err := q.MatVec(x, wide)
+		hasDotProd = true
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range wide {
+			if dot[i] != wide[i] {
+				t.Fatalf("%dx%d column %d: sdot %v != widening %v", shape[0], shape[1], i, dot[i], wide[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
The NEON matvec spends a sign-extend, a multiply and two pair-adds to fold a column's four rows, because Go's simd/archsimd exposes no dot product on arm64. The instruction exists: SDOT multiplies four signed bytes against four more and adds the products into a 32-bit lane, which is exactly this layout's shape, and sixteen weight bytes are four columns four rows deep, so one instruction closes four columns.

The assembler knows only the SVE spelling, which Apple silicon does not implement, so the eight instruction words go in by hand against the assembler's own encoding. The loop broadcasts an activation quad, subtracts the loader's offset once, and runs eight SDOTs over the 128-byte tile a quad covers.

FEAT_DotProd is ARMv8.2 and mandatory from v8.4, so every Apple core has it; a v8.0 part does not, and the widening path stays for it, chosen by a HWCAP read on linux and by construction on darwin.

Both paths accumulate the same products in a different order, which for exact integers is the same sum, so they agree bit for bit. A test asserts that on four shapes, and under emulation the quantized matvec checksums identically against the widening path, the portable bodies and AVX2, while the 0.5B generates the same text as on amd64. As with the rest of the arm64 work there is no speed measurement here: I have no arm64 hardware, and emulation cannot answer it.

The batched prefill fold still widens by hand; it shares its weight load across eight rows, where the multiply is a smaller share of the work.